### PR TITLE
Comment out fødselsattest-rendering

### DIFF
--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/RelasjonTilBarnFødselSteg.tsx
@@ -40,7 +40,6 @@ interface RelasjonTilBarnFødselStegProps {
     registrerteBarn: RegistrertBarn[];
     søknadenGjelderBarnValg: SøknadenGjelderBarnValg;
     terminbekreftelse: Attachment[];
-    fødselsattest: Attachment[];
     stegProps: StegProps;
     vis: RelasjonTilBarnFødselStegVisibility;
 }
@@ -64,7 +63,6 @@ class RelasjonTilBarnFødselSteg extends React.Component<Props> {
             barn,
             søker,
             annenForelder,
-            fødselsattest,
             terminbekreftelse,
             registrerteBarn,
             søknadenGjelderBarnValg,
@@ -103,7 +101,6 @@ class RelasjonTilBarnFødselSteg extends React.Component<Props> {
                         <FødtBarnPartial
                             dispatch={dispatch}
                             barn={barn as FødtBarn}
-                            fødselsattest={fødselsattest || []}
                             gjelderAnnetBarn={gjelderAnnetBarn}
                             registrerteBarn={registrerteBarn}
                             vis={vis.født}
@@ -136,7 +133,6 @@ class RelasjonTilBarnFødselSteg extends React.Component<Props> {
 const mapStateToProps = (state: AppState, props: Props): RelasjonTilBarnFødselStegProps => {
     const { registrerteBarn = [] } = props.søkerinfo;
     const { barn, sensitivInfoIkkeLagre, søker, annenForelder } = state.søknad;
-    const fødselsattest = (barn as FødtBarn).fødselsattest || [];
     const terminbekreftelse = (barn as UfødtBarn).terminbekreftelse || [];
 
     const stegProps: StegProps = {
@@ -156,7 +152,6 @@ const mapStateToProps = (state: AppState, props: Props): RelasjonTilBarnFødselS
         søknadenGjelderBarnValg: sensitivInfoIkkeLagre.søknadenGjelderBarnValg,
         barn,
         terminbekreftelse,
-        fødselsattest,
         stegProps,
         vis
     };

--- a/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
+++ b/src/app/connected-components/steg/relasjon-til-barn-fødsel/partials/FødtBarnPartial.tsx
@@ -8,18 +8,12 @@ import FødselsdatoerSpørsmål from '../../../../spørsmål/FødselsdatoerSpør
 
 import { DispatchProps } from 'common/redux/types/index';
 import getMessage from 'common/util/i18nUtils';
-import { Attachment } from 'common/storage/attachment/types/Attachment';
-import AttachmentsUploaderPure from 'common/storage/attachment/components/AttachmentUploaderPure';
 import Block from 'common/components/block/Block';
-import { Skjemanummer } from '../../../../types/søknad/Søknad';
-import Veilederinfo from 'common/components/veileder-info/Veilederinfo';
 import { RegistrertBarn } from '../../../../types/Person';
 import { RelasjonTilBarnFødtVisibility } from '../visibility/relasjonTilBarnFødselVisibility';
-import { AttachmentType } from 'common/storage/attachment/types/AttachmentType';
 
 interface StateProps {
     barn: FødtBarn;
-    fødselsattest: Attachment[];
     registrerteBarn: RegistrertBarn[];
     gjelderAnnetBarn?: boolean;
     vis: RelasjonTilBarnFødtVisibility;
@@ -50,7 +44,7 @@ class FødtBarnPartial extends React.Component<Props> {
     }
 
     render() {
-        const { intl, dispatch, barn, fødselsattest, vis } = this.props;
+        const { intl, dispatch, barn, vis } = this.props;
         return (
             <React.Fragment>
                 <AntallBarnBolk
@@ -73,28 +67,35 @@ class FødtBarnPartial extends React.Component<Props> {
                     />
                 </Block>
 
-                {vis.fødselsattest ? (
-                    <React.Fragment>
-                        <Block margin="xs">
-                            <Veilederinfo>{getMessage(intl, 'vedlegg.veileder.fødselsattest')}</Veilederinfo>
-                        </Block>
-                        <Block>
-                            <AttachmentsUploaderPure
-                                attachments={fødselsattest}
-                                attachmentType={AttachmentType.FØDSELSATTEST}
-                                skjemanummer={Skjemanummer.FØDSELSATTEST}
-                                onFilesSelect={(attachments: Attachment[]) => {
-                                    attachments.forEach((attachment: Attachment) => {
-                                        dispatch(søknadActions.uploadAttachment(attachment));
-                                    });
-                                }}
-                                onFileDelete={(attachment: Attachment) =>
-                                    dispatch(søknadActions.deleteAttachment(attachment))
-                                }
-                            />
-                        </Block>
-                    </React.Fragment>
-                ) : null}
+                {/*
+                    // This has been commented out as users won't have to upload birth certificate
+                    // in the first version of Foreldrepengesøknad, but it will be required
+                    // once we start fetching data from TPS about registered children later on.
+                    // PS! Please remove this comment once this is in place.
+
+                    {vis.fødselsattest ? (
+                        <React.Fragment>
+                            <Block margin="xs">
+                                <Veilederinfo>{getMessage(intl, 'vedlegg.veileder.fødselsattest')}</Veilederinfo>
+                            </Block>
+                            <Block>
+                                <AttachmentsUploaderPure
+                                    attachments={fødselsattest}
+                                    attachmentType={AttachmentType.FØDSELSATTEST}
+                                    skjemanummer={Skjemanummer.FØDSELSATTEST}
+                                    onFilesSelect={(attachments: Attachment[]) => {
+                                        attachments.forEach((attachment: Attachment) => {
+                                            dispatch(søknadActions.uploadAttachment(attachment));
+                                        });
+                                    }}
+                                    onFileDelete={(attachment: Attachment) =>
+                                        dispatch(søknadActions.deleteAttachment(attachment))
+                                    }
+                                />
+                            </Block>
+                        </React.Fragment>
+                    ) : null}
+                */}
             </React.Fragment>
         );
     }

--- a/src/common/components/summary/steg/RelasjonTilBarnSummary.tsx
+++ b/src/common/components/summary/steg/RelasjonTilBarnSummary.tsx
@@ -154,7 +154,7 @@ class RelasjonTilBarnSummary extends React.Component<Props> {
 
     renderOppsummeringFødtBarn() {
         const { barn, intl } = this.props;
-        const { fødselsdatoer, fødselsattest } = barn as FødtBarn;
+        const { fødselsdatoer } = barn as FødtBarn;
 
         return (
             <React.Fragment>
@@ -162,17 +162,24 @@ class RelasjonTilBarnSummary extends React.Component<Props> {
                     label={getMessage(intl, 'oppsummering.fødselsdato.label')}
                     text={formatDate(fødselsdatoer[0]) || ''}
                 />
-                {fødselsattest && (
-                    <DisplayTextWithLabel
-                        label={getMessage(intl, 'oppsummering.fødselsattest.label')}
-                        text={fødselsattest.map((vedlegg) => vedlegg.filename)}
-                    />
-                )}
-                {fødselsattest === undefined && (
-                    <DisplayContentWithLabel label={getMessage(intl, 'oppsummering.fødselsattest.label')}>
-                        <EtikettBase {...this.missingAttachmentEtikettProps()} />
-                    </DisplayContentWithLabel>
-                )}
+                {/*
+                    // This has been commented out as users won't have to upload birth certificate
+                    // in the first version of Foreldrepengesøknad, but it will be required
+                    // once we start fetching data from TPS about registered children later on.
+                    // PS! Please remove this comment once this is in place.
+
+                    {fødselsattest && (
+                        <DisplayTextWithLabel
+                            label={getMessage(intl, 'oppsummering.fødselsattest.label')}
+                            text={fødselsattest.map((vedlegg) => vedlegg.filename)}
+                        />
+                    )}
+                    {fødselsattest === undefined && (
+                        <DisplayContentWithLabel label={getMessage(intl, 'oppsummering.fødselsattest.label')}>
+                            <EtikettBase {...this.missingAttachmentEtikettProps()} />
+                        </DisplayContentWithLabel>
+                    )}
+                */}
             </React.Fragment>
         );
     }


### PR DESCRIPTION
Comment out all rendering of fødselsattest-attachment uploaders and information boxes.
Please remove these comments once we are fetching data from TPS about registered children later on.