### PR TITLE
Uttaksplan - Ny datovelger og fom/tom refactor i Tidsperiode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10054,11 +10054,11 @@
             "dev": true
         },
         "nav-datovelger": {
-            "version": "2.0.0",
+            "version": "2.1.0",
             "resolved":
-                "https://registry.npmjs.org/nav-datovelger/-/nav-datovelger-2.0.0.tgz",
+                "https://registry.npmjs.org/nav-datovelger/-/nav-datovelger-2.1.0.tgz",
             "integrity":
-                "sha512-W60vbBSKbdd6kxJAG4UOMH06lk+jybziSvDEeZiwg5N0fmv+RC2lbsymEvPTgWWVMPdaalPrOHX/oO2JBL5iBQ==",
+                "sha512-Js0k/8lF7TjzGDVXb02IDh4vYGsTsKw3B56msq0wlXUSIG76XFEFZmd23ryb23Fs56bV8g/nx9duikKe8sAq/w==",
             "requires": {
                 "babel-preset-env": "1.6.1",
                 "classnames": "2.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1660,6 +1660,7 @@
                 "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
             "integrity":
                 "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+            "dev": true,
             "requires": {
                 "babel-plugin-check-es2015-constants": "6.22.0",
                 "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -2237,6 +2238,7 @@
                 "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
             "integrity":
                 "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+            "dev": true,
             "requires": {
                 "caniuse-lite": "1.0.30000865",
                 "electron-to-chromium": "1.3.52"
@@ -5275,11 +5277,11 @@
             }
         },
         "focus-trap": {
-            "version": "2.4.6",
+            "version": "2.4.3",
             "resolved":
-                "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.6.tgz",
+                "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.3.tgz",
             "integrity":
-                "sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==",
+                "sha512-sT5Ip9nyAIxWq8Apt1Fdv6yTci5GotaOtO5Ro1/+F3PizttNBcCYz8j/Qze54PPFK73KUbOqh++HUCiyNPqvhA==",
             "requires": {
                 "tabbable": "1.1.3"
             }
@@ -5291,7 +5293,7 @@
             "integrity":
                 "sha512-MoQmONoy9gRPyrC5DGezkcOMGgx7MtIOAQDHe098UtL2sA2vmucJwEmQisb+8LRXNYFHxuw5zJ1oLFeKu4Mteg==",
             "requires": {
-                "focus-trap": "2.4.6"
+                "focus-trap": "2.4.3"
             }
         },
         "follow-redirects": {
@@ -10052,24 +10054,120 @@
             "dev": true
         },
         "nav-datovelger": {
-            "version": "1.1.10",
+            "version": "2.0.0",
             "resolved":
-                "https://registry.npmjs.org/nav-datovelger/-/nav-datovelger-1.1.10.tgz",
+                "https://registry.npmjs.org/nav-datovelger/-/nav-datovelger-2.0.0.tgz",
             "integrity":
-                "sha512-SoY56MhXL0J+Urc3i5qzauUJLVBMOfp6xjWqU1u6FoWwkRlLt/cImK+Hz8YvzX3GIwQsy0AaEl03gRlzm1bPeQ==",
+                "sha512-W60vbBSKbdd6kxJAG4UOMH06lk+jybziSvDEeZiwg5N0fmv+RC2lbsymEvPTgWWVMPdaalPrOHX/oO2JBL5iBQ==",
             "requires": {
-                "babel-preset-env": "1.7.0",
+                "babel-preset-env": "1.6.1",
                 "classnames": "2.2.5",
-                "focus-trap": "2.4.6",
+                "focus-trap": "2.4.3",
                 "focus-trap-react": "3.1.2",
                 "lodash.isequal": "4.5.0",
                 "lodash.throttle": "4.1.1",
-                "moment": "2.22.1",
+                "moment": "2.21.0",
                 "nav-frontend-core": "4.0.5",
-                "nav-frontend-js-utils": "1.0.5",
-                "nav-frontend-typografi": "2.0.3",
-                "react-day-picker": "7.1.10",
-                "react-dom": "16.3.2"
+                "nav-frontend-js-utils": "1.0.3",
+                "nav-frontend-typografi": "2.0.2",
+                "react-day-picker": "7.1.6",
+                "react-dom": "16.2.0"
+            },
+            "dependencies": {
+                "babel-preset-env": {
+                    "version": "1.6.1",
+                    "resolved":
+                        "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+                    "integrity":
+                        "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+                    "requires": {
+                        "babel-plugin-check-es2015-constants": "6.22.0",
+                        "babel-plugin-syntax-trailing-function-commas":
+                            "6.22.0",
+                        "babel-plugin-transform-async-to-generator": "6.24.1",
+                        "babel-plugin-transform-es2015-arrow-functions":
+                            "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoped-functions":
+                            "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                        "babel-plugin-transform-es2015-classes": "6.24.1",
+                        "babel-plugin-transform-es2015-computed-properties":
+                            "6.24.1",
+                        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                        "babel-plugin-transform-es2015-duplicate-keys":
+                            "6.24.1",
+                        "babel-plugin-transform-es2015-for-of": "6.23.0",
+                        "babel-plugin-transform-es2015-function-name": "6.24.1",
+                        "babel-plugin-transform-es2015-literals": "6.22.0",
+                        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                        "babel-plugin-transform-es2015-modules-commonjs":
+                            "6.26.2",
+                        "babel-plugin-transform-es2015-modules-systemjs":
+                            "6.24.1",
+                        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                        "babel-plugin-transform-es2015-object-super": "6.24.1",
+                        "babel-plugin-transform-es2015-parameters": "6.24.1",
+                        "babel-plugin-transform-es2015-shorthand-properties":
+                            "6.24.1",
+                        "babel-plugin-transform-es2015-spread": "6.22.0",
+                        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                        "babel-plugin-transform-es2015-template-literals":
+                            "6.22.0",
+                        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                        "babel-plugin-transform-exponentiation-operator":
+                            "6.24.1",
+                        "babel-plugin-transform-regenerator": "6.26.0",
+                        "browserslist": "2.11.3",
+                        "invariant": "2.2.4",
+                        "semver": "5.5.0"
+                    }
+                },
+                "browserslist": {
+                    "version": "2.11.3",
+                    "resolved":
+                        "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+                    "integrity":
+                        "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+                    "requires": {
+                        "caniuse-lite": "1.0.30000865",
+                        "electron-to-chromium": "1.3.52"
+                    }
+                },
+                "moment": {
+                    "version": "2.21.0",
+                    "resolved":
+                        "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+                    "integrity":
+                        "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+                },
+                "nav-frontend-js-utils": {
+                    "version": "1.0.3",
+                    "resolved":
+                        "https://registry.npmjs.org/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.3.tgz",
+                    "integrity":
+                        "sha512-koFdiecfbOT5IE1Rr+0pBEIa+3ZJg+CVvFdKh5vXNV2P8h3n/Xv7jJ4QzuzQtdYHAli/hbUtDJqa7vQS5EaU1Q=="
+                },
+                "nav-frontend-typografi": {
+                    "version": "2.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/nav-frontend-typografi/-/nav-frontend-typografi-2.0.2.tgz",
+                    "integrity":
+                        "sha512-I8azSHzvlasadR3HJ61ewy7+mum3WTTtjnIY3V+1UnfhW6h1sJbfHixiz71U74iGFfrYRDby95ezmeoqw2WcKA=="
+                },
+                "react-dom": {
+                    "version": "16.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+                    "integrity":
+                        "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+                    "requires": {
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1",
+                        "prop-types": "15.6.1"
+                    }
+                }
             }
         },
         "nav-frontend-chevron": {
@@ -12354,11 +12452,10 @@
             }
         },
         "react-day-picker": {
-            "version": "7.1.10",
+            "version": "7.1.6",
             "resolved":
-                "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.1.10.tgz",
-            "integrity":
-                "sha512-UoI3ktYU8oN0UTxX5ZbG02TZePHh4znUGT6/h4g+tLNM1O4GGCiafqyFEIp22HYb1sCPQ4UMyw6QFcxu+lFDVQ==",
+                "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.1.6.tgz",
+            "integrity": "sha1-t+mcLEpmGS9qCyBazKrZ5hyAye8=",
             "requires": {
                 "prop-types": "15.6.1"
             }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "lodash.throttle": "4.1.1",
         "moment": "2.22.1",
         "mustache-express": "1.2.5",
-        "nav-datovelger": "1.1.10",
+        "nav-datovelger": "^2.0.0",
         "nav-frontend-chevron": "1.0.2",
         "nav-frontend-core": "4.0.5",
         "nav-frontend-ekspanderbartpanel": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "lodash.throttle": "4.1.1",
         "moment": "2.22.1",
         "mustache-express": "1.2.5",
-        "nav-datovelger": "^2.0.0",
+        "nav-datovelger": "2.1.0",
         "nav-frontend-chevron": "1.0.2",
         "nav-frontend-core": "4.0.5",
         "nav-frontend-ekspanderbartpanel": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "lodash.throttle": "4.1.1",
         "moment": "2.22.1",
         "mustache-express": "1.2.5",
-        "nav-datovelger": "2.1.0",
+        "nav-datovelger": "^2.1.0",
         "nav-frontend-chevron": "1.0.2",
         "nav-frontend-core": "4.0.5",
         "nav-frontend-ekspanderbartpanel": "1.0.12",

--- a/src/app/bolker/AndreInntekterBolk.tsx
+++ b/src/app/bolker/AndreInntekterBolk.tsx
@@ -168,12 +168,12 @@ const AndreInntekterListeElement: React.StatelessComponent<
                 id="tidsintervall"
                 values={{
                     fom: ISODateToPrettyDateFormat(
-                        annenInntekt.tidsperiode.startdato
+                        annenInntekt.tidsperiode.fom
                     ),
                     tom: annenInntekt.pågående
                         ? 'pågående'
                         : ISODateToPrettyDateFormat(
-                              annenInntekt.tidsperiode.sluttdato
+                              annenInntekt.tidsperiode.tom
                           )
                 }}
             />

--- a/src/app/bolker/FrilansOppdragBolk.tsx
+++ b/src/app/bolker/FrilansOppdragBolk.tsx
@@ -169,14 +169,10 @@ const FrilansOppdragListeElement: React.StatelessComponent<
             <FormattedMessage
                 id="tidsintervall"
                 values={{
-                    fom: ISODateToPrettyDateFormat(
-                        oppdrag.tidsperiode.startdato
-                    ),
+                    fom: ISODateToPrettyDateFormat(oppdrag.tidsperiode.fom),
                     tom: oppdrag.pågående
                         ? 'pågående'
-                        : ISODateToPrettyDateFormat(
-                              oppdrag.tidsperiode.sluttdato
-                          )
+                        : ISODateToPrettyDateFormat(oppdrag.tidsperiode.tom)
                 }}
             />
         </div>

--- a/src/app/bolker/SelvstendigNæringsdrivendeBolk.tsx
+++ b/src/app/bolker/SelvstendigNæringsdrivendeBolk.tsx
@@ -169,14 +169,10 @@ const NæringListeElement: React.StatelessComponent<NæringListeElementProps> = 
             <FormattedMessage
                 id="tidsintervall"
                 values={{
-                    fom: ISODateToPrettyDateFormat(
-                        næring.tidsperiode.startdato
-                    ),
+                    fom: ISODateToPrettyDateFormat(næring.tidsperiode.fom),
                     tom: næring.pågående
                         ? 'pågående'
-                        : ISODateToPrettyDateFormat(
-                              næring.tidsperiode.sluttdato
-                          )
+                        : ISODateToPrettyDateFormat(næring.tidsperiode.tom)
                 }}
             />
         </div>

--- a/src/app/bolker/TidsperiodeBolk.tsx
+++ b/src/app/bolker/TidsperiodeBolk.tsx
@@ -41,13 +41,13 @@ class TidsperiodeBolk extends React.Component<Props> {
                         <DatoInput
                             id="fraDatoInput"
                             label={getMessage(intl, 'fraogmed')}
-                            onChange={(startdato: Date) => {
+                            onChange={(fom: Date) => {
                                 this.handleOnChange({
                                     ...tidsperiode,
-                                    startdato
+                                    fom
                                 });
                             }}
-                            dato={tidsperiode.startdato}
+                            dato={tidsperiode.fom}
                         />
                     )}
                 />
@@ -57,13 +57,13 @@ class TidsperiodeBolk extends React.Component<Props> {
                         <DatoInput
                             id="tilDatoInput"
                             label={getMessage(intl, 'tilogmed')}
-                            onChange={(sluttdato: Date) => {
+                            onChange={(tom: Date) => {
                                 this.handleOnChange({
                                     ...tidsperiode,
-                                    sluttdato
+                                    tom
                                 });
                             }}
-                            dato={tidsperiode.sluttdato}
+                            dato={tidsperiode.tom}
                             disabled={false || sluttdatoDisabled}
                         />
                     )}

--- a/src/app/bolker/UtenlandsoppholdBolk.tsx
+++ b/src/app/bolker/UtenlandsoppholdBolk.tsx
@@ -174,12 +174,8 @@ const OppholdListeElement: React.StatelessComponent<
             <FormattedMessage
                 id="tidsintervall"
                 values={{
-                    fom: ISODateToPrettyDateFormat(
-                        opphold.tidsperiode.startdato
-                    ),
-                    tom: ISODateToPrettyDateFormat(
-                        opphold.tidsperiode.sluttdato
-                    )
+                    fom: ISODateToPrettyDateFormat(opphold.tidsperiode.fom),
+                    tom: ISODateToPrettyDateFormat(opphold.tidsperiode.tom)
                 }}
             />
         </div>

--- a/src/app/components/annen-inntekt-modal/AnnenInntektModal.tsx
+++ b/src/app/components/annen-inntekt-modal/AnnenInntektModal.tsx
@@ -193,7 +193,7 @@ class AnnenInntektModal extends React.Component<Props, State> {
                                         pågående: !annenInntekt.pågående,
                                         tidsperiode: {
                                             ...annenInntekt.tidsperiode,
-                                            sluttdato: undefined
+                                            tom: undefined
                                         }
                                     });
                                 }}

--- a/src/app/components/frilans-oppdrag-modal/FrilansOppdragModal.tsx
+++ b/src/app/components/frilans-oppdrag-modal/FrilansOppdragModal.tsx
@@ -140,7 +140,7 @@ class FrilansOppdragModal extends React.Component<Props, State> {
                                         pågående: !oppdrag.pågående,
                                         tidsperiode: {
                                             ...oppdrag.tidsperiode,
-                                            sluttdato: undefined
+                                            tom: undefined
                                         }
                                     });
                                 }}

--- a/src/app/components/selvstendig-næringsdrivende-modal/SelvstendigNæringsdrivendeModal.tsx
+++ b/src/app/components/selvstendig-næringsdrivende-modal/SelvstendigNæringsdrivendeModal.tsx
@@ -179,7 +179,7 @@ class SelvstendigNæringsdrivendeModal extends React.Component<Props, State> {
                                         pågående: !pågående,
                                         tidsperiode: {
                                             ...tidsperiode,
-                                            sluttdato: undefined
+                                            tom: undefined
                                         }
                                     });
                                 }}
@@ -284,7 +284,7 @@ class SelvstendigNæringsdrivendeModal extends React.Component<Props, State> {
                         synlig={
                             stillingsprosent !== undefined &&
                             tidsperiode &&
-                            tidsperiode.startdato &&
+                            tidsperiode.fom &&
                             erMindreEnn4ÅrSidenOppstart(næring as Næring)
                         }
                         render={() => (
@@ -309,7 +309,7 @@ class SelvstendigNæringsdrivendeModal extends React.Component<Props, State> {
                         synlig={
                             stillingsprosent !== undefined &&
                             tidsperiode &&
-                            tidsperiode.startdato &&
+                            tidsperiode.fom &&
                             !erMindreEnn4ÅrSidenOppstart(næring as Næring)
                         }
                         render={() => (

--- a/src/app/components/utenlandsopphold-modal/UtenlandsoppholdModal.tsx
+++ b/src/app/components/utenlandsopphold-modal/UtenlandsoppholdModal.tsx
@@ -139,11 +139,11 @@ class UtenlandsoppholdModal extends React.Component<
             const { getFraAvgrensning, getTilAvgrensning } = avgrensningGetters;
             return {
                 fra: getFraAvgrensning && {
-                    ...getFraAvgrensning(tidsperiode && tidsperiode.sluttdato),
+                    ...getFraAvgrensning(tidsperiode && tidsperiode.tom),
                     ugyldigeTidsperioder: this.getTidsperioder()
                 },
                 til: getTilAvgrensning && {
-                    ...getTilAvgrensning(tidsperiode && tidsperiode.startdato),
+                    ...getTilAvgrensning(tidsperiode && tidsperiode.fom),
                     ugyldigeTidsperioder: this.getTidsperioder()
                 }
             };
@@ -158,8 +158,8 @@ class UtenlandsoppholdModal extends React.Component<
 
         const tidsperiode = oppholdToEdit && oppholdToEdit.tidsperiode;
         const ugyldigeTidsperioder = this.getTidsperioder();
-        const startdato = tidsperiode && tidsperiode.startdato;
-        const sluttdato = tidsperiode && tidsperiode.sluttdato;
+        const startdato = tidsperiode && tidsperiode.fom;
+        const sluttdato = tidsperiode && tidsperiode.tom;
 
         if (tidsperiodeValidators) {
             const { getFraRegler, getTilRegler } = tidsperiodeValidators;

--- a/src/app/util/domain/næringer.ts
+++ b/src/app/util/domain/næringer.ts
@@ -7,7 +7,7 @@ export const erMindreEnn4ÅrSidenOppstart = (næring: Næring): boolean => {
     const date4YearsAgo = moment()
         .subtract(4, 'years')
         .startOf('day');
-    const startdato = moment(tidsperiode.startdato).startOf('day');
+    const startdato = moment(tidsperiode.fom).startOf('day');
 
     return date4YearsAgo.isSameOrBefore(startdato);
 };

--- a/src/app/util/validation/common/dateIntervals.ts
+++ b/src/app/util/validation/common/dateIntervals.ts
@@ -6,15 +6,13 @@ export const harTidsperiodeOverlapp = (
     andreTidsperioder: Tidsperiode[]
 ) =>
     andreTidsperioder.some((t: Tidsperiode) => {
-        const startdato = moment(tidsperiode.startdato).startOf('day');
-        const sluttdato = moment(tidsperiode.sluttdato).endOf('day');
+        const fom = moment(tidsperiode.fom).startOf('day');
+        const tom = moment(tidsperiode.tom).endOf('day');
 
         return (
-            startdato.isBetween(t.startdato, t.sluttdato) ||
-            sluttdato.isBetween(t.startdato, t.sluttdato) ||
-            (startdato.isBefore(t.startdato) &&
-                sluttdato.isSameOrAfter(t.startdato)) ||
-            (sluttdato.isAfter(t.sluttdato) &&
-                startdato.isSameOrBefore(t.sluttdato))
+            fom.isBetween(t.fom, t.tom) ||
+            tom.isBetween(t.fom, t.tom) ||
+            (fom.isBefore(t.fom) && tom.isSameOrAfter(t.fom)) ||
+            (tom.isAfter(t.tom) && fom.isSameOrBefore(t.tom))
         );
     });

--- a/src/app/util/validation/fields/senereUtenlandsopphold.ts
+++ b/src/app/util/validation/fields/senereUtenlandsopphold.ts
@@ -24,18 +24,18 @@ export const getTilAvgrensninger = (fraDate?: Date): Avgrensninger => {
 };
 
 export const getSenereUtenlandsoppholdFradatoRegler = (
-    startdato: Date | undefined,
-    sluttdato: Date | undefined,
+    fom: Date | undefined,
+    tom: Date | undefined,
     ugyldigePerioder: Tidsperiode[],
     intl: InjectedIntl
 ): Validator[] => {
     const intlKey = 'valideringsfeil.utenlandsopphold';
-    const fradatoM = moment(startdato);
-    const tildatoM = moment(sluttdato);
+    const fradatoM = moment(fom);
+    const tildatoM = moment(tom);
 
     return [
         {
-            test: () => startdato !== undefined,
+            test: () => fom !== undefined,
             failText: getMessage(intl, `${intlKey}.senere`)
         },
         {
@@ -44,18 +44,13 @@ export const getSenereUtenlandsoppholdFradatoRegler = (
         },
         {
             test: () =>
-                sluttdato
-                    ? fradatoM.startOf('day').isSameOrBefore(tildatoM)
-                    : true,
+                tom ? fradatoM.startOf('day').isSameOrBefore(tildatoM) : true,
             failText: getMessage(intl, `${intlKey}.førTilDato`)
         },
         {
             test: () =>
-                startdato && sluttdato
-                    ? !harTidsperiodeOverlapp(
-                          { startdato, sluttdato },
-                          ugyldigePerioder
-                      )
+                fom && tom
+                    ? !harTidsperiodeOverlapp({ fom, tom }, ugyldigePerioder)
                     : true,
             failText: getMessage(intl, `${intlKey}.overlapp`)
         }
@@ -63,18 +58,18 @@ export const getSenereUtenlandsoppholdFradatoRegler = (
 };
 
 export const getSenereUtenlandsoppholdTildatoRegler = (
-    startdato: Date | undefined,
-    sluttdato: Date | undefined,
+    fom: Date | undefined,
+    tom: Date | undefined,
     ugyldigePerioder: Tidsperiode[],
     intl: InjectedIntl
 ): Validator[] => {
     const intlKey = 'valideringsfeil.utenlandsopphold';
-    const startM = moment(sluttdato);
-    const sluttM = moment(startdato);
+    const startM = moment(tom);
+    const sluttM = moment(fom);
 
     return [
         {
-            test: () => startdato !== undefined,
+            test: () => fom !== undefined,
             failText: getMessage(intl, `${intlKey}.senere`)
         },
         {
@@ -83,16 +78,13 @@ export const getSenereUtenlandsoppholdTildatoRegler = (
         },
         {
             test: () =>
-                sluttdato ? sluttM.endOf('day').isSameOrAfter(startM) : true,
+                tom ? sluttM.endOf('day').isSameOrAfter(startM) : true,
             failText: getMessage(intl, `${intlKey}.etterFraDato`)
         },
         {
             test: () =>
-                startdato && sluttdato
-                    ? !harTidsperiodeOverlapp(
-                          { startdato, sluttdato },
-                          ugyldigePerioder
-                      )
+                fom && tom
+                    ? !harTidsperiodeOverlapp({ fom, tom }, ugyldigePerioder)
                     : true,
             failText: getMessage(intl, `${intlKey}.overlapp`)
         }

--- a/src/app/util/validation/fields/tidligereUtenlandsopphold.ts
+++ b/src/app/util/validation/fields/tidligereUtenlandsopphold.ts
@@ -24,18 +24,18 @@ export const getTilAvgrensninger = (fraDate?: Date): Avgrensninger => {
 };
 
 export const getTidligereUtenlandsoppholdFradatoRegler = (
-    startdato: Date | undefined,
-    sluttdato: Date | undefined,
+    fom: Date | undefined,
+    tom: Date | undefined,
     ugyldigePerioder: Tidsperiode[],
     intl: InjectedIntl
 ): Validator[] => {
     const intlKey = 'valideringsfeil.utenlandsopphold';
-    const startM = moment(startdato);
-    const sluttM = moment(sluttdato);
+    const startM = moment(fom);
+    const sluttM = moment(tom);
 
     return [
         {
-            test: () => startdato !== undefined,
+            test: () => fom !== undefined,
             failText: getMessage(intl, `${intlKey}.tidligere`)
         },
         {
@@ -44,16 +44,13 @@ export const getTidligereUtenlandsoppholdFradatoRegler = (
         },
         {
             test: () =>
-                sluttdato ? startM.startOf('day').isSameOrBefore(sluttM) : true,
+                tom ? startM.startOf('day').isSameOrBefore(sluttM) : true,
             failText: getMessage(intl, `${intlKey}.førTilDato`)
         },
         {
             test: () =>
-                startdato && sluttdato
-                    ? !harTidsperiodeOverlapp(
-                          { startdato, sluttdato },
-                          ugyldigePerioder
-                      )
+                fom && tom
+                    ? !harTidsperiodeOverlapp({ fom, tom }, ugyldigePerioder)
                     : true,
             failText: getMessage(intl, `${intlKey}.overlapp`)
         }
@@ -61,18 +58,18 @@ export const getTidligereUtenlandsoppholdFradatoRegler = (
 };
 
 export const getTidligereUtenlandsoppholdTildatoRegler = (
-    startdato: Date | undefined,
-    sluttdato: Date | undefined,
+    fom: Date | undefined,
+    tom: Date | undefined,
     ugyldigePerioder: Tidsperiode[],
     intl: InjectedIntl
 ): Validator[] => {
     const intlKey = 'valideringsfeil.utenlandsopphold';
-    const startM = moment(sluttdato);
-    const sluttM = moment(startdato);
+    const startM = moment(tom);
+    const sluttM = moment(fom);
 
     return [
         {
-            test: () => startdato !== undefined,
+            test: () => fom !== undefined,
             failText: getMessage(intl, `${intlKey}.tidligere`)
         },
         {
@@ -81,16 +78,13 @@ export const getTidligereUtenlandsoppholdTildatoRegler = (
         },
         {
             test: () =>
-                sluttdato ? sluttM.endOf('day').isSameOrAfter(startM) : true,
+                tom ? sluttM.endOf('day').isSameOrAfter(startM) : true,
             failText: getMessage(intl, `${intlKey}.etterFraDato`)
         },
         {
             test: () =>
-                startdato && sluttdato
-                    ? !harTidsperiodeOverlapp(
-                          { startdato, sluttdato },
-                          ugyldigePerioder
-                      )
+                fom && tom
+                    ? !harTidsperiodeOverlapp({ fom, tom }, ugyldigePerioder)
                     : true,
             failText: getMessage(intl, `${intlKey}.overlapp`)
         }

--- a/src/common/components/dato-input/DatoInput.tsx
+++ b/src/common/components/dato-input/DatoInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import SkjemaInputElement from '../skjema-input-element/SkjemaInputElement';
 import { Feil } from '../skjema-input-element/types';
-import Datovelger, { Props as DatovelgerProps } from 'nav-datovelger';
+import NavDatovelger, { DatovelgerProps } from 'nav-datovelger';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
 
 export interface DatoInputProps extends DatovelgerProps {
@@ -16,10 +16,12 @@ class DatoInput extends React.Component<Props, {}> {
         const { label, feil, intl, ...rest } = this.props;
         return (
             <SkjemaInputElement id={this.props.id} feil={feil} label={label}>
-                <Datovelger
+                <NavDatovelger.Datovelger
                     {...rest}
                     locale={intl.locale}
-                    inputProps={{ placeholder: 'dd.mm.åååå' }}
+                    input={{
+                        placeholder: 'dd.mm.åååå'
+                    }}
                 />
             </SkjemaInputElement>
         );

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -5,13 +5,13 @@ export type Dekningsgrad = '80%' | '100%';
 export type Forelder = 'forelder1' | 'forelder2';
 
 export interface Tidsperiode {
-    startdato: Date;
-    sluttdato: Date;
+    fom: Date;
+    tom: Date;
 }
 
 export interface TidsperiodeMedValgfriSluttdato {
-    startdato: Date;
-    sluttdato?: Date;
+    fom: Date;
+    tom?: Date;
 }
 
 export type TidsperiodePartial = Partial<Tidsperiode>;

--- a/src/common/util/fridagerUtils.ts
+++ b/src/common/util/fridagerUtils.ts
@@ -13,8 +13,8 @@ import { Tidsperiode } from 'common/types';
 const holidays = DateHolidays('no');
 
 export const getOffentligeFridager = (tidsperiode: Tidsperiode): Holiday[] => {
-    const fraÅr = tidsperiode.startdato.getFullYear();
-    const tilÅr = tidsperiode.sluttdato.getFullYear();
+    const fraÅr = tidsperiode.fom.getFullYear();
+    const tilÅr = tidsperiode.tom.getFullYear();
     let days = [] as Holiday[];
     if (fraÅr === tilÅr) {
         days = holidays.getHolidays(fraÅr);
@@ -25,8 +25,8 @@ export const getOffentligeFridager = (tidsperiode: Tidsperiode): Holiday[] => {
             år++;
         }
     }
-    const start = addDays(tidsperiode.startdato, -1);
-    const slutt = addDays(tidsperiode.sluttdato, 1);
+    const start = addDays(tidsperiode.fom, -1);
+    const slutt = addDays(tidsperiode.tom, 1);
     return days
         .filter((d) => d.type === 'public')
         .filter((d) => isAfter(d.date, start) && isBefore(d.date, slutt));
@@ -43,8 +43,8 @@ export const getOffentligeFridagerIMåned = (måned: Date): Holiday[] => {
 
 /* Default - hente ut helligdager i default tidsrom */
 export const fridager = getOffentligeFridager({
-    startdato: new Date(2017, 0, 1),
-    sluttdato: new Date(2022, 0, 1)
+    fom: new Date(2017, 0, 1),
+    tom: new Date(2022, 0, 1)
 });
 
 export const erFridag = (dato: Date): string | undefined => {

--- a/src/common/util/fridagerUtils.ts
+++ b/src/common/util/fridagerUtils.ts
@@ -8,7 +8,7 @@ import {
     isEqual
 } from 'date-fns';
 import { normaliserDato } from 'common/util/datoUtils';
-import { Tidsperiode } from 'nav-datovelger';
+import { Tidsperiode } from 'common/types';
 
 const holidays = DateHolidays('no');
 

--- a/src/uttaksplan/components/periodeTimeline/PeriodeTimeline.tsx
+++ b/src/uttaksplan/components/periodeTimeline/PeriodeTimeline.tsx
@@ -99,11 +99,11 @@ class PeriodeTidslinje extends React.Component<Props, {}> {
                 durationRenderer={(dager: number) => (
                     <UkerOgDager dager={dager} />
                 )}
-                rangeRenderer={(startdato: Date, sluttdato: Date) => (
+                rangeRenderer={(fom: Date, tom: Date) => (
                     <TidsperiodeTekst
                         tidsperiode={{
-                            startdato,
-                            sluttdato
+                            fom,
+                            tom
                         }}
                         visSluttdato={true}
                         visUkedag={true}

--- a/src/uttaksplan/components/periodeTimeline/periodeTimelineUtils.ts
+++ b/src/uttaksplan/components/periodeTimeline/periodeTimelineUtils.ts
@@ -66,8 +66,8 @@ export const mapPeriodeToTimelineEvent = (
             id: periode.id || guid(),
             type: TimelineItemType.event,
             title: getTittel(),
-            startDate: periode.tidsperiode.startdato,
-            endDate: periode.tidsperiode.sluttdato,
+            startDate: periode.tidsperiode.fom,
+            endDate: periode.tidsperiode.tom,
             personName:
                 periode.forelder === 'forelder2' && annenForelder
                     ? annenForelder.fornavn
@@ -80,10 +80,10 @@ export const mapPeriodeToTimelineEvent = (
         };
     } else {
         const gapItem: TimelineGap = {
-            id: periode.tidsperiode.startdato.toDateString(),
+            id: periode.tidsperiode.fom.toDateString(),
             type: TimelineItemType.gap,
-            startDate: periode.tidsperiode.startdato,
-            endDate: periode.tidsperiode.sluttdato,
+            startDate: periode.tidsperiode.fom,
+            endDate: periode.tidsperiode.tom,
             title: 'Opphold/tapte dager',
             days: Tidsperioden(periode.tidsperiode).getAntallUttaksdager(),
             icons: getTimelineIconsForPeriode(periode),

--- a/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
+++ b/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
@@ -6,7 +6,7 @@ import { Row, Column } from 'nav-frontend-grid';
 import DatoInput from 'common/components/dato-input/DatoInput';
 import { InjectedIntlProps, injectIntl } from 'react-intl';
 import { renderDag } from 'common/util/renderUtils';
-import { Tidsperiode } from 'nav-datovelger';
+import { Tidsperiode } from 'common/types';
 
 interface TidsperiodeDatoProps {
     label?: string;
@@ -76,7 +76,9 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                     helgedagerIkkeTillatt,
                                     ugyldigeTidsperioder
                                 }}
-                                kalenderplassering="fullskjerm"
+                                kalender={{
+                                    plassering: 'fullskjerm'
+                                }}
                                 dayPickerProps={{
                                     renderDay: renderDag
                                 }}
@@ -88,8 +90,8 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                     <div className="blokkPad-s">
                         <div className="blokk-xxs">
                             <DatoInput
-                                id="sluttdato"
                                 dato={sluttdato.dato}
+                                id="sluttdato"
                                 label={
                                     sluttdato.label ||
                                     intl.formatMessage({
@@ -114,7 +116,7 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                     helgedagerIkkeTillatt
                                 }}
                                 onChange={(date) => sluttdato.onChange(date)}
-                                kalenderplassering="fullskjerm"
+                                kalender={{ plassering: 'fullskjerm' }}
                                 dayPickerProps={{
                                     renderDay: renderDag
                                 }}

--- a/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
+++ b/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
@@ -68,13 +68,18 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                 }
                                 avgrensninger={{
                                     minDato: tidsperiodeStartdato
-                                        ? tidsperiodeStartdato.startdato
+                                        ? tidsperiodeStartdato.fom
                                         : undefined,
                                     maksDato: tidsperiodeStartdato
-                                        ? tidsperiodeStartdato.sluttdato
+                                        ? tidsperiodeStartdato.tom
                                         : undefined,
                                     helgedagerIkkeTillatt,
-                                    ugyldigeTidsperioder
+                                    ugyldigeTidsperioder: ugyldigeTidsperioder
+                                        ? ugyldigeTidsperioder.map((p) => ({
+                                              startdato: p.fom,
+                                              sluttdato: p.tom
+                                          }))
+                                        : undefined
                                 }}
                                 kalender={{
                                     plassering: 'fullskjerm'
@@ -107,13 +112,18 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                     minDato:
                                         minSluttdato ||
                                         (tidsperiodeSluttdato
-                                            ? tidsperiodeSluttdato.startdato
+                                            ? tidsperiodeSluttdato.fom
                                             : undefined),
                                     maksDato: tidsperiodeSluttdato
-                                        ? tidsperiodeSluttdato.sluttdato
+                                        ? tidsperiodeSluttdato.tom
                                         : undefined,
-                                    ugyldigeTidsperioder,
-                                    helgedagerIkkeTillatt
+                                    helgedagerIkkeTillatt,
+                                    ugyldigeTidsperioder: ugyldigeTidsperioder
+                                        ? ugyldigeTidsperioder.map((p) => ({
+                                              startdato: p.fom,
+                                              sluttdato: p.tom
+                                          }))
+                                        : undefined
                                 }}
                                 onChange={(date) => sluttdato.onChange(date)}
                                 kalender={{ plassering: 'fullskjerm' }}

--- a/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
+++ b/src/uttaksplan/components/skjema/spørsmål/TidsperiodeSpørsmål.tsx
@@ -75,10 +75,7 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                         : undefined,
                                     helgedagerIkkeTillatt,
                                     ugyldigeTidsperioder: ugyldigeTidsperioder
-                                        ? ugyldigeTidsperioder.map((p) => ({
-                                              startdato: p.fom,
-                                              sluttdato: p.tom
-                                          }))
+                                        ? ugyldigeTidsperioder
                                         : undefined
                                 }}
                                 kalender={{
@@ -119,10 +116,7 @@ const TidsperiodeSpørsmål: React.StatelessComponent<Props> = ({
                                         : undefined,
                                     helgedagerIkkeTillatt,
                                     ugyldigeTidsperioder: ugyldigeTidsperioder
-                                        ? ugyldigeTidsperioder.map((p) => ({
-                                              startdato: p.fom,
-                                              sluttdato: p.tom
-                                          }))
+                                        ? ugyldigeTidsperioder
                                         : undefined
                                 }}
                                 onChange={(date) => sluttdato.onChange(date)}

--- a/src/uttaksplan/components/skjema/utsettelseSkjema/UtsettelseSkjema.tsx
+++ b/src/uttaksplan/components/skjema/utsettelseSkjema/UtsettelseSkjema.tsx
@@ -151,12 +151,10 @@ class UtsettelseSkjema extends React.Component<Props, State> {
         const utsettelser = utsettelse
             ? registrerteUtsettelser.filter((u) => u.id !== utsettelse.id)
             : registrerteUtsettelser;
-        const tilTidsromStartdato = startdato
-            ? startdato
-            : tidsperiode.startdato;
+        const tilTidsromStartdato = startdato ? startdato : tidsperiode.fom;
         const tilTidsperiode: Tidsperiode = {
-            startdato: tilTidsromStartdato,
-            sluttdato: getTilTidsromSluttdato(
+            fom: tilTidsromStartdato,
+            tom: getTilTidsromSluttdato(
                 tilTidsromStartdato,
                 utsettelser,
                 this.props.uttaksgrunnlag

--- a/src/uttaksplan/components/skjema/utsettelseSkjema/utils.ts
+++ b/src/uttaksplan/components/skjema/utsettelseSkjema/utils.ts
@@ -28,10 +28,10 @@ export function getDefaultState(
                       ? 'forelder1'
                       : undefined,
               startdato: utsettelse.tidsperiode
-                  ? utsettelse.tidsperiode.startdato
+                  ? utsettelse.tidsperiode.fom
                   : undefined,
               sluttdato: utsettelse.tidsperiode
-                  ? utsettelse.tidsperiode.sluttdato
+                  ? utsettelse.tidsperiode.tom
                   : undefined
           }
         : {
@@ -99,8 +99,8 @@ export function validerUtsettelseskjema(
             sluttdato,
             {
                 ...tidsperiode,
-                sluttdato: getTilTidsromSluttdato(
-                    startdato || tidsperiode.startdato,
+                tom: getTilTidsromSluttdato(
+                    startdato || tidsperiode.fom,
                     andreUtsettelser,
                     uttaksgrunnlag
                 )
@@ -178,8 +178,8 @@ export function validerUtsettelseskjema(
         startdato &&
         sluttdato &&
         Tidsperioden({
-            startdato,
-            sluttdato
+            fom: startdato,
+            tom: sluttdato
         }).getAntallFridager() > 0
     ) {
         valideringsfeil.set('tidsperiode', {
@@ -206,8 +206,8 @@ export function getUgyldigeTidsrom(
         registrerteUtsettelser
             .filter((u) => !utsettelse || utsettelse.id !== u.id)
             .map((u) => ({
-                startdato: u.tidsperiode.startdato,
-                sluttdato: u.tidsperiode.sluttdato
+                fom: u.tidsperiode.fom,
+                tom: u.tidsperiode.tom
             }));
     return ugyldigeTidsrom;
 }
@@ -216,21 +216,21 @@ export function getUgyldigeTidsrom(
  * Finner siste gyldige sluttdato for en utsettelse
  * @param familiehendelsedato
  * @param permisjonsregler
- * @param tilTidsromStartdato
+ * @param tilTidsromFom
  * @param registrerteUtsettelser
  */
 export function getTilTidsromSluttdato(
-    tilTidsromStartdato: Date,
+    tilTidsromFom: Date,
     registrerteUtsettelser: Utsettelsesperiode[],
     uttaksgrunnlag: Uttaksgrunnlag
 ) {
     if (registrerteUtsettelser.length > 0) {
         const pafolgendeUtsettelser = registrerteUtsettelser.filter((u) =>
-            isAfter(u.tidsperiode.startdato, tilTidsromStartdato)
+            isAfter(u.tidsperiode.fom, tilTidsromFom)
         );
         if (pafolgendeUtsettelser.length > 0) {
             return Uttaksdagen(
-                pafolgendeUtsettelser[0].tidsperiode.startdato
+                pafolgendeUtsettelser[0].tidsperiode.fom
             ).forrige();
         }
     }
@@ -242,16 +242,16 @@ export function getTilTidsromSluttdato(
  * ny utsettelse
  * @param årsak
  * @param forelder
- * @param startdato
- * @param sluttdato
+ * @param fom
+ * @param tom
  * @param registrerteUtsettelser
  * @param utsettelse
  */
 export function getAntallFeriedager(
     årsak: UtsettelseÅrsakType | undefined,
     forelder: Forelder | undefined,
-    startdato: Date | undefined,
-    sluttdato: Date | undefined,
+    fom: Date | undefined,
+    tom: Date | undefined,
     registrerteUtsettelser: Utsettelsesperiode[],
     utsettelse: Utsettelsesperiode | undefined
 ) {
@@ -267,10 +267,10 @@ export function getAntallFeriedager(
     }
 
     let fridager = 0;
-    if (startdato && sluttdato) {
+    if (fom && tom) {
         const tidsperiode: Tidsperiode = {
-            startdato,
-            sluttdato
+            fom,
+            tom
         };
         nyeFeriedager = Tidsperioden(tidsperiode).getAntallUttaksdager();
         fridager = Tidsperioden(tidsperiode).getAntallFridager();

--- a/src/uttaksplan/components/skjema/uttaksperiodeSkjema/UttaksperiodeSkjema.tsx
+++ b/src/uttaksplan/components/skjema/uttaksperiodeSkjema/UttaksperiodeSkjema.tsx
@@ -13,7 +13,7 @@ import { normaliserDato } from 'common/util/datoUtils';
 import EkspanderbartInnhold from 'common/components/ekspanderbart-innhold/EkspanderbartInnhold';
 import Knapperad from 'common/components/knapperad/Knapperad';
 import { preventFormSubmit } from 'common/util/eventUtils';
-import { Tidsperiode } from 'nav-datovelger';
+import { Tidsperiode } from 'common/types';
 import { getStønadskontoRegler } from 'uttaksplan/utils/regler/uttaksperioderegler';
 import { Uttaksgrunnlag } from 'uttaksplan/utils/uttak/uttaksgrunnlag';
 import HvemGjelderPeriodenSpørsmål from 'uttaksplan/components/skjema/spørsmål/HvemGjelderPeriodenSpørsmål';

--- a/src/uttaksplan/components/skjema/uttaksperiodeSkjema/UttaksperiodeSkjema.tsx
+++ b/src/uttaksplan/components/skjema/uttaksperiodeSkjema/UttaksperiodeSkjema.tsx
@@ -32,8 +32,8 @@ export interface OwnProps {
 
 export interface State {
     forelder?: Forelder;
-    startdato?: Date;
-    sluttdato?: Date;
+    fom?: Date;
+    tom?: Date;
     stønadskonto?: StønadskontoType;
     visStønadskontoSpørsmål: boolean;
     tilgjengeligeStønadskontoer: StønadskontoType[];
@@ -61,21 +61,21 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
         this.state = {
             forelder: periode ? periode.forelder : undefined,
             stønadskonto: periode ? periode.konto : singelStønadskonto,
-            startdato: periode ? periode.tidsperiode.startdato : undefined,
-            sluttdato: periode ? periode.tidsperiode.sluttdato : undefined,
+            fom: periode ? periode.tidsperiode.fom : undefined,
+            tom: periode ? periode.tidsperiode.tom : undefined,
             tilgjengeligeStønadskontoer,
             visStønadskontoSpørsmål: tilgjengeligeStønadskontoer.length > 1
         };
     }
 
-    setStartdato(startdato: Date) {
+    setStartdato(fom: Date) {
         this.setState({
-            startdato: normaliserDato(startdato)
+            fom: normaliserDato(fom)
         });
     }
 
-    setSluttdato(sluttdato: Date) {
-        this.setState({ sluttdato: normaliserDato(sluttdato) });
+    setSluttdato(tom: Date) {
+        this.setState({ tom: normaliserDato(tom) });
     }
 
     handleSubmitClick(evt: React.MouseEvent<HTMLButtonElement>) {
@@ -87,16 +87,16 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
     }
 
     getPeriodeFromSkjema(): Uttaksperiode | undefined {
-        const { startdato, sluttdato, stønadskonto, forelder } = this.state;
-        if (!startdato || !sluttdato || !stønadskonto || !forelder) {
+        const { fom, tom, stønadskonto, forelder } = this.state;
+        if (!fom || !tom || !stønadskonto || !forelder) {
             return undefined;
         }
         const periode: Uttaksperiode = {
             ...this.props.periode,
             type: Periodetype.Uttak,
             tidsperiode: {
-                startdato,
-                sluttdato
+                fom,
+                tom
             },
             forelder,
             konto: stønadskonto
@@ -109,8 +109,8 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
         return (
             this.state.forelder !== undefined &&
             this.state.stønadskonto !== undefined &&
-            this.state.startdato !== undefined &&
-            this.state.sluttdato !== undefined
+            this.state.fom !== undefined &&
+            this.state.tom !== undefined
         );
     }
 
@@ -124,7 +124,7 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
         const tittelKey = periode
             ? 'uttaksplan.uttaksperiodeskjema.endre.tittel'
             : 'uttaksplan.uttaksperiodeskjema.tittel';
-        const { startdato, sluttdato, forelder, stønadskonto } = this.state;
+        const { fom, tom, forelder, stønadskonto } = this.state;
         const tilgjengeligeStønadskontoer =
             uttaksgrunnlag.tilgjengeligeStønadskontoer;
 
@@ -155,12 +155,12 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
 
         const tidsperiode: Tidsperiode | undefined = regler
             ? {
-                  startdato: regler.tidligsteUttaksdato,
-                  sluttdato: regler.sisteUttaksdato
+                  fom: regler.tidligsteUttaksdato,
+                  tom: regler.sisteUttaksdato
               }
             : {
-                  startdato: this.props.familiehendelsedato,
-                  sluttdato: uttaksgrunnlag.datoer.sisteMuligeUttaksdag
+                  fom: this.props.familiehendelsedato,
+                  tom: uttaksgrunnlag.datoer.sisteMuligeUttaksdag
               };
 
         return (
@@ -207,12 +207,12 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
                 <EkspanderbartInnhold erApen={visSpørsmålOmTidsrom}>
                     <TidsperiodeSpørsmål
                         startdato={{
-                            dato: startdato,
+                            dato: fom,
                             onChange: this.setStartdato,
                             tidsperiode
                         }}
                         sluttdato={{
-                            dato: sluttdato,
+                            dato: tom,
                             onChange: this.setSluttdato,
                             tidsperiode
                         }}
@@ -222,7 +222,7 @@ class UttaksperiodeSkjema extends React.Component<Props, State> {
                 </EkspanderbartInnhold>
 
                 <EkspanderbartInnhold
-                    erApen={startdato !== undefined && sluttdato !== undefined}>
+                    erApen={fom !== undefined && tom !== undefined}>
                     <Knapperad>
                         <Hovedknapp
                             onClick={this.handleSubmitClick}

--- a/src/uttaksplan/components/tidsperiodeTekst/TidsperiodeTekst.tsx
+++ b/src/uttaksplan/components/tidsperiodeTekst/TidsperiodeTekst.tsx
@@ -18,16 +18,13 @@ const TidsperiodeTekst: React.StatelessComponent<Props> = ({
     return (
         <div className="tidsperiodeTekst">
             <span className="tidsperiodeTekst__periode">
-                <FormatertDato
-                    dato={tidsperiode.startdato}
-                    visUkedag={visUkedag}
-                />
+                <FormatertDato dato={tidsperiode.fom} visUkedag={visUkedag} />
                 {visSluttdato && (
                     <span>
                         {' '}
                         -{' '}
                         <FormatertDato
-                            dato={tidsperiode.sluttdato}
+                            dato={tidsperiode.tom}
                             visUkedag={visUkedag}
                         />
                     </span>

--- a/src/uttaksplan/components/tidsperiodeTekst/TidsperiodeTekst.tsx
+++ b/src/uttaksplan/components/tidsperiodeTekst/TidsperiodeTekst.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import './tidsperiodeTekst.less';
 import FormatertDato from 'common/components/formatert-dato/FormatertDato';
-import { Tidsperiode } from 'nav-datovelger';
+import { Tidsperiode } from 'common/types';
 
 export interface Props {
     tidsperiode: Tidsperiode;

--- a/src/uttaksplan/components/uttaksoversikt/Uttaksoversikt.tsx
+++ b/src/uttaksplan/components/uttaksoversikt/Uttaksoversikt.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
-import * as classnames from 'classnames';
-import './uttaksoversikt.less';
+import classnames from 'classnames';
 import { BeregnetUttak } from 'uttaksplan/types';
+
+import './uttaksoversikt.less';
 
 export interface OwnProps {
     uttak: BeregnetUttak[];

--- a/src/uttaksplan/connectedComponents/utsettelsesperiodeDialog/UtsettelsesperiodeDialog.tsx
+++ b/src/uttaksplan/connectedComponents/utsettelsesperiodeDialog/UtsettelsesperiodeDialog.tsx
@@ -108,7 +108,7 @@ const mapStateToProps = (
     const { familiehendelsedato } = props;
     const { dekningsgrad } = form;
     const sisteRegistrertePermisjonsdag =
-        props.uttaksinfo.registrertTidsperiode.sluttdato;
+        props.uttaksinfo.registrertTidsperiode.tom;
     if (
         !familiehendelsedato ||
         !dekningsgrad ||

--- a/src/uttaksplan/main/UttaksplanMain.tsx
+++ b/src/uttaksplan/main/UttaksplanMain.tsx
@@ -127,7 +127,7 @@ class UttaksplanMain extends React.Component<Props> {
                 <div className="blokk-m">
                     <Veilederinfo type="info">
                         Her setter du opp hvordan dere ønsker å ta ut
-                        foreldrepengene. Henrik må sende inn egen søknad.
+                        foreldrepengene.
                     </Veilederinfo>
                 </div>
                 {!perioderOpprettet && (

--- a/src/uttaksplan/main/dev/DevBeregning.tsx
+++ b/src/uttaksplan/main/dev/DevBeregning.tsx
@@ -23,15 +23,15 @@ const DevBeregning: React.StatelessComponent<Props> = ({
                     <ul>
                         <li>
                             Første registrerte uttaksdag:{' '}
-                            {uttaksinfo.registrertTidsperiode.startdato.toDateString()}
+                            {uttaksinfo.registrertTidsperiode.fom.toDateString()}
                         </li>
                         <li>
                             Siste registrerte uttaksdag:{' '}
-                            {uttaksinfo.registrertTidsperiode.sluttdato.toDateString()}
+                            {uttaksinfo.registrertTidsperiode.tom.toDateString()}
                         </li>
                         <li>
                             Siste registrerte uttaksdag (inkludert opphold):{' '}
-                            {uttaksinfo.registrertTidsperiodeInkludertOpphold.sluttdato.toDateString()}
+                            {uttaksinfo.registrertTidsperiodeInkludertOpphold.tom.toDateString()}
                         </li>
                         <li>
                             Siste beregnet uttaksdag:{' '}

--- a/src/uttaksplan/main/dev/DevToolbar.tsx
+++ b/src/uttaksplan/main/dev/DevToolbar.tsx
@@ -56,8 +56,8 @@ const mockUtsettelse: Utsettelsesperiode = {
     type: Periodetype.Utsettelse,
     årsak: UtsettelseÅrsakType.Ferie,
     tidsperiode: {
-        startdato: normaliserDato(new Date(2018, 7, 30)),
-        sluttdato: normaliserDato(new Date(2018, 7, 31))
+        fom: normaliserDato(new Date(2018, 7, 30)),
+        tom: normaliserDato(new Date(2018, 7, 31))
     }
 };
 
@@ -65,8 +65,8 @@ const mockUtsettelse2: Utsettelsesperiode = {
     ...mockUtsettelse,
     årsak: UtsettelseÅrsakType.Arbeid,
     tidsperiode: {
-        startdato: normaliserDato(new Date(2018, 9, 22)),
-        sluttdato: normaliserDato(new Date(2018, 9, 22))
+        fom: normaliserDato(new Date(2018, 9, 22)),
+        tom: normaliserDato(new Date(2018, 9, 22))
     }
 };
 
@@ -74,8 +74,8 @@ export const mockUttaksperiode: Uttaksperiode = {
     forelder: 'forelder1',
     konto: StønadskontoType.Foreldrepenger,
     tidsperiode: {
-        startdato: normaliserDato(new Date(2018, 9, 3)),
-        sluttdato: normaliserDato(new Date(2018, 9, 4))
+        fom: normaliserDato(new Date(2018, 9, 3)),
+        tom: normaliserDato(new Date(2018, 9, 4))
     },
     type: Periodetype.Uttak
 };
@@ -84,8 +84,8 @@ const mockUttaksperiodeOverUtsettelse: Uttaksperiode = {
     forelder: 'forelder2',
     konto: StønadskontoType.Foreldrepenger,
     tidsperiode: {
-        startdato: normaliserDato(new Date(2018, 7, 28)),
-        sluttdato: normaliserDato(new Date(2018, 8, 3))
+        fom: normaliserDato(new Date(2018, 7, 28)),
+        tom: normaliserDato(new Date(2018, 8, 3))
     },
     type: Periodetype.Uttak
 };
@@ -152,7 +152,7 @@ class DevToolbar extends React.Component<Props, {}> {
             return;
         }
         const tidsperiode = Tidsperioden(periode.tidsperiode).setStartdato(
-            Uttaksdagen(periode.tidsperiode.startdato).leggTil(10)
+            Uttaksdagen(periode.tidsperiode.fom).leggTil(10)
         );
         this.props.dispatch(
             opprettEllerOppdaterPeriode({
@@ -164,7 +164,7 @@ class DevToolbar extends React.Component<Props, {}> {
     flyttPeriode(dager: number = 1, idx: number = 3) {
         const periode = this.props.appState.uttaksplan.uttaksplan.perioder[idx];
         const tidsperiode = Tidsperioden(periode.tidsperiode).setStartdato(
-            Uttaksdagen(periode.tidsperiode.startdato).leggTil(dager)
+            Uttaksdagen(periode.tidsperiode.fom).leggTil(dager)
         );
         this.props.dispatch(
             opprettEllerOppdaterPeriode({

--- a/src/uttaksplan/redux/reducers/mockdata.ts
+++ b/src/uttaksplan/redux/reducers/mockdata.ts
@@ -9,8 +9,8 @@ export const mockArbeid: Utsettelsesperiode = {
     type: Periodetype.Utsettelse,
     årsak: UtsettelseÅrsakType.Arbeid,
     tidsperiode: {
-        startdato: new Date('2018-07-30T22:00:00.000Z'),
-        sluttdato: new Date('2018-07-30T22:00:00.000Z')
+        fom: new Date('2018-07-30T22:00:00.000Z'),
+        tom: new Date('2018-07-30T22:00:00.000Z')
     },
     forelder: 'forelder1'
 };
@@ -19,8 +19,8 @@ export const mockFerie: Utsettelsesperiode = {
     type: Periodetype.Utsettelse,
     årsak: UtsettelseÅrsakType.Ferie,
     tidsperiode: {
-        startdato: new Date('2018-08-05T22:00:00.000Z'),
-        sluttdato: new Date('2018-08-10T22:00:00.000Z')
+        fom: new Date('2018-08-05T22:00:00.000Z'),
+        tom: new Date('2018-08-10T22:00:00.000Z')
     },
     forelder: 'forelder1'
 };

--- a/src/uttaksplan/utils/Perioden.ts
+++ b/src/uttaksplan/utils/Perioden.ts
@@ -10,10 +10,10 @@ export const Perioden = (periode: Periode) => ({
     erLik: (periode2: Periode) => erPerioderLike(periode, periode2),
     erSammenhengende: (periode2: Periode) =>
         erPerioderSammenhengende(periode, periode2),
-    setStartdato: (startdato: Date) => flyttPeriode(periode, startdato),
+    setStartdato: (fom: Date) => flyttPeriode(periode, fom),
     setUttaksdager: (uttaksdager: number) =>
         (periode.tidsperiode = getTidsperiode(
-            periode.tidsperiode.startdato,
+            periode.tidsperiode.fom,
             uttaksdager
         )),
     getAntallUttaksdager: () =>
@@ -39,8 +39,8 @@ function erUttak(periode: Periode): boolean {
  * @param p2
  */
 function erPerioderSammenhengende(p1: Periode, p2: Periode) {
-    const p1NesteUttaksdato = Uttaksdagen(p1.tidsperiode.sluttdato).neste();
-    const p2Startdato = p2.tidsperiode.startdato;
+    const p1NesteUttaksdato = Uttaksdagen(p1.tidsperiode.tom).neste();
+    const p2Startdato = p2.tidsperiode.fom;
     return isSameDay(p1NesteUttaksdato, p2Startdato);
 }
 
@@ -85,11 +85,11 @@ function getPeriodeFootprint(periode: Periode) {
 /**
  * Flytter periode til ny startdato, beholder samme antall uttaksdager
  * @param periode
- * @param startdato
+ * @param fom
  */
-function flyttPeriode(periode: Periode, startdato: Date): Periode {
+function flyttPeriode(periode: Periode, fom: Date): Periode {
     return {
         ...periode,
-        tidsperiode: Tidsperioden(periode.tidsperiode).setStartdato(startdato)
+        tidsperiode: Tidsperioden(periode.tidsperiode).setStartdato(fom)
     };
 }

--- a/src/uttaksplan/utils/Tidsperioden.ts
+++ b/src/uttaksplan/utils/Tidsperioden.ts
@@ -19,26 +19,23 @@ export const Tidsperioden = (tidsperiode: Tidsperiode) => ({
     getAntallUttaksdager: (taBortFridager?: boolean) =>
         getAntallUttaksdagerITidsperiode(tidsperiode, taBortFridager),
     getAntallFridager: () => getUttaksdagerSomErFridager(tidsperiode).length,
-    setStartdato: (startdato: Date) => flyttTidsperiode(tidsperiode, startdato),
+    setStartdato: (fom: Date) => flyttTidsperiode(tidsperiode, fom),
     setUttaksdager: (uttaksdager: number) =>
-        getTidsperiode(tidsperiode.startdato, uttaksdager)
+        getTidsperiode(tidsperiode.fom, uttaksdager)
 });
 
 /**
  * Returnerer ny Tidsperiode gitt gyldig uttaksdag-startdato og antall uttaksdager
- * @param startdato
+ * @param fom
  * @param uttaksdager
  */
-export function getTidsperiode(
-    startdato: Date,
-    uttaksdager: number
-): Tidsperiode {
-    if (!Uttaksdagen(startdato).erUttaksdag()) {
+export function getTidsperiode(fom: Date, uttaksdager: number): Tidsperiode {
+    if (!Uttaksdagen(fom).erUttaksdag()) {
         throw new Error('Startdato er ikke en uttaksdag');
     }
     return {
-        startdato,
-        sluttdato: Uttaksdagen(startdato).leggTil(uttaksdager - 1)
+        fom,
+        tom: Uttaksdagen(fom).leggTil(uttaksdager - 1)
     };
 }
 
@@ -73,18 +70,18 @@ function getAntallUttaksdagerITidsperiode(
     tidsperiode: Tidsperiode,
     taBortFridager?: boolean
 ): number {
-    if (tidsperiode.startdato > tidsperiode.sluttdato) {
+    if (tidsperiode.fom > tidsperiode.tom) {
         return -1;
     }
-    const startdato = new Date(tidsperiode.startdato.getTime());
-    const sluttdato = new Date(tidsperiode.sluttdato.getTime());
+    const fom = new Date(tidsperiode.fom.getTime());
+    const tom = new Date(tidsperiode.tom.getTime());
     let antall = 0;
     let fridager = 0;
-    while (startdato <= sluttdato) {
-        if (Uttaksdagen(startdato).erUttaksdag()) {
+    while (fom <= tom) {
+        if (Uttaksdagen(fom).erUttaksdag()) {
             antall++;
         }
-        startdato.setDate(startdato.getDate() + 1);
+        fom.setDate(fom.getDate() + 1);
     }
     if (taBortFridager) {
         fridager = getUttaksdagerSomErFridager(tidsperiode).length;
@@ -105,14 +102,11 @@ function getUttaksdagerSomErFridager(tidsperiode: Tidsperiode): Holiday[] {
  * Setter ny startdato og flytter sluttdato slik at antall
  * uttaksdager blir det samme
  * @param tidsperiode
- * @param startdato
+ * @param fom
  */
-function flyttTidsperiode(
-    tidsperiode: Tidsperiode,
-    startdato: Date
-): Tidsperiode {
+function flyttTidsperiode(tidsperiode: Tidsperiode, fom: Date): Tidsperiode {
     const uttaksdager = getAntallUttaksdagerITidsperiode(tidsperiode);
-    return getTidsperiode(startdato, uttaksdager);
+    return getTidsperiode(fom, uttaksdager);
 }
 
 /**
@@ -134,14 +128,8 @@ function erTidsperiodeOmsluttetAvTidsperiode(
     tidsperiode2: Tidsperiode
 ): boolean {
     return (
-        erSammeEllerSenereDato(
-            tidsperiode1.startdato,
-            tidsperiode2.startdato
-        ) &&
-        erSammeEllerTidligereDato(
-            tidsperiode1.sluttdato,
-            tidsperiode2.sluttdato
-        )
+        erSammeEllerSenereDato(tidsperiode1.fom, tidsperiode2.fom) &&
+        erSammeEllerTidligereDato(tidsperiode1.tom, tidsperiode2.tom)
     );
 }
 
@@ -155,7 +143,7 @@ function erTidsperiodeUtenforTidsperiode(
     tidsperiode2: Tidsperiode
 ): boolean {
     return (
-        isAfter(tidsperiode1.startdato, tidsperiode2.sluttdato) ||
-        isBefore(tidsperiode1.sluttdato, tidsperiode2.startdato)
+        isAfter(tidsperiode1.fom, tidsperiode2.tom) ||
+        isBefore(tidsperiode1.tom, tidsperiode2.fom)
     );
 }

--- a/src/uttaksplan/utils/Uttaksdagen.ts
+++ b/src/uttaksplan/utils/Uttaksdagen.ts
@@ -131,20 +131,18 @@ function trekkUttaksdagerFraDato(dato: Date, uttaksdager: number): Date {
  * @param fra
  * @param til
  */
-function getUttaksdagerFremTilDato(startdato: Date, sluttdato: Date): number {
-    if (isSameDay(startdato, sluttdato)) {
+function getUttaksdagerFremTilDato(fom: Date, tom: Date): number {
+    if (isSameDay(fom, tom)) {
         return 0;
     }
-    if (isBefore(startdato, sluttdato)) {
-        return (
-            Tidsperioden({ startdato, sluttdato }).getAntallUttaksdager() - 1
-        );
+    if (isBefore(fom, tom)) {
+        return Tidsperioden({ fom, tom }).getAntallUttaksdager() - 1;
     }
     return (
         -1 *
         (Tidsperioden({
-            startdato: sluttdato,
-            sluttdato: startdato
+            fom: tom,
+            tom: fom
         }).getAntallUttaksdager() -
             1)
     );

--- a/src/uttaksplan/utils/permisjonUtils.ts
+++ b/src/uttaksplan/utils/permisjonUtils.ts
@@ -45,10 +45,10 @@ export function getGyldigTidsromForUtsettelse(
         familiehendelsedato,
         permisjonsregler
     );
-    const startdato = Uttaksdagen(mødrekvoteEtterTermin.sluttdato).neste();
+    const fom = Uttaksdagen(mødrekvoteEtterTermin.tom).neste();
     return {
-        startdato,
-        sluttdato: sisteRegistrertePermisjonsdag
+        fom,
+        tom: sisteRegistrertePermisjonsdag
     };
 }
 

--- a/src/uttaksplan/utils/planer/UttaksplanManuell.ts
+++ b/src/uttaksplan/utils/planer/UttaksplanManuell.ts
@@ -68,26 +68,20 @@ function fjernUttaksdagerFraPerioder(
             fjernTidsperiodeFraPeriode(p, periode.tidsperiode).forEach((p2) =>
                 nyePerioder.push(p2)
             );
-        } else if (
-            isBefore(p.tidsperiode.startdato, periode.tidsperiode.startdato)
-        ) {
+        } else if (isBefore(p.tidsperiode.fom, periode.tidsperiode.fom)) {
             nyePerioder.push({
                 ...p,
                 tidsperiode: {
-                    startdato: p.tidsperiode.startdato,
-                    sluttdato: Uttaksdagen(
-                        periode.tidsperiode.startdato
-                    ).forrige()
+                    fom: p.tidsperiode.fom,
+                    tom: Uttaksdagen(periode.tidsperiode.fom).forrige()
                 }
             });
         } else {
             nyePerioder.push({
                 ...p,
                 tidsperiode: {
-                    startdato: Uttaksdagen(
-                        periode.tidsperiode.sluttdato
-                    ).neste(),
-                    sluttdato: p.tidsperiode.sluttdato
+                    fom: Uttaksdagen(periode.tidsperiode.tom).neste(),
+                    tom: p.tidsperiode.tom
                 }
             });
         }
@@ -107,40 +101,37 @@ function fjernTidsperiodeFraPeriode(
     const t1 = periode.tidsperiode;
 
     // Dersom de ikke overlapper
-    if (
-        isBefore(t1.sluttdato, tidsperiode.startdato) ||
-        isAfter(t1.startdato, tidsperiode.sluttdato)
-    ) {
+    if (isBefore(t1.tom, tidsperiode.fom) || isAfter(t1.fom, tidsperiode.tom)) {
         return [periode];
     }
 
     // Total overlapp
     if (
-        isSameDay(t1.startdato, tidsperiode.startdato) &&
-        isSameDay(t1.sluttdato, tidsperiode.sluttdato)
+        isSameDay(t1.fom, tidsperiode.fom) &&
+        isSameDay(t1.tom, tidsperiode.tom)
     ) {
         return [];
     }
 
-    if (isSameDay(t1.startdato, tidsperiode.startdato)) {
+    if (isSameDay(t1.fom, tidsperiode.fom)) {
         // Samme startdato -> dvs. startdato må flyttes, mens sluttdato er samme
         return [
             {
                 ...periode,
                 tidsperiode: {
                     ...periode.tidsperiode,
-                    startdato: Uttaksdagen(tidsperiode.startdato).forrige()
+                    fom: Uttaksdagen(tidsperiode.fom).forrige()
                 }
             }
         ];
-    } else if (isSameDay(t1.sluttdato, tidsperiode.sluttdato)) {
+    } else if (isSameDay(t1.tom, tidsperiode.tom)) {
         // Sluttdato er samme, dvs. sluttdato må flyttes, startdato er samme
         return [
             {
                 ...periode,
                 tidsperiode: {
                     ...periode.tidsperiode,
-                    sluttdato: Uttaksdagen(tidsperiode.sluttdato).neste()
+                    tom: Uttaksdagen(tidsperiode.tom).neste()
                 }
             }
         ];
@@ -151,7 +142,7 @@ function fjernTidsperiodeFraPeriode(
             ...periode,
             tidsperiode: {
                 ...periode.tidsperiode,
-                sluttdato: Uttaksdagen(tidsperiode.startdato).forrige()
+                tom: Uttaksdagen(tidsperiode.fom).forrige()
             }
         },
         {
@@ -159,7 +150,7 @@ function fjernTidsperiodeFraPeriode(
             id: guid(),
             tidsperiode: {
                 ...periode.tidsperiode,
-                startdato: Uttaksdagen(tidsperiode.sluttdato).neste()
+                fom: Uttaksdagen(tidsperiode.tom).neste()
             }
         }
     ];

--- a/src/uttaksplan/utils/planer/oppsett/forenklet.ts
+++ b/src/uttaksplan/utils/planer/oppsett/forenklet.ts
@@ -55,7 +55,7 @@ export function opprettUttaksperioderEnkel(
         forelder: 'forelder2',
         konto: StønadskontoType.FarsDel,
         tidsperiode: getTidsperiode(
-            Uttaksdagen(morsDelEtterTermin.tidsperiode.sluttdato).neste(),
+            Uttaksdagen(morsDelEtterTermin.tidsperiode.tom).neste(),
             ukerFarsDel * UTTAKSDAGER_I_UKE
         )
     };

--- a/src/uttaksplan/utils/planer/oppsett/toForeldreEttBarn.ts
+++ b/src/uttaksplan/utils/planer/oppsett/toForeldreEttBarn.ts
@@ -39,7 +39,7 @@ function getFrivilligMødrekvoteEtterTermin(
 ): Tidsperiode {
     const startdato = Uttaksdagen(
         getPakrevdMødrekvoteEtterTermin(familiehendelsedato, permisjonsregler)
-            .sluttdato
+            .tom
     ).neste();
     return getTidsperiode(
         startdato,
@@ -56,7 +56,7 @@ function getFellesperiodeForelder1(
 ): Tidsperiode {
     const startdato = Uttaksdagen(
         getFrivilligMødrekvoteEtterTermin(familiehendelsedato, permisjonsregler)
-            .sluttdato
+            .tom
     ).neste();
     return getTidsperiode(startdato, fellesukerForelder1 * UTTAKSDAGER_I_UKE);
 }
@@ -72,12 +72,12 @@ function getFellesperiodeForelder2(
             ? getFrivilligMødrekvoteEtterTermin(
                   familiehendelsedato,
                   permisjonsregler
-              ).sluttdato
+              ).tom
             : getFellesperiodeForelder1(
                   familiehendelsedato,
                   permisjonsregler,
                   fellesukerForelder1
-              ).sluttdato
+              ).tom
     ).neste();
     return getTidsperiode(startdato, fellesukerForelder2 * UTTAKSDAGER_I_UKE);
 }
@@ -94,13 +94,13 @@ function getFedrekvote(
                   familiehendelsedato,
                   permisjonsregler,
                   fellesukerForelder1
-              ).sluttdato
+              ).tom
             : getFellesperiodeForelder2(
                   familiehendelsedato,
                   permisjonsregler,
                   fellesukerForelder1,
                   fellesukerForelder2
-              ).sluttdato
+              ).tom
     ).neste();
     return getTidsperiode(
         startdato,

--- a/src/uttaksplan/utils/planer/oppsett/toForeldreEttBarn.ts
+++ b/src/uttaksplan/utils/planer/oppsett/toForeldreEttBarn.ts
@@ -3,9 +3,9 @@ import {
     Uttaksperiode,
     StønadskontoType,
     Periodetype,
-    Dekningsgrad
+    Dekningsgrad,
+    Tidsperiode
 } from 'uttaksplan/types';
-import { Tidsperiode } from 'nav-datovelger';
 import { sorterPerioder, Uttaksdagen, getTidsperiode } from 'uttaksplan/utils';
 import { getPermisjonStartdato } from 'uttaksplan/utils/permisjonUtils';
 import { normaliserDato } from 'common/util/datoUtils';

--- a/src/uttaksplan/utils/uttak/uttaksinfo.ts
+++ b/src/uttaksplan/utils/uttak/uttaksinfo.ts
@@ -34,9 +34,9 @@ export const getUttaksinfo = (perioder: Periode[]): Uttaksinfo | undefined => {
         true
     ) as Tidsperiode;
     const sluttdatoGittUttaksdager = getTidsperiode(
-        registrertTidsperiode.startdato,
+        registrertTidsperiode.fom,
         antallDagerTotalt
-    ).sluttdato;
+    ).tom;
     return {
         antallDagerTotalt,
         antallDagerOpphold,

--- a/src/uttaksplan/utils/uttak/uttaksinfo.ts
+++ b/src/uttaksplan/utils/uttak/uttaksinfo.ts
@@ -1,4 +1,4 @@
-import { Tidsperiode } from 'nav-datovelger';
+import { Tidsperiode } from 'common/types';
 import { getTidsperiode, Periodene } from 'uttaksplan/utils';
 import { Periode } from 'uttaksplan/types';
 

--- a/src/uttaksplan/utils/validerDatoUtils.ts
+++ b/src/uttaksplan/utils/validerDatoUtils.ts
@@ -37,7 +37,7 @@ export const validerDato = (
         isWithinRange(
             normaliserDato(dato),
             normaliserDato(familiehendelsedato),
-            normaliserDato(Uttaksdagen(tidsrom.startdato).forrige())
+            normaliserDato(Uttaksdagen(tidsrom.fom).forrige())
         )
     ) {
         return 'innenforForsteSeksUker';
@@ -45,8 +45,8 @@ export const validerDato = (
     if (
         !isWithinRange(
             normaliserDato(dato),
-            normaliserDato(tidsrom.startdato),
-            normaliserDato(tidsrom.sluttdato)
+            normaliserDato(tidsrom.fom),
+            normaliserDato(tidsrom.tom)
         )
     ) {
         return 'utenforPerioder';
@@ -56,7 +56,7 @@ export const validerDato = (
     }
     let gyldig: DatoValideringsfeil;
     ugyldigePerioder.forEach((p) => {
-        if (gyldig && isWithinRange(dato, p.startdato, p.sluttdato)) {
+        if (gyldig && isWithinRange(dato, p.fom, p.tom)) {
             gyldig = 'innenforUlovligPeriode';
         }
     });


### PR DESCRIPTION
Har lagt inn bruk av datovelger 2.0.1, samt refactorert Tidsperiode til å være fom/tom i stedet for startdato/sluttdato.
Denne forutsetter deploy av nav-datovelger 2.1.0.