### PR TITLE
Set UUID on uploaded attachments

### DIFF
--- a/src/app/redux/actions/søknad/søknadActionCreators.ts
+++ b/src/app/redux/actions/søknad/søknadActionCreators.ts
@@ -90,10 +90,11 @@ const uploadAttachment = (payload: Attachment) => ({
     payload
 });
 
-const uploadAttachmentSuccess = (attachment: Attachment, url: string): UploadAttachmentSuccess => ({
+const uploadAttachmentSuccess = (attachment: Attachment, url: string, uuid: string): UploadAttachmentSuccess => ({
     type: SøknadActionKeys.UPLOAD_ATTACHMENT_SUCCESS,
     attachment,
-    url
+    url,
+    uuid
 });
 
 const uploadAttachmentFailed = (error: string, attachment: Attachment): UploadAttachmentFailed => ({

--- a/src/app/redux/actions/søknad/søknadActionDefinitions.ts
+++ b/src/app/redux/actions/søknad/søknadActionDefinitions.ts
@@ -121,6 +121,7 @@ export interface UploadAttachmentSuccess {
     type: SøknadActionKeys.UPLOAD_ATTACHMENT_SUCCESS;
     attachment: Attachment;
     url: string;
+    uuid: string;
 }
 
 export interface UploadAttachmentFailed {

--- a/src/app/redux/reducers/__tests__/søknadReducerTests.ts
+++ b/src/app/redux/reducers/__tests__/søknadReducerTests.ts
@@ -120,7 +120,10 @@ describe('søknadReducer', () => {
             state.vedlegg = [attachment];
             return state;
         });
-        const newSøknadState = reducer(defaultState, actions.uploadAttachmentSuccess(mockedAttachment, 'someUrl'));
+        const newSøknadState = reducer(
+            defaultState,
+            actions.uploadAttachmentSuccess(mockedAttachment, 'someUrl', 'uuid')
+        );
         expect(attachmentReducerUtils.editAttachmentInState).toHaveBeenCalledWith(mockedAttachment, defaultState);
         expect(newSøknadState.vedlegg![0].pending).toBe(false);
         expect(newSøknadState.vedlegg![0].uploaded).toBe(true);

--- a/src/app/redux/reducers/søknadReducer.ts
+++ b/src/app/redux/reducers/søknadReducer.ts
@@ -251,7 +251,9 @@ const søknadReducer = (state = getDefaultSøknadState(), action: SøknadAction)
         case SøknadActionKeys.UPLOAD_ATTACHMENT_SUCCESS:
             const uploadedAttachment = action.attachment;
             const url = action.url;
+            const uuid = action.uuid;
             uploadedAttachment.url = url;
+            uploadedAttachment.uuid = uuid;
             uploadedAttachment.pending = false;
             uploadedAttachment.uploaded = true;
             return editAttachmentInState(uploadedAttachment, state);

--- a/src/app/redux/sagas/attachmentSaga.ts
+++ b/src/app/redux/sagas/attachmentSaga.ts
@@ -9,7 +9,8 @@ function* uploadAttachment(action: UploadAttachment) {
     try {
         const response = yield call(AttachmentApi.saveAttachment, attachment);
         const uri: string = response.headers.location || 'mockurl';
-        yield put(søknadActions.uploadAttachmentSuccess(attachment, uri));
+        const uuid: string = response.data;
+        yield put(søknadActions.uploadAttachmentSuccess(attachment, uri, uuid));
     } catch (error) {
         yield put(søknadActions.uploadAttachmentFailed(error, attachment));
     }

--- a/src/common/storage/attachment/components/AttachmentUploader.tsx
+++ b/src/common/storage/attachment/components/AttachmentUploader.tsx
@@ -34,6 +34,7 @@ export default class AttachmentsUploader extends React.Component<AttachmentsUplo
                     file.pending = false;
                     file.uploaded = true;
                     file.url = response.headers.location;
+                    file.uuid = response.data;
                     onFileUploadFinish(file);
                 })
                 .catch((error) => {

--- a/src/common/storage/attachment/types/Attachment.ts
+++ b/src/common/storage/attachment/types/Attachment.ts
@@ -11,6 +11,7 @@ export interface Attachment {
     filesize: number;
     file: File;
     url?: string;
+    uuid?: string;
     pending: boolean;
     uploaded: boolean;
     type: AttachmentType;


### PR DESCRIPTION
Cleaning up attachment handling in the API requires that the client knows the UUID of the stored attachment.