### PR TITLE
Fix AnnenForelderSteg visibility-bug

### DIFF
--- a/src/app/connected-components/steg/annen-forelder/__tests__/annenForelderVisibilityFunctionsTests.ts
+++ b/src/app/connected-components/steg/annen-forelder/__tests__/annenForelderVisibilityFunctionsTests.ts
@@ -68,15 +68,6 @@ describe('AnnenForelder visibility tests', () => {
                     )
                 ).toBeTruthy();
                 expect(
-                    func.visErAnnenForelderInformertSpørsmål(
-                        { erAleneOmOmsorg: true },
-                        { harRettPåForeldrepenger: false },
-                        true,
-                        true
-                    )
-                ).toBeFalsy();
-                expect(func.visErAnnenForelderInformertSpørsmål({ erAleneOmOmsorg: true }, {}, true, true)).toBeFalsy();
-                expect(
                     func.visErAnnenForelderInformertSpørsmål({ erAleneOmOmsorg: false }, {}, true, false)
                 ).toBeFalsy();
                 expect(

--- a/src/app/connected-components/steg/annen-forelder/visibility/visibilityFunctions.ts
+++ b/src/app/connected-components/steg/annen-forelder/visibility/visibilityFunctions.ts
@@ -62,10 +62,8 @@ const visErAnnenForelderInformertSpørsmål = (
     erFarEllerMedmor: boolean
 ): boolean => {
     return (
-        (søker.erAleneOmOmsorg === false && annenForelder.harRettPåForeldrepenger === true) ||
-        (søker.erAleneOmOmsorg === false &&
-            harAnnenForelderOpplystOmSinPågåendeSak === true &&
-            erFarEllerMedmor === true)
+        annenForelder.harRettPåForeldrepenger === true ||
+        (harAnnenForelderOpplystOmSinPågåendeSak === true && erFarEllerMedmor === true)
     );
 };
 


### PR DESCRIPTION
Fixed a bug that caused no more content to be shown when answering question for property
annenForelder.harRettPåForeldrepenger