### PR TITLE
Overføringsperiodedetaljer fixes

### DIFF
--- a/src/app/components/uttak-form/partials/OverføringUttakPart.tsx
+++ b/src/app/components/uttak-form/partials/OverføringUttakPart.tsx
@@ -22,11 +22,7 @@ const visVedlegg = (søkerErFarEllerMedmor: boolean, årsak: OverføringÅrsakTy
     if (søkerErFarEllerMedmor) {
         return årsak !== undefined;
     } else {
-        return (
-            årsak !== undefined &&
-            årsak !== OverføringÅrsakType.aleneomsorg &&
-            årsak !== OverføringÅrsakType.ikkeRettAnnenForelder
-        );
+        return årsak !== undefined && årsak !== OverføringÅrsakType.aleneomsorg;
     }
 };
 

--- a/src/app/spørsmål/OverføringsårsakSpørsmål.tsx
+++ b/src/app/spørsmål/OverføringsårsakSpørsmål.tsx
@@ -29,7 +29,6 @@ const OverføringsårsakSpørsmål = (props: Props) => {
             toKolonner={true}
             spørsmål={intl.formatMessage({ id: 'uttaksplan.overføring.årsak.spørsmål' }, { annenForelderNavn })}
             alternativer={[
-                getOverføringsårsakAlternativ(OverføringÅrsakType.ikkeRettAnnenForelder, annenForelderNavn, intl),
                 getOverføringsårsakAlternativ(
                     OverføringÅrsakType.insititusjonsoppholdAnnenForelder,
                     annenForelderNavn,

--- a/src/app/types/uttaksplan/periodetyper.ts
+++ b/src/app/types/uttaksplan/periodetyper.ts
@@ -48,8 +48,7 @@ export enum OppholdÅrsakType {
 export enum OverføringÅrsakType {
     'insititusjonsoppholdAnnenForelder' = 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
     'sykdomAnnenForelder' = 'SYKDOM_ANNEN_FORELDER',
-    'aleneomsorg' = 'ALENEOMSORG',
-    'ikkeRettAnnenForelder' = 'IKKE_RETT_ANNEN_FORELDER'
+    'aleneomsorg' = 'ALENEOMSORG'
 }
 
 export interface Helligdag {

--- a/src/common/components/oppsummering/Oppsummering.tsx
+++ b/src/common/components/oppsummering/Oppsummering.tsx
@@ -4,7 +4,7 @@ import Veilederinfo from 'common/components/veileder-info/Veilederinfo';
 import getMessage from 'common/util/i18nUtils';
 import Søknad from '../../../app/types/søknad/Søknad';
 import SøkerPersonalia from 'common/components/søker-personalia/SøkerPersonalia';
-import { formaterNavn } from 'app/util/domain/personUtil';
+import { erFarEllerMedmor, formaterNavn } from 'app/util/domain/personUtil';
 import { Søkerinfo } from '../../../app/types/søkerinfo';
 import { skalSøkerLasteOppTerminbekreftelse } from '../../../app/util/validation/steg/barn';
 import Block from 'common/components/block/Block';
@@ -77,6 +77,7 @@ class Oppsummering extends React.Component<Props> {
                         <UttaksplanOppsummering
                             perioder={søknad.uttaksplan}
                             navnPåForeldre={getNavnPåForeldre(søknad, søkerinfo.person)}
+                            erFarEllerMedmor={erFarEllerMedmor(søknad.søker.rolle)}
                         />
                     </Oppsummeringspanel>
                 </div>

--- a/src/common/components/oppsummering/oppsummeringer/UttaksplanOppsummering.tsx
+++ b/src/common/components/oppsummering/oppsummeringer/UttaksplanOppsummering.tsx
@@ -7,6 +7,7 @@ import { NavnPåForeldre } from 'common/types';
 interface UttaksplanOppsummeringProps {
     perioder: Periode[];
     navnPåForeldre: NavnPåForeldre;
+    erFarEllerMedmor: boolean;
 }
 
 class UttaksplanOppsummering extends React.Component<UttaksplanOppsummeringProps> {

--- a/src/common/components/oppsummering/oppsummeringer/detaljer/Overføringsperiodedetaljer.tsx
+++ b/src/common/components/oppsummering/oppsummeringer/detaljer/Overføringsperiodedetaljer.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { InjectedIntlProps, injectIntl } from 'react-intl';
-import { Overføringsperiode, StønadskontoType } from '../../../../../app/types/uttaksplan/periodetyper';
+import {
+    Overføringsperiode,
+    OverføringÅrsakType,
+    StønadskontoType
+} from '../../../../../app/types/uttaksplan/periodetyper';
 import Feltoppsummering from 'common/components/feltoppsummering/Feltoppsummering';
 import OppsummeringAvDokumentasjon from 'common/components/oppsummering-av-dokumentasjon/OppsummeringAvDokumentasjon';
 import getMessage from 'common/util/i18nUtils';
@@ -10,6 +14,7 @@ import { NavnPåForeldre } from 'common/types';
 interface OverføringsperiodedetaljerProps {
     periode: Overføringsperiode;
     navnPåForeldre: NavnPåForeldre;
+    erFarEllerMedmor: boolean;
 }
 
 type Props = OverføringsperiodedetaljerProps & InjectedIntlProps;
@@ -23,8 +28,13 @@ const getNavnPåAnnenForelder = (navnPåForeldre: NavnPåForeldre, konto: Støna
     return 'Annen forelder ';
 };
 
-const Overføringsperiodedetaljer: React.StatelessComponent<Props> = ({ periode, navnPåForeldre, intl }) => {
-    const { vedlegg } = periode;
+const Overføringsperiodedetaljer: React.StatelessComponent<Props> = ({
+    periode,
+    navnPåForeldre,
+    erFarEllerMedmor,
+    intl
+}) => {
+    const { årsak, vedlegg } = periode;
     const annenForelderNavn = getNavnPåAnnenForelder(navnPåForeldre, periode.konto);
     return (
         <>
@@ -32,7 +42,10 @@ const Overføringsperiodedetaljer: React.StatelessComponent<Props> = ({ periode,
                 feltnavn={getMessage(intl, 'oppsummering.uttak.årsak')}
                 verdi={getÅrsakTekst(intl, periode, { annenForelderNavn })}
             />
-            <OppsummeringAvDokumentasjon vedlegg={vedlegg || []} />
+
+            {(erFarEllerMedmor || årsak !== OverføringÅrsakType.aleneomsorg) && (
+                <OppsummeringAvDokumentasjon vedlegg={vedlegg || []} />
+            )}
         </>
     );
 };

--- a/src/common/components/oppsummering/oppsummeringer/lister/UttaksplanOppsummeringsliste.tsx
+++ b/src/common/components/oppsummering/oppsummeringer/lister/UttaksplanOppsummeringsliste.tsx
@@ -22,6 +22,7 @@ import { getStønadskontoNavn } from '../../../../../app/util/uttaksplan';
 interface UttaksplanOppsummeringslisteProps {
     perioder: Periode[];
     navnPåForeldre: NavnPåForeldre;
+    erFarEllerMedmor: boolean;
 }
 
 type Props = UttaksplanOppsummeringslisteProps & InjectedIntlProps;
@@ -80,14 +81,20 @@ class UttaksplanOppsummeringsliste extends React.Component<Props> {
     }
 
     createOppsummeringslisteelementPropsForOverføringsperiode(periode: Overføringsperiode) {
-        const { navnPåForeldre, intl } = this.props;
+        const { navnPåForeldre, erFarEllerMedmor, intl } = this.props;
         const kontonavn = this.getStønadskontoNavnFromKonto(periode.konto);
         return {
             venstrestiltTekst: getMessage(intl, 'oppsummering.overtakelse.pga', {
                 konto: kontonavn
             }),
             høyrestiltTekst: this.formatTidsperiode(periode.tidsperiode),
-            content: <Overføringsperiodedetaljer periode={periode} navnPåForeldre={navnPåForeldre} />
+            content: (
+                <Overføringsperiodedetaljer
+                    periode={periode}
+                    navnPåForeldre={navnPåForeldre}
+                    erFarEllerMedmor={erFarEllerMedmor}
+                />
+            )
         };
     }
 


### PR DESCRIPTION
- Remove "Annen forelder har ikke rett" as a reason for using Overføringsperiode.
- Ensure we only show OppsummeringAvDokumentasjon when erFarEllerMedmor or årsak is not aleneomsorg.