### PR TITLE
Fixup RelasjonTilBarnFødsel-logic

### DIFF
--- a/src/app/connected-components/sider/inngangsside/Inngangsside.tsx
+++ b/src/app/connected-components/sider/inngangsside/Inngangsside.tsx
@@ -9,13 +9,13 @@ import søknadActions from '../../../redux/actions/søknad/søknadActionCreators
 import Applikasjonsside from '../../sider/Applikasjonsside';
 import SøkerrolleSpørsmål from '../../../spørsmål/SøkerrolleSpørsmål';
 import { getSøkerrollerForBruker } from '../../../util/søkerrollerUtils';
-import { History } from 'history';
 import { StegID } from '../../../util/stegConfig';
 import { søknadStegPath } from '../../steg/StegRoutes';
 import FortsettKnapp from '../../../components/fortsett-knapp/FortsettKnapp';
 import getMessage from '../../../util/i18nUtils';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
 import BekreftCheckboksPanel from 'nav-frontend-skjema/lib/bekreft-checkboks-panel';
+import { HistoryProps } from '../../../types/common';
 
 export interface StateProps {
     situasjon?: Søkersituasjon;
@@ -24,10 +24,6 @@ export interface StateProps {
     rolle?: SøkerRolle;
     roller?: SøkerRolle[];
     nesteStegRoute?: StegID;
-}
-
-interface HistoryProps {
-    history: History;
 }
 
 export type Props = DispatchProps &

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
@@ -26,32 +26,8 @@ interface StateProps {
 
 type Props = StateProps & InjectedIntlProps & DispatchProps & HistoryProps;
 class RelasjonTilBarnFødsel extends React.Component<Props, StateProps> {
-    renderRelasjonTilBarnPartial(erFarEllerMedmor: boolean) {
-        const { barn, vedlegg, dispatch, søknad, history } = this.props;
-        if (barn.erBarnetFødt === true) {
-            return (
-                <partials.FødtBarnPartial
-                    dispatch={dispatch}
-                    barn={barn as FødtBarn}
-                    vedlegg={vedlegg}
-                    history={history}
-                />
-            );
-        }
-        return (
-            <partials.UfødtBarnPartial
-                dispatch={dispatch}
-                barn={barn as UfødtBarn}
-                vedlegg={vedlegg}
-                søknad={søknad}
-                erFarEllerMedmor={erFarEllerMedmor}
-                history={history}
-            />
-        );
-    }
-
     render() {
-        const { barn, dispatch, person, søknad } = this.props;
+        const { barn, dispatch, person, søknad, vedlegg, history } = this.props;
 
         if (person) {
             const { søkerRolle } = søknad;
@@ -76,8 +52,23 @@ class RelasjonTilBarnFødsel extends React.Component<Props, StateProps> {
                         )}
                     />
 
-                    {barn.erBarnetFødt !== undefined &&
-                        this.renderRelasjonTilBarnPartial(erFarEllerMedmor)}
+                    {barn && barn.erBarnetFødt === true ? (
+                        <partials.FødtBarnPartial
+                            dispatch={dispatch}
+                            barn={barn as FødtBarn}
+                            vedlegg={vedlegg}
+                            history={history}
+                        />
+                    ) : (
+                        <partials.UfødtBarnPartial
+                            dispatch={dispatch}
+                            barn={barn as UfødtBarn}
+                            vedlegg={vedlegg}
+                            søknad={søknad}
+                            erFarEllerMedmor={erFarEllerMedmor}
+                            history={history}
+                        />
+                    )}
                 </Steg>
             );
         }

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
@@ -10,68 +10,87 @@ import Spørsmål from '../../../components/spørsmål/Spørsmål';
 import ErBarnetFødtSpørsmål from '../../../spørsmål/ErBarnetFødtSpørsmål';
 import { BarnPartial, FødtBarn, UfødtBarn } from '../../../types/søknad/Barn';
 import { DispatchProps } from '../../../redux/types';
-import { partials } from '../../../partials';
-import Søknad from '../../../types/søknad/Søknad';
+import { partials } from './partials';
+import Søknad, { SøkerRolle } from '../../../types/søknad/Søknad';
 import { AppState } from '../../../redux/reducers';
 import Vedlegg from '../../../types/søknad/Vedlegg';
+import Person from '../../../types/Person';
+import { HistoryProps, Kjønn } from '../../../types/common';
 
 interface StateProps {
     barn: BarnPartial;
     søknad: Søknad;
     vedlegg: Vedlegg;
+    person?: Person;
 }
 
-type Props = StateProps & InjectedIntlProps & DispatchProps;
+type Props = StateProps & InjectedIntlProps & DispatchProps & HistoryProps;
 class RelasjonTilBarnFødsel extends React.Component<Props, StateProps> {
-    renderPartial() {
-        const { barn, vedlegg, dispatch, søknad } = this.props;
+    renderRelasjonTilBarnPartial(erFarEllerMedmor: boolean) {
+        const { barn, vedlegg, dispatch, søknad, history } = this.props;
         if (barn.erBarnetFødt === true) {
             return (
                 <partials.FødtBarnPartial
                     dispatch={dispatch}
                     barn={barn as FødtBarn}
                     vedlegg={vedlegg}
+                    history={history}
                 />
             );
         }
         return (
-            <partials.UFødtBarnAnnenForelderPartial
+            <partials.UfødtBarnPartial
                 dispatch={dispatch}
                 barn={barn as UfødtBarn}
                 vedlegg={vedlegg}
                 søknad={søknad}
+                erFarEllerMedmor={erFarEllerMedmor}
+                history={history}
             />
         );
     }
 
     render() {
-        const { barn, dispatch } = this.props;
-        return (
-            <Steg id={StegID.ANNEN_FORELDER}>
-                <Spørsmål
-                    render={() => (
-                        <ErBarnetFødtSpørsmål
-                            erBarnetFødt={barn.erBarnetFødt}
-                            onChange={(erBarnetFødt: boolean) =>
-                                dispatch(
-                                    søknadActions.updateBarn({
-                                        erBarnetFødt
-                                    })
-                                )
-                            }
-                        />
-                    )}
-                />
-                {barn.erBarnetFødt !== undefined && this.renderPartial()}
-            </Steg>
-        );
+        const { barn, dispatch, person, søknad } = this.props;
+
+        if (person) {
+            const { søkerRolle } = søknad;
+            const { kjønn } = person;
+            const erFarEllerMedmor =
+                kjønn === Kjønn.MANN || søkerRolle === SøkerRolle.MEDMOR;
+
+            return (
+                <Steg id={StegID.RELASJON_TIL_BARN_FØDSEL}>
+                    <Spørsmål
+                        render={() => (
+                            <ErBarnetFødtSpørsmål
+                                erBarnetFødt={barn.erBarnetFødt}
+                                onChange={(erBarnetFødt: boolean) =>
+                                    dispatch(
+                                        søknadActions.updateBarn({
+                                            erBarnetFødt
+                                        })
+                                    )
+                                }
+                            />
+                        )}
+                    />
+
+                    {barn.erBarnetFødt !== undefined &&
+                        this.renderRelasjonTilBarnPartial(erFarEllerMedmor)}
+                </Steg>
+            );
+        }
+
+        return null;
     }
 }
 
 const mapStateToProps = (state: AppState): StateProps => ({
     søknad: state.søknad,
     barn: state.søknad.barn,
-    vedlegg: state.søknad.vedlegg
+    vedlegg: state.søknad.vedlegg,
+    person: state.api.person
 });
 
 export default connect<StateProps, {}, {}>(mapStateToProps)(

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
@@ -1,29 +1,32 @@
 import * as React from 'react';
 import { InjectedIntlProps, injectIntl } from 'react-intl';
-import { DispatchProps } from '../redux/types';
-import Spørsmål from '../components/spørsmål/Spørsmål';
-import Bolk from '../components/layout/Bolk';
-import getMessage from '../util/i18nUtils';
+import { DispatchProps } from '../../../../redux/types/index';
+import Spørsmål from '../../../../components/spørsmål/Spørsmål';
+import Bolk from '../../../../components/layout/Bolk';
+import getMessage from '../../../../util/i18nUtils';
 import {
     concatNewFiles,
     removeFileFromArray
-} from '../components/vedlegg/util';
-import VedleggOversikt from '../components/vedlegg/VedleggOversikt';
-import Vedlegg from '../types/søknad/Vedlegg';
+} from '../../../../components/vedlegg/util';
+import VedleggOversikt from '../../../../components/vedlegg/VedleggOversikt';
+import Vedlegg from '../../../../types/søknad/Vedlegg';
 
-import søknadActions from './../redux/actions/søknad/søknadActionCreators';
-import AntallBarnSpørsmål from '../spørsmål/AntallBarnSpørsmål';
-import { FødtBarn } from '../types/søknad/Barn';
-import FødselsdatoerSpørsmål from '../spørsmål/FødselsdatoerSpørsmål';
+import søknadActions from '../../../../redux/actions/søknad/søknadActionCreators';
+import AntallBarnSpørsmål from '../../../../spørsmål/AntallBarnSpørsmål';
+import { FødtBarn } from '../../../../types/søknad/Barn';
+import FødselsdatoerSpørsmål from '../../../../spørsmål/FødselsdatoerSpørsmål';
 
-import utils from '../util/fødselsdato';
+import utils from '../../../../util/fødselsdato';
+import { søknadStegPath } from '../../StegRoutes';
+import FortsettKnapp from '../../../../components/fortsett-knapp/FortsettKnapp';
+import { HistoryProps } from '../../../../types/common';
 
 interface StateProps {
     barn: FødtBarn;
     vedlegg: Vedlegg;
 }
 
-type Props = StateProps & InjectedIntlProps & DispatchProps;
+type Props = StateProps & InjectedIntlProps & DispatchProps & HistoryProps;
 
 class FødtBarnPartial extends React.Component<Props> {
     constructor(props: Props) {
@@ -45,15 +48,15 @@ class FødtBarnPartial extends React.Component<Props> {
     }
 
     render() {
-        const { intl, dispatch, barn, vedlegg } = this.props;
+        const { intl, dispatch, barn, vedlegg, history } = this.props;
         return (
-            <div>
+            <React.Fragment>
                 <Spørsmål
                     render={() => (
                         <AntallBarnSpørsmål
                             spørsmål={getMessage(
                                 intl,
-                                'antallBarn.spørsmål.venter'
+                                'antallBarn.spørsmål.fått'
                             )}
                             inputName="antallBarn"
                             antallBarn={barn.antallBarn}
@@ -112,7 +115,15 @@ class FødtBarnPartial extends React.Component<Props> {
                         />
                     )}
                 />
-            </div>
+
+                {vedlegg.fødselsattest.length > 0 && (
+                    <FortsettKnapp
+                        history={history}
+                        location={søknadStegPath('annen-forelder')}>
+                        {getMessage(intl, 'fortsettknapp.label')}
+                    </FortsettKnapp>
+                )}
+            </React.Fragment>
         );
     }
 }

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/UfødtBarnPartial.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/UfødtBarnPartial.tsx
@@ -1,38 +1,58 @@
 import * as React from 'react';
 import { InjectedIntlProps, injectIntl } from 'react-intl';
-
-import { DispatchProps } from '../redux/types';
-import { UfødtBarn } from '../types/søknad/Barn';
-import Spørsmål from '../components/spørsmål/Spørsmål';
-import MorForSykSpørsmål from '../spørsmål/MorForSykSpørsmål';
-import DatoInput from '../components/dato-input/DatoInput';
-import Bolk from '../components/layout/Bolk';
-import getMessage from '../util/i18nUtils';
+import { DispatchProps } from '../../../../redux/types/index';
+import { UfødtBarn } from '../../../../types/søknad/Barn';
+import Spørsmål from '../../../../components/spørsmål/Spørsmål';
+import MorForSykSpørsmål from '../../../../spørsmål/MorForSykSpørsmål';
+import DatoInput from '../../../../components/dato-input/DatoInput';
+import Bolk from '../../../../components/layout/Bolk';
+import getMessage from '../../../../util/i18nUtils';
 import {
     concatNewFiles,
     removeFileFromArray
-} from '../components/vedlegg/util';
-import VedleggOversikt from '../components/vedlegg/VedleggOversikt';
-import Vedlegg from '../types/søknad/Vedlegg';
+} from '../../../../components/vedlegg/util';
+import VedleggOversikt from '../../../../components/vedlegg/VedleggOversikt';
+import Vedlegg from '../../../../types/søknad/Vedlegg';
 
-import søknadActions from './../redux/actions/søknad/søknadActionCreators';
-import Veilederinfo from '../components/veileder-info/Veilederinfo';
-import { SøknadPartial } from '../types/søknad/Søknad';
+import søknadActions from '../../../../redux/actions/søknad/søknadActionCreators';
+import Veilederinfo from '../../../../components/veileder-info/Veilederinfo';
+import { SøknadPartial } from '../../../../types/søknad/Søknad';
+import AntallBarnSpørsmål from '../../../../spørsmål/AntallBarnSpørsmål';
+import { søknadStegPath } from '../../StegRoutes';
+import FortsettKnapp from '../../../../components/fortsett-knapp/FortsettKnapp';
+import { HistoryProps } from '../../../../types/common';
 
-interface StateProps {
+interface UfødtBarnPartialProps {
     barn: UfødtBarn;
     søknad: SøknadPartial;
     vedlegg: Vedlegg;
+    erFarEllerMedmor: boolean;
 }
 
-type Props = StateProps & InjectedIntlProps & DispatchProps;
+type Props = UfødtBarnPartialProps &
+    InjectedIntlProps &
+    DispatchProps &
+    HistoryProps;
 
-class UFødtBarnAnnenForelderPartial extends React.Component<Props> {
+class UfødtBarnPartial extends React.Component<Props> {
     render() {
-        const { intl, dispatch, barn, vedlegg, søknad } = this.props;
+        const {
+            intl,
+            dispatch,
+            barn,
+            vedlegg,
+            søknad,
+            erFarEllerMedmor,
+            history
+        } = this.props;
+
+        const erMorEllerMorErForSyk =
+            !erFarEllerMedmor || søknad.erMorForSyk === true;
+
         return (
-            <div>
+            <React.Fragment>
                 <Spørsmål
+                    synlig={erFarEllerMedmor}
                     render={() => (
                         <MorForSykSpørsmål
                             erMorForSyk={søknad.erMorForSyk}
@@ -53,10 +73,30 @@ class UFødtBarnAnnenForelderPartial extends React.Component<Props> {
                     </Veilederinfo>
                 )}
 
-                {søknad.erMorForSyk === true && (
+                {erMorEllerMorErForSyk && (
                     <React.Fragment>
                         <Spørsmål
-                            synlig={søknad.erMorForSyk === true}
+                            render={() => (
+                                <AntallBarnSpørsmål
+                                    antallBarn={barn.antallBarn}
+                                    inputName="antallBarn"
+                                    onChange={(antallBarn: number) => {
+                                        dispatch(
+                                            søknadActions.updateBarn({
+                                                antallBarn
+                                            })
+                                        );
+                                    }}
+                                    spørsmål={getMessage(
+                                        intl,
+                                        'antallBarn.spørsmål.venter'
+                                    )}
+                                />
+                            )}
+                        />
+
+                        <Spørsmål
+                            synlig={barn.antallBarn !== undefined}
                             render={() => (
                                 <DatoInput
                                     id="termindato"
@@ -133,10 +173,19 @@ class UFødtBarnAnnenForelderPartial extends React.Component<Props> {
                                 />
                             )}
                         />
+
+                        {barn.terminbekreftelseDato &&
+                            vedlegg.terminbekreftelse.length > 0 && (
+                                <FortsettKnapp
+                                    history={history}
+                                    location={søknadStegPath('annen-forelder')}>
+                                    {getMessage(intl, 'fortsettknapp.label')}
+                                </FortsettKnapp>
+                            )}
                     </React.Fragment>
                 )}
-            </div>
+            </React.Fragment>
         );
     }
 }
-export default injectIntl(UFødtBarnAnnenForelderPartial);
+export default injectIntl(UfødtBarnPartial);

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/index.ts
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/index.ts
@@ -1,0 +1,7 @@
+import FødtBarnPartial from './FødtBarnPartial';
+import UfødtBarnPartial from './UfødtBarnPartial';
+
+export const partials = {
+    FødtBarnPartial,
+    UfødtBarnPartial
+};

--- a/src/app/intl/nb_NO.json
+++ b/src/app/intl/nb_NO.json
@@ -7,6 +7,7 @@
     "annenForelder.spørsmål.fnr": "Fødselsnummer",
     "annenForelder.spørsmål.utenlandskFnr": "Utenlandsk fødselsnummer",
 
+    "antallBarn.spørsmål.fått": "Hvor mange barn har du fått?",
     "antallBarn.spørsmål.venter": "Hvor mange barn venter du?",
     "antallBarn.alternativ.ettbarn": "ett barn",
     "antallBarn.alternativ.tvillinger": "tvillinger",

--- a/src/app/intl/nn_NO.json
+++ b/src/app/intl/nn_NO.json
@@ -7,6 +7,7 @@
     "annenForelder.spørsmål.fnr": "Fødselsnummer",
     "annenForelder.spørsmål.utenlandskFnr": "Utenlandsk fødselsnummer",
 
+    "antallBarn.spørsmål.fått": "Hvor mange barn har du fått?",
     "antallBarn.spørsmål.venter": "Hvor mange barn venter du?",
     "antallBarn.alternativ.ettbarn": "ett barn",
     "antallBarn.alternativ.tvillinger": "tvillinger",

--- a/src/app/partials/index.ts
+++ b/src/app/partials/index.ts
@@ -1,7 +1,0 @@
-import FødtBarnPartial from './FødtBarnPartial';
-import UFødtBarnAnnenForelderPartial from './UFødtBarnAnnenForelderPartial';
-
-export const partials = {
-    FødtBarnPartial,
-    UFødtBarnAnnenForelderPartial
-};

--- a/src/app/types/common.ts
+++ b/src/app/types/common.ts
@@ -1,3 +1,5 @@
+import { History } from 'history';
+
 export type Fødselsdato = Date | undefined;
 
 export interface Alder {
@@ -9,4 +11,8 @@ export interface Alder {
 export enum Kjønn {
     'MANN' = 'M',
     'KVINNE' = 'K'
+}
+
+export interface HistoryProps {
+    history: History;
 }

--- a/src/app/util/stegConfig.ts
+++ b/src/app/util/stegConfig.ts
@@ -2,8 +2,7 @@ export enum StegID {
     'RELASJON_TIL_BARN_FØDSEL' = 'relasjon-til-barn-fødsel',
     'RELASJON_TIL_BARN_ADOPSJON' = 'relasjon-til-barn-adopsjon',
     'RELASJON_TIL_BARN_STEBARNSADOPSJON' = 'relasjon-til-barn-stebarnsadopsjon',
-    'RELASJON_TIL_BARN_FORELDREANSVAR' = 'relasjon-til-barn-foreldreansvar',
-    'ANNEN_FORELDER' = 'annen-forelder'
+    'RELASJON_TIL_BARN_FORELDREANSVAR' = 'relasjon-til-barn-foreldreansvar'
 }
 
 export interface StegConfig {
@@ -16,10 +15,6 @@ export interface StegConfig {
 const stegConfig: StegConfig = {
     [StegID.RELASJON_TIL_BARN_ADOPSJON]: {
         tittel: 'Relasjon til barn (adopsjon) header',
-        nesteKnapp: 'Fortsett'
-    },
-    [StegID.ANNEN_FORELDER]: {
-        tittel: 'Annen forelder header',
         nesteKnapp: 'Fortsett'
     },
     [StegID.RELASJON_TIL_BARN_STEBARNSADOPSJON]: {


### PR DESCRIPTION
- Implement FødtBarnPartial and UfødtBarnPartial logic for Mor, and make sure the same
partials are used regardless of søkerRolle or kjønn
- Add <FortsettKnapp>-usage to partials
- Move partials to /relasjon-til-barn-fødsel folder
- Remove outdated annen-forelder configs