### PR TITLE
Convert dates that are stored as a string to date objects.

### DIFF
--- a/src/app/connected-components/Eksempelsøknad.tsx
+++ b/src/app/connected-components/Eksempelsøknad.tsx
@@ -9,7 +9,6 @@ import søknadActions from './../redux/actions/søknad/søknadActionCreators';
 import Barn, { UfødtBarn } from '../types/søknad/Barn';
 import AntallBarnSpørsmål from '../spørsmål/AntallBarnSpørsmål';
 import getMessage from '../util/i18nUtils';
-import { getDateFromString } from '../util/dates';
 import Spørsmål from '../components/spørsmål/Spørsmål';
 import AnnenForelderBolk from '../bolker/AnnenForelderBolk';
 import AnnenForelder, {
@@ -111,17 +110,14 @@ class Eksempelsøknad extends React.Component<Props> {
                     synlig={barn.antallBarn !== undefined}
                     render={() => (
                         <DatoInput
+                            id="termindatoinput"
                             label={getMessage(intl, 'termindato.spørsmål')}
-                            onChange={(value: Date) => {
-                                const termindato = value.toISOString();
+                            onChange={(termindato: Date) => {
                                 dispatch(
                                     søknadActions.updateBarn({ termindato })
                                 );
                             }}
-                            dato={getDateFromString(
-                                (barn as UfødtBarn).termindato
-                            )}
-                            id="termindatoinput"
+                            dato={(barn as UfødtBarn).termindato}
                         />
                     )}
                 />
@@ -134,17 +130,14 @@ class Eksempelsøknad extends React.Component<Props> {
                                 intl,
                                 'terminbekreftelseDato.spørsmål'
                             )}
-                            onChange={(value: Date) => {
-                                const terminbekreftelseDato = value.toISOString();
+                            onChange={(terminbekreftelseDato: Date) => {
                                 dispatch(
                                     søknadActions.updateBarn({
                                         terminbekreftelseDato
                                     })
                                 );
                             }}
-                            dato={getDateFromString(
-                                (barn as UfødtBarn).terminbekreftelseDato
-                            )}
+                            dato={(barn as UfødtBarn).terminbekreftelseDato}
                             id="termindatoinput"
                         />
                     )}

--- a/src/app/connected-components/steg/relasjon-til-barn-adopsjon/RelasjonTilBarnAdopsjonSteg.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-adopsjon/RelasjonTilBarnAdopsjonSteg.tsx
@@ -125,15 +125,11 @@ class RelasjonTilBarnAdopsjonSteg extends React.Component<Props> {
                     synlig={barn.antallBarn !== undefined}
                     render={() => (
                         <FødselsdatoerSpørsmål
-                            fødselsdatoer={utils.fødselsdatoerFromString(
-                                barn.fødselsdatoer || []
-                            )}
+                            fødselsdatoer={barn.fødselsdatoer || []}
                             onChange={(fødselsdatoer: Date[]) =>
                                 dispatch(
                                     søknadActions.updateBarn({
-                                        fødselsdatoer: utils.fødselsdatoerToString(
-                                            fødselsdatoer
-                                        )
+                                        fødselsdatoer
                                     })
                                 )
                             }

--- a/src/app/connected-components/steg/relasjon-til-barn-foreldreansvar/RelasjonTilBarnForeldreansvar.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-foreldreansvar/RelasjonTilBarnForeldreansvar.tsx
@@ -90,15 +90,11 @@ class RelasjonTilBarnForeldreansvar extends React.Component<Props, {}> {
                     margin="none"
                     render={() => (
                         <FødselsdatoerSpørsmål
-                            fødselsdatoer={utils.fødselsdatoerFromString(
-                                barn.fødselsdatoer || []
-                            )}
-                            onChange={(fødselsdatoer) =>
+                            fødselsdatoer={barn.fødselsdatoer || []}
+                            onChange={(fødselsdatoer: Date[]) =>
                                 dispatch(
                                     søknadActions.updateBarn({
-                                        fødselsdatoer: utils.fødselsdatoerToString(
-                                            fødselsdatoer
-                                        )
+                                        fødselsdatoer
                                     })
                                 )
                             }
@@ -129,9 +125,7 @@ const mapStateToProps = (state: AppState): StateProps => {
     const barn = state.søknad.barn as ForeldreansvarBarnPartial;
     return {
         barn,
-        visOver15årMelding: erAlderOver15År(
-            utils.fødselsdatoerFromString(barn.fødselsdatoer || [])
-        )
+        visOver15årMelding: erAlderOver15År(barn.fødselsdatoer || [])
     };
 };
 

--- a/src/app/connected-components/steg/relasjon-til-barn-stebarnsadopsjon/RelasjonTilBarnStebarnsadopsjon.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-stebarnsadopsjon/RelasjonTilBarnStebarnsadopsjon.tsx
@@ -86,15 +86,11 @@ class RelasjonTilBarnStebarnsadopsjon extends React.Component<Props, {}> {
                     margin="none"
                     render={() => (
                         <FødselsdatoerSpørsmål
-                            fødselsdatoer={utils.fødselsdatoerFromString(
-                                barn.fødselsdatoer
-                            )}
+                            fødselsdatoer={barn.fødselsdatoer}
                             onChange={(fødselsdatoer: Date[]) =>
                                 dispatch(
                                     søknadActions.updateBarn({
-                                        fødselsdatoer: utils.fødselsdatoerToString(
-                                            fødselsdatoer
-                                        )
+                                        fødselsdatoer
                                     })
                                 )
                             }

--- a/src/app/types/søknad/Barn.ts
+++ b/src/app/types/søknad/Barn.ts
@@ -4,12 +4,12 @@ abstract class Barn {
 }
 
 export interface UfødtBarn extends Barn {
-    termindato: string;
-    terminbekreftelseDato: string;
+    termindato: Date;
+    terminbekreftelseDato: Date;
 }
 
 export interface FødtBarn extends Barn {
-    fødselsdatoer: string[];
+    fødselsdatoer: Date[];
 }
 
 export interface Adopsjonsbarn extends FødtBarn {

--- a/src/app/util/fødselsdato.ts
+++ b/src/app/util/fødselsdato.ts
@@ -14,13 +14,15 @@ const fødselsdatoerFromString = (datoer: string[]) => {
     );
 };
 
-const trimFødselsdatoer = (antall: number, datoer: string[] = []): string[] => {
-    let fødselsdatoer: string[] = [...datoer];
+const trimFødselsdatoer = (antall: number, datoer: Date[] = []): Date[] => {
+    let fødselsdatoer = [...datoer];
     if (datoer.length > antall) {
         fødselsdatoer = datoer.slice(0, antall);
-    }
-    while (fødselsdatoer.length < antall) {
-        fødselsdatoer.push('');
+    } else {
+        fødselsdatoer = new Array(antall - fødselsdatoer.length).fill(
+            undefined
+        );
+        fødselsdatoer.unshift(...datoer);
     }
     return fødselsdatoer;
 };


### PR DESCRIPTION
DatoInput dispatches a Date object to store and expects a Date object as a prop.
Typing dates as a Date object reduces unnecessary parsing.