### PR TITLE
Render <FortsettKnapp>-component in <Steg>

### DIFF
--- a/src/app/components/layout/Steg.tsx
+++ b/src/app/components/layout/Steg.tsx
@@ -1,17 +1,30 @@
 import * as React from 'react';
 import stegConfig, { StegID } from '../../util/stegConfig';
+import { søknadStegPath } from '../../connected-components/steg/StegRoutes';
+import { History } from 'history';
+import FortsettKnapp from 'common/components/fortsett-knapp/FortsettKnapp';
 
-export interface Props {
+export interface StegProps {
     id: StegID;
+    renderFortsettKnapp?: boolean;
+    history: History;
 }
 
-class Steg extends React.Component<Props, {}> {
+class Steg extends React.Component<StegProps, {}> {
     render() {
-        const { id } = this.props;
+        const { id, renderFortsettKnapp, history } = this.props;
         return (
             <div className="steg">
                 <h1 className="steg__tittel">{stegConfig[id].tittel}</h1>
                 {this.props.children}
+
+                {renderFortsettKnapp === true && (
+                    <FortsettKnapp
+                        history={history}
+                        location={søknadStegPath(stegConfig[id].nesteSteg)}>
+                        {stegConfig[id].fortsettKnappLabel}
+                    </FortsettKnapp>
+                )}
             </div>
         );
     }

--- a/src/app/connected-components/steg/relasjon-til-barn-adopsjon/RelasjonTilBarnAdopsjonSteg.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-adopsjon/RelasjonTilBarnAdopsjonSteg.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { InjectedIntlProps, injectIntl } from 'react-intl';
-
 import { StegID } from '../../../util/stegConfig';
-
 import { DispatchProps } from 'common/redux/types';
 import søknadActions from './../../../redux/actions/søknad/søknadActionCreators';
 import AntallBarnSpørsmål from '../../../spørsmål/AntallBarnSpørsmål';
@@ -13,20 +11,21 @@ import Spørsmål from 'common/components/spørsmål/Spørsmål';
 import { FødtBarn, Adopsjonsbarn } from '../../../types/søknad/Barn';
 import DatoInput from 'common/components/dato-input/DatoInput';
 import FødselsdatoerSpørsmål from '../../../spørsmål/FødselsdatoerSpørsmål';
-
 import utils from '../../../util/fødselsdato';
 import { AppState } from '../../../redux/reducers';
-import Steg from '../../../components/layout/Steg';
+import Steg, { StegProps } from '../../../components/layout/Steg';
 import Bolk from '../../../components/layout/Bolk';
 import Søknadsvedlegg from '../../../components/søknadsvedlegg/Søknadsvedlegg';
 import { getSøknadsvedlegg } from '../../../util/vedleggUtil';
+import { HistoryProps } from '../../../types/common';
 
 interface StateProps {
     barn: FødtBarn;
     visSpørsmålOmAntallBarn: boolean;
+    stegProps: StegProps;
 }
 
-type Props = StateProps & InjectedIntlProps & DispatchProps;
+type Props = StateProps & InjectedIntlProps & DispatchProps & HistoryProps;
 class RelasjonTilBarnAdopsjonSteg extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
@@ -47,10 +46,16 @@ class RelasjonTilBarnAdopsjonSteg extends React.Component<Props> {
     }
 
     render() {
-        const { visSpørsmålOmAntallBarn, barn, dispatch, intl } = this.props;
+        const {
+            visSpørsmålOmAntallBarn,
+            barn,
+            dispatch,
+            stegProps,
+            intl
+        } = this.props;
 
         return (
-            <Steg id={StegID.RELASJON_TIL_BARN_ADOPSJON}>
+            <Steg {...stegProps}>
                 <Spørsmål
                     render={() => (
                         <DatoInput
@@ -114,7 +119,7 @@ class RelasjonTilBarnAdopsjonSteg extends React.Component<Props> {
                             adoptertIUtlandet={
                                 (barn as Adopsjonsbarn).adoptertIUtlandet
                             }
-                            onChange={(adoptertIUtlandet, e) =>
+                            onChange={(adoptertIUtlandet) =>
                                 dispatch(
                                     søknadActions.updateBarn({
                                         adoptertIUtlandet
@@ -129,11 +134,22 @@ class RelasjonTilBarnAdopsjonSteg extends React.Component<Props> {
     }
 }
 
-const mapStateToProps = (state: AppState): StateProps => ({
-    barn: state.søknad.barn as FødtBarn,
-    visSpørsmålOmAntallBarn:
-        getSøknadsvedlegg('omsorgsovertakelse', state).length > 0
-});
+const mapStateToProps = (state: AppState, props: Props): StateProps => {
+    const barn = state.søknad.barn as Adopsjonsbarn;
+
+    const stegProps = {
+        id: StegID.RELASJON_TIL_BARN_ADOPSJON,
+        renderFortsettKnapp: barn.adoptertIUtlandet !== undefined,
+        history: props.history
+    };
+
+    return {
+        barn,
+        visSpørsmålOmAntallBarn:
+            getSøknadsvedlegg('omsorgsovertakelse', state).length > 0,
+        stegProps
+    };
+};
 
 export default connect<StateProps, {}, {}>(mapStateToProps)(
     injectIntl(RelasjonTilBarnAdopsjonSteg)

--- a/src/app/connected-components/steg/relasjon-til-barn-foreldreansvar/RelasjonTilBarnForeldreansvar.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-foreldreansvar/RelasjonTilBarnForeldreansvar.tsx
@@ -17,16 +17,21 @@ import Labeltekst from 'common/components/labeltekst/Labeltekst';
 import utils from '../../../util/fødselsdato';
 import { ForeldreansvarBarnPartial } from '../../../types/søknad/Barn';
 import Veilederinfo from 'common/components/veileder-info/Veilederinfo';
-import { Fødselsdato } from '../../../types/common';
+import { Fødselsdato, HistoryProps } from '../../../types/common';
 import { getAlderFraDato } from '../../../util/dates';
 import Søknadsvedlegg from '../../../components/søknadsvedlegg/Søknadsvedlegg';
+import { StegProps } from '../../../components/layout/Steg';
 
 export interface StateProps {
     barn: ForeldreansvarBarnPartial;
     visOver15årMelding: boolean;
+    stegProps: StegProps;
 }
 
-export type Props = DispatchProps & StateProps & InjectedIntlProps;
+export type Props = DispatchProps &
+    StateProps &
+    InjectedIntlProps &
+    HistoryProps;
 
 class RelasjonTilBarnForeldreansvar extends React.Component<Props, {}> {
     constructor(props: Props) {
@@ -47,9 +52,15 @@ class RelasjonTilBarnForeldreansvar extends React.Component<Props, {}> {
     }
 
     render() {
-        const { barn, visOver15årMelding, intl, dispatch } = this.props;
+        const {
+            barn,
+            visOver15årMelding,
+            intl,
+            stegProps,
+            dispatch
+        } = this.props;
         return (
-            <Steg id={StegID.RELASJON_TIL_BARN_FORELDREANSVAR}>
+            <Steg {...stegProps}>
                 <Spørsmål
                     render={() => (
                         <DatoInput
@@ -124,11 +135,20 @@ const erAlderOver15År = (datoer: Fødselsdato[]) => {
     return harBarnOver15 !== undefined;
 };
 
-const mapStateToProps = (state: AppState): StateProps => {
+const mapStateToProps = (state: AppState, props: Props): StateProps => {
     const barn = state.søknad.barn as ForeldreansvarBarnPartial;
+
+    const stegProps: StegProps = {
+        id: StegID.RELASJON_TIL_BARN_STEBARNSADOPSJON,
+        renderFortsettKnapp:
+            barn.fødselsdatoer && barn.fødselsdatoer.length > 0,
+        history: props.history
+    };
+
     return {
         barn,
-        visOver15årMelding: erAlderOver15År(barn.fødselsdatoer || [])
+        visOver15årMelding: erAlderOver15År(barn.fødselsdatoer || []),
+        stegProps
     };
 };
 

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
@@ -9,19 +9,15 @@ import { FødtBarn } from '../../../../types/søknad/Barn';
 import FødselsdatoerSpørsmål from '../../../../spørsmål/FødselsdatoerSpørsmål';
 
 import utils from '../../../../util/fødselsdato';
-import { søknadStegPath } from '../../StegRoutes';
-import FortsettKnapp from 'common/components/fortsett-knapp/FortsettKnapp';
-import { HistoryProps } from '../../../../types/common';
 import { DispatchProps } from 'common/redux/types';
 import getMessage from 'common/util/i18nUtils';
 import Søknadsvedlegg from '../../../../components/søknadsvedlegg/Søknadsvedlegg';
 
 interface StateProps {
     barn: FødtBarn;
-    fødselsattestErLastetOpp: boolean;
 }
 
-type Props = StateProps & InjectedIntlProps & DispatchProps & HistoryProps;
+type Props = StateProps & InjectedIntlProps & DispatchProps;
 
 class FødtBarnPartial extends React.Component<Props> {
     constructor(props: Props) {
@@ -43,13 +39,7 @@ class FødtBarnPartial extends React.Component<Props> {
     }
 
     render() {
-        const {
-            intl,
-            dispatch,
-            barn,
-            fødselsattestErLastetOpp,
-            history
-        } = this.props;
+        const { intl, dispatch, barn } = this.props;
         return (
             <React.Fragment>
                 <Spørsmål
@@ -91,14 +81,6 @@ class FødtBarnPartial extends React.Component<Props> {
                     tittel={getMessage(intl, 'vedlegg.tittel.fødselsattest')}
                     render={() => <Søknadsvedlegg type="fødselsattest" />}
                 />
-
-                {fødselsattestErLastetOpp && (
-                    <FortsettKnapp
-                        history={history}
-                        location={søknadStegPath('annen-forelder')}>
-                        {getMessage(intl, 'fortsettknapp.label')}
-                    </FortsettKnapp>
-                )}
             </React.Fragment>
         );
     }

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/UfødtBarnPartial.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/UfødtBarnPartial.tsx
@@ -10,9 +10,6 @@ import søknadActions from '../../../../redux/actions/søknad/søknadActionCreat
 import Veilederinfo from 'common/components/veileder-info/Veilederinfo';
 import { SøknadPartial } from '../../../../types/søknad/Søknad';
 import AntallBarnSpørsmål from '../../../../spørsmål/AntallBarnSpørsmål';
-import { søknadStegPath } from '../../StegRoutes';
-import FortsettKnapp from 'common/components/fortsett-knapp/FortsettKnapp';
-import { HistoryProps } from '../../../../types/common';
 import { DispatchProps } from 'common/redux/types';
 import getMessage from 'common/util/i18nUtils';
 import Søknadsvedlegg from '../../../../components/søknadsvedlegg/Søknadsvedlegg';
@@ -24,10 +21,7 @@ interface UfødtBarnPartialProps {
     erFarEllerMedmor: boolean;
 }
 
-type Props = UfødtBarnPartialProps &
-    InjectedIntlProps &
-    DispatchProps &
-    HistoryProps;
+type Props = UfødtBarnPartialProps & InjectedIntlProps & DispatchProps;
 
 class UfødtBarnPartial extends React.Component<Props> {
     render() {
@@ -37,8 +31,7 @@ class UfødtBarnPartial extends React.Component<Props> {
             barn,
             terminbekreftelseErLastetOpp,
             søknad,
-            erFarEllerMedmor,
-            history
+            erFarEllerMedmor
         } = this.props;
 
         const erMorEllerMorErForSyk =
@@ -145,15 +138,6 @@ class UfødtBarnPartial extends React.Component<Props> {
                                 />
                             )}
                         />
-
-                        {barn.terminbekreftelseDato &&
-                            terminbekreftelseErLastetOpp && (
-                                <FortsettKnapp
-                                    history={history}
-                                    location={søknadStegPath('annen-forelder')}>
-                                    {getMessage(intl, 'fortsettknapp.label')}
-                                </FortsettKnapp>
-                            )}
                     </React.Fragment>
                 )}
             </React.Fragment>

--- a/src/app/connected-components/steg/relasjon-til-barn-stebarnsadopsjon/RelasjonTilBarnStebarnsadopsjon.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-stebarnsadopsjon/RelasjonTilBarnStebarnsadopsjon.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
 
 import { StegID } from '../../../util/stegConfig';
-import Steg from 'app/components/layout/Steg';
+import Steg, { StegProps } from 'app/components/layout/Steg';
 
 import { DispatchProps } from 'common/redux/types';
 import { AppState } from '../../../redux/reducers';
@@ -17,12 +17,17 @@ import Labeltekst from 'common/components/labeltekst/Labeltekst';
 
 import utils from '../../../util/fødselsdato';
 import Søknadsvedlegg from '../../../components/søknadsvedlegg/Søknadsvedlegg';
+import { HistoryProps } from '../../../types/common';
 
 export interface StateProps {
     barn: Adopsjonsbarn;
+    stegProps: StegProps;
 }
 
-export type Props = DispatchProps & StateProps & InjectedIntlProps;
+export type Props = DispatchProps &
+    StateProps &
+    InjectedIntlProps &
+    HistoryProps;
 
 class RelasjonTilBarnStebarnsadopsjon extends React.Component<Props, {}> {
     constructor(props: Props) {
@@ -46,9 +51,9 @@ class RelasjonTilBarnStebarnsadopsjon extends React.Component<Props, {}> {
     }
 
     render() {
-        const { barn, intl, dispatch } = this.props;
+        const { barn, intl, dispatch, stegProps } = this.props;
         return (
-            <Steg id={StegID.RELASJON_TIL_BARN_STEBARNSADOPSJON}>
+            <Steg {...stegProps}>
                 <Spørsmål
                     render={() => (
                         <DatoInput
@@ -108,9 +113,22 @@ class RelasjonTilBarnStebarnsadopsjon extends React.Component<Props, {}> {
     }
 }
 
-const mapStateToProps = (state: AppState): StateProps => {
+const mapStateToProps = (
+    state: AppState & StegProps,
+    props: Props
+): StateProps => {
+    const barn = state.søknad.barn as Adopsjonsbarn;
+
+    const stegProps: StegProps = {
+        id: StegID.RELASJON_TIL_BARN_STEBARNSADOPSJON,
+        renderFortsettKnapp:
+            barn.fødselsdatoer && barn.fødselsdatoer.length > 0,
+        history: props.history
+    };
+
     return {
-        barn: state.søknad.barn as Adopsjonsbarn
+        barn,
+        stegProps
     };
 };
 

--- a/src/app/util/stegConfig.ts
+++ b/src/app/util/stegConfig.ts
@@ -2,32 +2,49 @@ export enum StegID {
     'RELASJON_TIL_BARN_FØDSEL' = 'relasjon-til-barn-fødsel',
     'RELASJON_TIL_BARN_ADOPSJON' = 'relasjon-til-barn-adopsjon',
     'RELASJON_TIL_BARN_STEBARNSADOPSJON' = 'relasjon-til-barn-stebarnsadopsjon',
-    'RELASJON_TIL_BARN_FORELDREANSVAR' = 'relasjon-til-barn-foreldreansvar'
+    'RELASJON_TIL_BARN_FORELDREANSVAR' = 'relasjon-til-barn-foreldreansvar',
+    'ANNEN_FORELDER' = 'annen-forelder',
+    'UTENLANDSOPPHOLD' = 'utenlandsopphold'
 }
 
 export interface StegConfig {
     [key: string]: {
         tittel: string;
-        nesteKnapp: string;
+        fortsettKnappLabel: string;
+        nesteSteg: StegID;
     };
 }
 
 const stegConfig: StegConfig = {
     [StegID.RELASJON_TIL_BARN_ADOPSJON]: {
         tittel: 'Relasjon til barn (adopsjon) header',
-        nesteKnapp: 'Fortsett'
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.ANNEN_FORELDER
     },
     [StegID.RELASJON_TIL_BARN_STEBARNSADOPSJON]: {
         tittel: 'Relasjon til barn tidlig stebarnsadopsjon',
-        nesteKnapp: 'Fortsett'
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.ANNEN_FORELDER
     },
     [StegID.RELASJON_TIL_BARN_FORELDREANSVAR]: {
         tittel: 'Relasjon til barn overtakelse av foreldreansvar',
-        nesteKnapp: 'Fortsett'
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.ANNEN_FORELDER
     },
     [StegID.RELASJON_TIL_BARN_FØDSEL]: {
         tittel: 'Relasjon til barn fødsel',
-        nesteKnapp: 'Fortsett'
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.ANNEN_FORELDER
+    },
+    [StegID.ANNEN_FORELDER]: {
+        tittel: 'Annen forelder',
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.UTENLANDSOPPHOLD
+    },
+    [StegID.UTENLANDSOPPHOLD]: {
+        tittel: 'Utenlandsopphold',
+        fortsettKnappLabel: 'Fortsett',
+        nesteSteg: StegID.UTENLANDSOPPHOLD // will change later
     }
 };
 


### PR DESCRIPTION
Implements FortsettKnapp-rendering in Steg based on values provided by StegConfig.
All existing steg-components have been rewritten to take StegProps in as a required prop, which
is being provided by mapStateToProps, to make sure our actual component logic is being kept
pure and simple.