### PR TITLE
Remove Overføringsårsak-type

### DIFF
--- a/src/app/components/uttak-form/UttakForm.tsx
+++ b/src/app/components/uttak-form/UttakForm.tsx
@@ -173,7 +173,6 @@ class UttaksperiodeForm extends React.Component<Props> {
             periode,
             søknad,
             velgbareStønadskontotyper,
-            søkerErFarEllerMedmor,
             navnPåForeldre,
             familiehendelsesdato,
             arbeidsforhold,
@@ -293,7 +292,6 @@ class UttaksperiodeForm extends React.Component<Props> {
                         <OverføringUttakPart
                             navnAnnenForelder={søknad.annenForelder.fornavn}
                             årsak={periode.årsak}
-                            søkerErFarEllerMedmor={søkerErFarEllerMedmor}
                             vedlegg={periode.vedlegg as Attachment[]}
                             onChange={(p) => this.updateOverføringUttak(p)}
                         />

--- a/src/app/components/uttak-form/partials/OverføringUttakPart.tsx
+++ b/src/app/components/uttak-form/partials/OverføringUttakPart.tsx
@@ -14,17 +14,8 @@ interface Props {
     årsak?: OverføringÅrsakType;
     vedlegg?: Attachment[];
     navnAnnenForelder: string;
-    søkerErFarEllerMedmor: boolean;
     onChange: (periode: RecursivePartial<Overføringsperiode>) => void;
 }
-
-export const visVedlegg = (søkerErFarEllerMedmor: boolean, årsak: OverføringÅrsakType | undefined): boolean => {
-    if (søkerErFarEllerMedmor) {
-        return årsak !== undefined;
-    } else {
-        return årsak !== undefined && årsak !== OverføringÅrsakType.aleneomsorg;
-    }
-};
 
 const getVeilederInfotekst = (årsak: OverføringÅrsakType, navnAnnenForelder: string) => {
     if (årsak === OverføringÅrsakType.insititusjonsoppholdAnnenForelder) {
@@ -48,7 +39,7 @@ const getVeilederInfotekst = (årsak: OverføringÅrsakType, navnAnnenForelder: 
 
 class OverføringUttakPart extends React.Component<Props> {
     render() {
-        const { onChange, søkerErFarEllerMedmor, årsak, vedlegg, navnAnnenForelder } = this.props;
+        const { onChange, årsak, vedlegg, navnAnnenForelder } = this.props;
         const vedleggList = vedlegg || [];
 
         return (
@@ -60,7 +51,7 @@ class OverføringUttakPart extends React.Component<Props> {
                         onChange={(å) => onChange({ årsak: å })}
                     />
                 </Block>
-                <Block visible={visVedlegg(søkerErFarEllerMedmor, årsak)}>
+                <Block visible={årsak !== undefined}>
                     <Veilederinfo>{getVeilederInfotekst(årsak!, navnAnnenForelder)}</Veilederinfo>
                     <VedleggSpørsmål
                         vedlegg={vedleggList}

--- a/src/app/components/uttak-form/uttakFormConfig.ts
+++ b/src/app/components/uttak-form/uttakFormConfig.ts
@@ -5,7 +5,6 @@ import { Tidsperiode } from 'nav-datovelger';
 import {
     StønadskontoType,
     Periodetype,
-    OverføringÅrsakType,
     isForeldrepengerFørFødselUttaksperiode,
     isUttaksperiode
 } from '../../types/uttaksplan/periodetyper';
@@ -147,17 +146,6 @@ const visSamtidigUttak = (payload: UttakFormPayload): boolean => {
     return false;
 };
 
-const visOverføringsdokumentasjon = (payload: UttakFormPayload): boolean => {
-    const { periode } = payload;
-    if (periode.type !== Periodetype.Overføring || periode.årsak === undefined) {
-        return false;
-    }
-    return (
-        periode.årsak !== OverføringÅrsakType.aleneomsorg ||
-        (periode.årsak === OverføringÅrsakType.aleneomsorg && payload.søkerErFarEllerMedmor === true)
-    );
-};
-
 const visGradering = (payload: UttakFormPayload): boolean => {
     const { periode } = payload;
     if (
@@ -244,11 +232,6 @@ export const uttaksperiodeFormConfig: QuestionConfig<UttakFormPayload, UttakSpø
             visKvote(payload) &&
             payload.periode.type === Periodetype.Overføring &&
             erUttakEgenKvote(payload.periode.konto, payload.søkerErFarEllerMedmor) === false
-    },
-    [Sp.overføringsdokumentasjon]: {
-        isOptional: () => true,
-        isAnswered: ({ periode }) => periode.type === Periodetype.Overføring && questionValueIsOk(periode.årsak),
-        condition: (payload) => visOverføringsdokumentasjon(payload)
     },
     [Sp.skalHaGradering]: {
         isAnswered: ({ periode }) => periode.type === Periodetype.Uttak && questionValueIsOk(periode.gradert),

--- a/src/app/spørsmål/OverføringsårsakSpørsmål.tsx
+++ b/src/app/spørsmål/OverføringsårsakSpørsmål.tsx
@@ -34,8 +34,7 @@ const OverføringsårsakSpørsmål = (props: Props) => {
                     annenForelderNavn,
                     intl
                 ),
-                getOverføringsårsakAlternativ(OverføringÅrsakType.sykdomAnnenForelder, annenForelderNavn, intl),
-                getOverføringsårsakAlternativ(OverføringÅrsakType.aleneomsorg, annenForelderNavn, intl)
+                getOverføringsårsakAlternativ(OverføringÅrsakType.sykdomAnnenForelder, annenForelderNavn, intl)
             ]}
             valgtVerdi={årsak}
             onChange={(valgtÅrsak) => onChange(valgtÅrsak as OverføringÅrsakType)}

--- a/src/app/types/uttaksplan/periodetyper.ts
+++ b/src/app/types/uttaksplan/periodetyper.ts
@@ -49,8 +49,7 @@ export enum OppholdÅrsakType {
 
 export enum OverføringÅrsakType {
     'insititusjonsoppholdAnnenForelder' = 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
-    'sykdomAnnenForelder' = 'SYKDOM_ANNEN_FORELDER',
-    'aleneomsorg' = 'ALENEOMSORG'
+    'sykdomAnnenForelder' = 'SYKDOM_ANNEN_FORELDER'
 }
 
 export enum PeriodeHullÅrsak {

--- a/src/app/util/cleanup/periodeCleanup.ts
+++ b/src/app/util/cleanup/periodeCleanup.ts
@@ -44,9 +44,7 @@ const cleanupUtsettelse = (
         orgnr: periode.årsak === UtsettelseÅrsakType.Arbeid ? periode.orgnr : undefined,
         arbeidsform: periode.årsak === UtsettelseÅrsakType.Arbeid ? periode.arbeidsform : undefined,
         erArbeidstaker: periode.erArbeidstaker,
-        vedlegg: shouldPeriodeHaveAttachment(periode, getErSøkerFarEllerMedmor(søker.rolle))
-            ? periode.vedlegg
-            : undefined
+        vedlegg: shouldPeriodeHaveAttachment(periode) ? periode.vedlegg : undefined
     };
 };
 
@@ -55,9 +53,7 @@ const cleanupUttak = (periode: Uttaksperiode, søker: Søker, visibility?: Uttak
         type: Periodetype.Uttak,
         id: periode.id,
         konto: periode.konto,
-        vedlegg: shouldPeriodeHaveAttachment(periode, getErSøkerFarEllerMedmor(søker.rolle))
-            ? periode.vedlegg
-            : undefined,
+        vedlegg: shouldPeriodeHaveAttachment(periode) ? periode.vedlegg : undefined,
         forelder: periode.forelder,
         tidsperiode: periode.tidsperiode,
         gradert: periode.gradert,

--- a/src/app/util/uttaksplan/utsettelsesperiode.ts
+++ b/src/app/util/uttaksplan/utsettelsesperiode.ts
@@ -1,6 +1,4 @@
 import {
-    Overføringsperiode,
-    OverføringÅrsakType,
     Utsettelsesperiode,
     UtsettelseÅrsakType,
     Uttaksperiode,
@@ -12,11 +10,6 @@ export const dokumentasjonBehøvesForUtsettelsesperiode = ({ årsak, erArbeidsta
     årsak === UtsettelseÅrsakType.InstitusjonBarnet ||
     årsak === UtsettelseÅrsakType.InstitusjonSøker ||
     (erArbeidstaker && årsak !== UtsettelseÅrsakType.Ferie);
-
-export const dokumentasjonBehøvesForOverføringsperiode = (
-    erFarEllerMedmor: boolean,
-    periode: Overføringsperiode
-): boolean => erFarEllerMedmor || periode.årsak !== OverføringÅrsakType.aleneomsorg;
 
 export const dokumentasjonBehøvesForUttaksperiode = (periode: Uttaksperiode): boolean => {
     return (

--- a/src/app/util/validation/__tests__/uttakFarValidation.test.ts
+++ b/src/app/util/validation/__tests__/uttakFarValidation.test.ts
@@ -64,15 +64,6 @@ describe('Validering av fars uttak første 6 uker', () => {
         );
         expect(result).toBeFalsy();
     });
-    it('skal IKKE godta overføring på grunn av annet enn sykdom annen forelder', () => {
-        const result = harFarHarSøktUgyldigUttakFørsteSeksUker(
-            [{ ...overføring, årsak: OverføringÅrsakType.aleneomsorg }],
-            familiehendelsesdato,
-            1,
-            Søkersituasjon.FØDSEL
-        );
-        expect(result).toBeTruthy();
-    });
     it('skal IKKE godta utsettelser', () => {
         const result = harFarHarSøktUgyldigUttakFørsteSeksUker(
             [{ ...utsettelse }],

--- a/src/common/components/oppsummering/oppsummeringer/detaljer/Overføringsperiodedetaljer.tsx
+++ b/src/common/components/oppsummering/oppsummeringer/detaljer/Overføringsperiodedetaljer.tsx
@@ -6,7 +6,6 @@ import OppsummeringAvDokumentasjon from 'common/components/oppsummering-av-dokum
 import getMessage from 'common/util/i18nUtils';
 import { getÅrsakTekst } from 'common/util/oppsummeringUtils';
 import { NavnPåForeldre } from 'common/types';
-import { dokumentasjonBehøvesForOverføringsperiode } from '../../../../../app/util/uttaksplan/utsettelsesperiode';
 
 interface OverføringsperiodedetaljerProps {
     periode: Overføringsperiode;
@@ -39,10 +38,7 @@ const Overføringsperiodedetaljer: React.StatelessComponent<Props> = ({
                 feltnavn={getMessage(intl, 'oppsummering.uttak.årsak')}
                 verdi={getÅrsakTekst(intl, periode, { annenForelderNavn })}
             />
-
-            {dokumentasjonBehøvesForOverføringsperiode(erFarEllerMedmor, periode) && (
-                <OppsummeringAvDokumentasjon vedlegg={vedlegg || []} />
-            )}
+            <OppsummeringAvDokumentasjon vedlegg={vedlegg || []} />
         </>
     );
 };


### PR DESCRIPTION
Removes Overføringårsak-type aleneomsorg, as it makes no sense to
use the aleneomsorg-type when user is already asked if they have
aleneomsorg, in which case the user will not be able to make use
of Overføringsperiode.