### PR TITLE
Remove .env from production code

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,3 @@
-require('dotenv').config();
-
 const express = require('express');
 const path = require('path');
 const mustacheExpress = require('mustache-express');

--- a/src/build/scripts/decorator.js
+++ b/src/build/scripts/decorator.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const jsdom = require('jsdom');
 const request = require('request');
 


### PR DESCRIPTION
Keeping this in production code can mask errors in configuration, since it will then default to values in the .env file