### PR TITLE
Remove path from the redirect query param sent to loginservice

### DIFF
--- a/src/app/util/routing/login.ts
+++ b/src/app/util/routing/login.ts
@@ -1,5 +1,5 @@
 import Environment from '../../Environment';
 
 export const redirectToLogin = () => {
-    window.location.href = Environment.LOGIN_URL + '?redirect=' + window.location.href;
+    window.location.href = Environment.LOGIN_URL + '?redirect=' + window.location.origin;
 };


### PR DESCRIPTION
Loginservice can only redirect to whitelisted URLs.
URLs with /path is not whitelisted.