### PR TITLE
Skjul veileder i uttaksplan ved visse tilfeller

### DIFF
--- a/src/app/components/uttaksplanlegger/Uttaksplanlegger.tsx
+++ b/src/app/components/uttaksplanlegger/Uttaksplanlegger.tsx
@@ -199,7 +199,11 @@ class Uttaksplanlegger extends React.Component<Props, State> {
         }
 
         const informerOmNårPeriodenBegynnerÅLøpe =
-            uttaksplan.length === 0 && søknadsinfo.mor.harRett === false && søknadsinfo.søker.erFarEllerMedmor === true;
+            uttaksplan.length === 0 &&
+            søknadsinfo.søker.erFarEllerMedmor &&
+            !søknadsinfo.søker.erAleneOmOmsorg &&
+            !søknadsinfo.mor.harRett &&
+            !søknadsinfo.mor.erUfør;
 
         return (
             <section>


### PR DESCRIPTION
Som hovedregel skal veilederen vises når søker er far eller medmor og
mor ikke har rett til foreldrepenger. Unntaket er hvis du er alene om
omsorgen eller hvis mor er ufør. Denne commiten innfører nevnte unntak.