### PR TITLE
Fellesperiode fordeling fix

### DIFF
--- a/src/app/connected-components/steg/uttaksplan-skjema/UttaksplanSkjemaSteg.tsx
+++ b/src/app/connected-components/steg/uttaksplan-skjema/UttaksplanSkjemaSteg.tsx
@@ -50,12 +50,12 @@ class UttaksplanSkjemaSteg extends React.Component<Props> {
         }
     }
 
-    componentWillMount() {
-        const defaultAntallUkerAvFellesperiode = Math.round(this.props.antallUkerFellesperiode / 2);
-        if (this.props.søknad.ekstrainfo.uttaksplanSkjema.fellesperiodeukerMor === undefined) {
+    componentWillReceiveProps(nextProps: Props) {
+        const dekningsgrad = this.props.søknad.dekningsgrad;
+        if (dekningsgrad !== nextProps.søknad.dekningsgrad) {
             this.props.dispatch(
                 søknadActions.uttaksplanUpdateSkjemdata({
-                    fellesperiodeukerMor: defaultAntallUkerAvFellesperiode
+                    fellesperiodeukerMor: Math.round(nextProps.antallUkerFellesperiode / 2)
                 })
             );
         }


### PR DESCRIPTION
Make sure to update default distribution of Fellesperiode when
dekningsgrad changes. Also fixed an issue where it was alwasy based
on 100%, also when 80% was chosen as first choice.