### PR TITLE
Bugfix - visning av tidsperiodespørsmål

### DIFF
--- a/src/app/components/uttak-form/UttakForm.tsx
+++ b/src/app/components/uttak-form/UttakForm.tsx
@@ -352,9 +352,12 @@ class UttaksperiodeForm extends React.Component<Props, ComponentStateProps> {
                 ? { feilmelding: getMessage(intl, 'periodeliste.nyPeriodeErFørFamiliehendelsesdato') }
                 : undefined;
 
+        const erForeldrepengerFørFødselOgSkalIkkeHaUttakFørTermin =
+            isForeldrepengerFørFødselUttaksperiode(periode) && periode.skalIkkeHaUttakFørTermin === true;
+
         return (
             <React.Fragment>
-                <Block>
+                <Block visible={erForeldrepengerFørFødselOgSkalIkkeHaUttakFørTermin === false}>
                     <UttakTidsperiodeSpørsmål
                         periode={periode}
                         ugyldigeTidsperioder={ugyldigeTidsperioder}


### PR DESCRIPTION
Valg av dato for en periode i uttaksplanen var synlig, selv om bruker hadde valgt at en ikke skulle ha uttak før termin.