### PR TITLE
WIP: Refaktorering av endringstidspunkt

### DIFF
--- a/src/app/util/dates/__tests__/dateUtils.test.ts
+++ b/src/app/util/dates/__tests__/dateUtils.test.ts
@@ -127,196 +127,358 @@ describe('dateUtils', () => {
         expect(timeintervalsOverlap(overlap3, fixedIntervals)).toBe(true);
         expect(timeintervalsOverlap(noOverlap, fixedIntervals)).toBe(false);
     });
+});
 
-    describe('getEndringstidspunkt', () => {
-        it('Skal returnere undefined hvis ikke endringssøknad', () => {
-            const endringstidspunkt = getEndringstidspunkt(undefined, [], false);
+describe('getEndringstidspunkt', () => {
+    it('Skal returnere undefined hvis ikke endringssøknad', () => {
+        const endringstidspunkt = getEndringstidspunkt(undefined, [], false);
 
-            expect(endringstidspunkt).toBe(undefined);
-        });
+        expect(endringstidspunkt).toBe(undefined);
+    });
 
-        it('Skal returnere undefined for ingen endringer', () => {
-            const endringstidspunkt = getEndringstidspunkt(
-                opprinneligPlan as Periode[],
-                [...opprinneligPlan] as Periode[],
-                true
-            );
+    it('Skal returnere undefined for ingen endringer', () => {
+        const endringstidspunkt = getEndringstidspunkt(
+            opprinneligPlan as Periode[],
+            [...opprinneligPlan] as Periode[],
+            true
+        );
 
-            expect(endringstidspunkt).toBe(undefined);
-        });
+        expect(endringstidspunkt).toBe(undefined);
+    });
 
-        it('Skal finne endringstidspunkt gitt at det er endringer', () => {
-            const gradertPeriode: Partial<Uttaksperiode> = {
-                id: guid(),
-                tidsperiode: {
-                    fom: new Date('2020-05-05'),
-                    tom: new Date('2020-05-08'),
-                },
-                type: Periodetype.Uttak,
-                gradert: true,
-                stillingsprosent: '50',
-            };
-            const endretPlan = [...opprinneligPlan, gradertPeriode];
+    it('Skal finne endringstidspunkt gitt at det er endringer', () => {
+        const gradertPeriode: Partial<Uttaksperiode> = {
+            id: guid(),
+            tidsperiode: {
+                fom: new Date('2020-05-05'),
+                tom: new Date('2020-05-08'),
+            },
+            type: Periodetype.Uttak,
+            gradert: true,
+            stillingsprosent: '50',
+        };
+        const endretPlan = [...opprinneligPlan, gradertPeriode];
 
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-            expect(endringstidspunkt).toEqual(gradertPeriode.tidsperiode!.fom);
-        });
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toEqual(gradertPeriode.tidsperiode!.fom);
+    });
 
-        it('Hvis uttaksplanlogikken setter hull inn i planen skal det telle som en endring', () => {
-            const hullPeriode: Partial<PeriodeHull> = {
-                type: Periodetype.Hull,
-                tidsperiode: {
-                    fom: new Date('2019-09-01'),
-                    tom: new Date('2019-09-09'),
-                },
-            };
-            const endretPlan = [hullPeriode, ...opprinneligPlan];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+    it('Hvis uttaksplanlogikken setter hull inn i planen skal det telle som en endring', () => {
+        const hullPeriode: Partial<PeriodeHull> = {
+            type: Periodetype.Hull,
+            tidsperiode: {
+                fom: new Date('2019-09-01'),
+                tom: new Date('2019-09-09'),
+            },
+        };
+        const endretPlan = [hullPeriode, ...opprinneligPlan];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
 
-            expect(endringstidspunkt).toBe(hullPeriode.tidsperiode!.fom);
-        });
+        expect(endringstidspunkt).toBe(hullPeriode.tidsperiode!.fom);
+    });
 
-        it('Hvis uttaksplanlogikken deler en periode skal endringstidspunkt være fra delingen og fremover ikke ta med tidligere del av perioden', () => {
-            const deltPeriodeTidligereDel: Partial<Uttaksperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
-                tidsperiode: {
-                    fom: new Date('2020-01-14T00:00:00.000Z'),
-                    tom: new Date('2020-04-03T00:00:00.000Z'),
-                },
-                type: Periodetype.Uttak,
-            };
-            const periodeSomDeltePeriode: Partial<Utsettelsesperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
-                tidsperiode: {
-                    fom: new Date('2020-04-06T00:00:00.000Z'),
-                    tom: new Date('2020-04-17T00:00:00.000Z'),
-                },
-                type: Periodetype.Utsettelse,
-                årsak: UtsettelseÅrsakType.Arbeid,
-            };
-            const deltPeriodeSenereDel: Partial<Uttaksperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
-                tidsperiode: {
-                    fom: new Date('2020-04-20T00:00:00.000Z'),
-                    tom: new Date('2020-05-04T00:00:00.000Z'),
-                },
-                type: Periodetype.Uttak,
-            };
+    it('Hvis uttaksplanlogikken deler en periode skal endringstidspunkt være fra delingen og fremover ikke ta med tidligere del av perioden', () => {
+        const deltPeriodeTidligereDel: Partial<Uttaksperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-01-14T00:00:00.000Z'),
+                tom: new Date('2020-04-03T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
+        const periodeSomDeltePeriode: Partial<Utsettelsesperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-04-06T00:00:00.000Z'),
+                tom: new Date('2020-04-17T00:00:00.000Z'),
+            },
+            type: Periodetype.Utsettelse,
+            årsak: UtsettelseÅrsakType.Arbeid,
+        };
+        const deltPeriodeSenereDel: Partial<Uttaksperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-04-20T00:00:00.000Z'),
+                tom: new Date('2020-05-04T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
 
-            const endretPlan = [
-                opprinneligPlan[0],
-                opprinneligPlan[1],
-                deltPeriodeTidligereDel,
-                periodeSomDeltePeriode,
-                deltPeriodeSenereDel,
-            ];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        const endretPlan = [
+            opprinneligPlan[0],
+            opprinneligPlan[1],
+            deltPeriodeTidligereDel,
+            periodeSomDeltePeriode,
+            deltPeriodeSenereDel,
+        ];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
 
-            expect(endringstidspunkt).toBe(periodeSomDeltePeriode.tidsperiode!.fom);
-        });
-        it('Hvis uttaksplanlogikken deler to perioder skal endringstidspunkt være fra delingen og fremover', () => {
-            const deltPeriode2: Partial<Uttaksperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
+        expect(endringstidspunkt).toBe(periodeSomDeltePeriode.tidsperiode!.fom);
+    });
+    it('Hvis uttaksplanlogikken deler to perioder skal endringstidspunkt være fra delingen og fremover', () => {
+        const deltPeriode2: Partial<Uttaksperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2019-10-01T00:00:00.000Z'),
+                tom: new Date('2020-01-09T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
+
+        const nyPeriode: Partial<Utsettelsesperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-01-10T00:00:00.000Z'),
+                tom: new Date('2020-04-02T00:00:00.000Z'),
+            },
+            type: Periodetype.Utsettelse,
+            årsak: UtsettelseÅrsakType.Fri,
+        };
+        const deltPeriode3: Partial<Uttaksperiode> = {
+            id: '3105926427-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-04-05T00:00:00.000Z'),
+                tom: new Date('2020-05-04T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
+
+        const endretPlan = [opprinneligPlan[0], deltPeriode2, nyPeriode, deltPeriode3];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(nyPeriode.tidsperiode!.fom);
+    });
+    it('Hvis endrer en periode til å ha senere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på perioden .', () => {
+        const nyMidterstePeriode = {
+            id: opprinneligPlan[1].id,
+            tidsperiode: {
+                fom: opprinneligPlan[1].tidsperiode!.fom,
+                tom: new Date('2020-01-14T00:00:00.000Z'),
+            },
+            type: opprinneligPlan[1].type,
+        };
+        const nyEndretSistePeriode = {
+            ...opprinneligPlan[2],
+            tidsperiode: {
+                fom: new Date('2020-01-15T00:00:00.000Z'),
+                tom: new Date('2020-05-05T00:00:00.000Z'),
+            },
+        };
+        const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyEndretSistePeriode];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
+    });
+
+    it('Hvis endrer en periode til å ha tidligere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på neste periode i den nye planen .', () => {
+        const nyMidterstePeriode = {
+            id: opprinneligPlan[1].id,
+            tidsperiode: {
+                fom: opprinneligPlan[1].tidsperiode!.fom,
+                tom: new Date('2020-01-08T00:00:00.000Z'),
+            },
+            type: opprinneligPlan[1].type,
+        };
+        const nyHullPeriode = {
+            ...opprinneligPlan[2],
+            tidsperiode: {
+                fom: new Date('2020-01-09T00:00:00.000Z'),
+                tom: new Date('2020-01-13T00:00:00.000Z'),
+            },
+        };
+        const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyHullPeriode, opprinneligPlan[2]];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(nyHullPeriode.tidsperiode.fom);
+    });
+    it('Hvis endrer en periode til å starte tidligere enn i opprinnelig plan, skal endringstidspunkt være den nye starten på perioden.', () => {
+        const opprinneligPlanMedHull = [
+            opprinneligPlan[0],
+            { ...opprinneligPlan[1], type: Periodetype.Hull },
+            opprinneligPlan[2],
+        ];
+        const endretPlan = [
+            opprinneligPlanMedHull[0],
+            {
+                ...opprinneligPlanMedHull[1],
                 tidsperiode: {
                     fom: new Date('2019-10-01T00:00:00.000Z'),
-                    tom: new Date('2020-01-09T00:00:00.000Z'),
+                    tom: new Date('2020-01-06T00:00:00.000Z'),
                 },
-                type: Periodetype.Uttak,
-            };
-
-            const nyPeriode: Partial<Utsettelsesperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
+            },
+            {
+                ...opprinneligPlanMedHull[2],
                 tidsperiode: {
-                    fom: new Date('2020-01-10T00:00:00.000Z'),
-                    tom: new Date('2020-04-02T00:00:00.000Z'),
-                },
-                type: Periodetype.Utsettelse,
-                årsak: UtsettelseÅrsakType.Fri,
-            };
-            const deltPeriode3: Partial<Uttaksperiode> = {
-                id: '3105926427-6496-7446-7246-02332065872239',
-                tidsperiode: {
-                    fom: new Date('2020-04-05T00:00:00.000Z'),
+                    fom: new Date('2020-01-07T00:00:00.000Z'),
                     tom: new Date('2020-05-04T00:00:00.000Z'),
                 },
-                type: Periodetype.Uttak,
-            };
-
-            const endretPlan = [opprinneligPlan[0], deltPeriode2, nyPeriode, deltPeriode3];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(nyPeriode.tidsperiode!.fom);
-        });
-        it('Hvis endrer en periode til å ha senere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på perioden .', () => {
-            const nyMidterstePeriode = {
-                id: opprinneligPlan[1].id,
-                tidsperiode: {
-                    fom: opprinneligPlan[1].tidsperiode!.fom,
-                    tom: new Date('2020-01-14T00:00:00.000Z'),
-                },
-                type: opprinneligPlan[1].type,
-            };
-            const nyEndretSistePeriode = {
-                ...opprinneligPlan[2],
-                tidsperiode: {
-                    fom: new Date('2020-01-15T00:00:00.000Z'),
-                    tom: new Date('2020-05-05T00:00:00.000Z'),
-                },
-            };
-            const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyEndretSistePeriode];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
-        });
-
-        it('Hvis endrer en periode til å ha tidligere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på neste periode i den nye planen .', () => {
-            const nyMidterstePeriode = {
-                id: opprinneligPlan[1].id,
-                tidsperiode: {
-                    fom: opprinneligPlan[1].tidsperiode!.fom,
-                    tom: new Date('2020-01-08T00:00:00.000Z'),
-                },
-                type: opprinneligPlan[1].type,
-            };
-            const nyHullPeriode = {
-                ...opprinneligPlan[2],
-                tidsperiode: {
-                    fom: new Date('2020-01-09T00:00:00.000Z'),
-                    tom: new Date('2020-01-13T00:00:00.000Z'),
-                },
-            };
-            const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyHullPeriode, opprinneligPlan[2]];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(nyHullPeriode.tidsperiode.fom);
-        });
-        it('Hvis endret periode er siste i planen, har samme startdato som i opprinnelig plan men ulik sluttdato, skal endringstidspunkt være starten på perioden .', () => {
-            const nySistePeriode = {
-                id: opprinneligPlan[2].id,
-                tidsperiode: {
-                    fom: opprinneligPlan[2].tidsperiode!.fom,
-                    tom: new Date('2020-05-14T00:00:00.000Z'),
-                },
-                type: opprinneligPlan[2].type,
-            };
-            const endretPlan = [opprinneligPlan[0], opprinneligPlan[1], nySistePeriode];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(nySistePeriode.tidsperiode.fom);
-        });
-        it('Hvis ingen opprinnelig plan, skal endringstidspunkt være startdatoen på første periode i endret plan.', () => {
-            const tomOpprinneligPlan = [] as Periode[];
-            const endretPlan = [opprinneligPlan[2], opprinneligPlan[3]];
-            const endringstidspunkt = getEndringstidspunkt(tomOpprinneligPlan, endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(opprinneligPlan[2].tidsperiode!.fom);
-        });
-
-        it('Hvis periode er slettet i den nye planen skal endringstidspunkt være startdatoen på slettet periode.', () => {
-            const endretPlan = [opprinneligPlan[0], opprinneligPlan[1]];
-            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
-
-            expect(endringstidspunkt).toBe(opprinneligPlan[2].tidsperiode!.fom);
-        });
+            },
+        ];
+        const endringstidspunkt = getEndringstidspunkt(
+            opprinneligPlanMedHull as Periode[],
+            endretPlan as Periode[],
+            true
+        );
+        expect(endringstidspunkt).toBe(endretPlan[2].tidsperiode!.fom);
     });
+    it('Hvis endret periode er siste i planen, har samme startdato som i opprinnelig plan men senere sluttdato, skal endringstidspunkt være starten på perioden .', () => {
+        const nySistePeriode = {
+            id: opprinneligPlan[2].id,
+            tidsperiode: {
+                fom: opprinneligPlan[2].tidsperiode!.fom,
+                tom: new Date('2020-05-14T00:00:00.000Z'),
+            },
+            type: opprinneligPlan[2].type,
+        };
+        const endretPlan = [opprinneligPlan[0], opprinneligPlan[1], nySistePeriode];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(nySistePeriode.tidsperiode.fom);
+    });
+    it('Hvis endret periode er siste i planen, har samme startdato som i opprinnelig plan men tidligere sluttdato, skal endringstidspunkt være starten på perioden som er først i planen.', () => {
+        const nySistePeriode = {
+            id: opprinneligPlan[2].id,
+            tidsperiode: {
+                fom: opprinneligPlan[2].tidsperiode!.fom,
+                tom: new Date('2020-05-01T00:00:00.000Z'),
+            },
+            type: opprinneligPlan[2].type,
+        };
+        const endretPlan = [opprinneligPlan[0], opprinneligPlan[1], nySistePeriode];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(nySistePeriode.tidsperiode.fom);
+    });
+    it('Hvis ingen opprinnelig plan, skal endringstidspunkt være startdatoen på første periode i endret plan.', () => {
+        const tomOpprinneligPlan = [] as Periode[];
+        const endretPlan = [opprinneligPlan[2], opprinneligPlan[3]];
+        const endringstidspunkt = getEndringstidspunkt(tomOpprinneligPlan, endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(opprinneligPlan[2].tidsperiode!.fom);
+    });
+
+    it('Hvis siste periode er slettet i den nye planen skal endringstidspunkt være startdatoen på slettet periode.', () => {
+        const endretPlan = [opprinneligPlan[0], opprinneligPlan[1]];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+        expect(endringstidspunkt).toBe(opprinneligPlan[2].tidsperiode!.fom);
+    });
+    it('Hvis både endret type på en periode i midten og siste periode er slettet i den nye planen skal endringstidspunkt være startdatoen på den endrede perioden.', () => {
+        const endretPlan = [opprinneligPlan[0], { ...opprinneligPlan[1], type: Periodetype.Hull }];
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
+    });
+    it('Hvis forlenget en periode i midten og siste periode er slettet i den nye planen skal endringstidspunkt være startdatoen på den forlengede perioden.', () => {
+        const forlengetTidsperiodeMidten = {
+            ...opprinneligPlan[1].tidsperiode,
+            tom: new Date('2020-01-17T00:00:00.000Z'),
+        };
+        const endretPlan = [opprinneligPlan[0], { ...opprinneligPlan[1], forlengetTidsperiodeMidten }];
+
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
+    });
+    it('Hvis forkortet en periode i midten og siste periode er slettet i den nye planen skal endringstidspunkt være startdatoen på den forkortede perioden.', () => {
+        const forkortetTidsperiodeMidten = {
+            ...opprinneligPlan[1].tidsperiode,
+            tom: new Date('2020-01-08T00:00:00.000Z'),
+        };
+        const endretPlan = [opprinneligPlan[0], { ...opprinneligPlan[1], forkortetTidsperiodeMidten }];
+
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
+    });
+    it('Hvis endrer første periode til å starte senere enn i opprinnelig plan, skal endringstidspunkt være startdatoen på den opprinnelige første perioden.', () => {
+        const forkortetFørsteTidsperiode = {
+            ...opprinneligPlan[0].tidsperiode,
+            fom: new Date('2019-09-16T00:00:00.000Z'),
+        };
+        const forkortetFørstePeriode = {
+            ...opprinneligPlan[0],
+            tidsperiode: forkortetFørsteTidsperiode,
+        };
+        const endretPlan = [forkortetFørstePeriode, opprinneligPlan[1], opprinneligPlan[2]];
+
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toBe(opprinneligPlan[0].tidsperiode!.fom);
+    });
+    it('Hvis endrer første periode til å starte tidligere enn i opprinnelig plan, skal endringstidspunkt være startdatoen på første perioden i endret plan.', () => {
+        const forlengetFørsteTidsperiode = {
+            ...opprinneligPlan[0].tidsperiode,
+            fom: new Date('2019-09-02T00:00:00.000Z'),
+        };
+        const forlengetFørstePeriode = {
+            ...opprinneligPlan[0],
+            tidsperiode: forlengetFørsteTidsperiode,
+        };
+        const endretPlan = [forlengetFørstePeriode, opprinneligPlan[1], opprinneligPlan[2]];
+
+        const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+        expect(endringstidspunkt).toBe(forlengetFørsteTidsperiode.fom);
+    });
+    it('Hvis sletter en periode i midten og samtidig forkorter perioden før skal endringstidspunktet være starten på hull perioden etter den forkortede perioden i endret plan.', () => {
+        const fjerdePeriode = {
+            id: '89454212-6496-7446-7246-02332065872239',
+            tidsperiode: {
+                fom: new Date('2020-05-05T00:00:00.000Z'),
+                tom: new Date('2020-05-19T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
+
+        const opprinneligPlanFirePerioder = [...opprinneligPlan, fjerdePeriode];
+
+        const forkortetAndreTidsPeriode = {
+            ...opprinneligPlanFirePerioder[0].tidsperiode,
+            tom: new Date('2020-01-06T00:00:00.000Z'),
+        };
+        const forkortetAndrePeriode = {
+            ...opprinneligPlanFirePerioder[1],
+            tidsperiode: forkortetAndreTidsPeriode,
+        };
+
+        const nyTredjePeriodeHull = {
+            id: opprinneligPlanFirePerioder[2],
+            tidsperiode: {
+                fom: new Date('2020-01-07T00:00:00.000Z'),
+                tom: new Date('2020-04-29T00:00:00.000Z'),
+            },
+            type: Periodetype.Hull,
+        };
+
+        const nyFjerdePeriode = {
+            id: fjerdePeriode.id,
+            tidsperiode: {
+                fom: new Date('2020-04-30T00:00:00.000Z'),
+                tom: new Date('2020-05-12T00:00:00.000Z'),
+            },
+            type: Periodetype.Uttak,
+        };
+
+        const endretPlanFirePerioder = [
+            opprinneligPlanFirePerioder[0],
+            forkortetAndrePeriode,
+            nyTredjePeriodeHull,
+            nyFjerdePeriode,
+        ];
+
+        const endringstidspunkt = getEndringstidspunkt(
+            opprinneligPlanFirePerioder as Periode[],
+            endretPlanFirePerioder as Periode[],
+            true
+        );
+        expect(endringstidspunkt).toBe(nyTredjePeriodeHull.tidsperiode.fom);
+    });
+    it('Hvis sletter siste periode og samtidig forkorter perioden før skal endringstidspunktet være starten på den forkortede perioden i endret plan.', () => {});
+    const forkortetAndreTidsperiode = {
+        ...opprinneligPlan[1].tidsperiode,
+        tom: new Date('2020-01-06T00:00:00.000Z'),
+    };
+
+    const forkortetAndrePeriode = { ...opprinneligPlan[1], tidsperiode: forkortetAndreTidsperiode };
+
+    const endretPlan = [opprinneligPlan[0], forkortetAndrePeriode];
+
+    const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+    expect(endringstidspunkt).toBe(forkortetAndreTidsperiode.fom);
 });

--- a/src/app/util/dates/__tests__/dateUtils.test.ts
+++ b/src/app/util/dates/__tests__/dateUtils.test.ts
@@ -247,7 +247,50 @@ describe('dateUtils', () => {
 
             expect(endringstidspunkt).toBe(nyPeriode.tidsperiode!.fom);
         });
-        it('Hvis endret periode er siste, har samme startdato som i opprinnelig plan men ulik sluttdato, skal endringstidspunkt være starten på perioden .', () => {
+        it('Hvis endrer en periode til å ha senere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på perioden .', () => {
+            const nyMidterstePeriode = {
+                id: opprinneligPlan[1].id,
+                tidsperiode: {
+                    fom: opprinneligPlan[1].tidsperiode!.fom,
+                    tom: new Date('2020-01-14T00:00:00.000Z'),
+                },
+                type: opprinneligPlan[1].type,
+            };
+            const nyEndretSistePeriode = {
+                ...opprinneligPlan[2],
+                tidsperiode: {
+                    fom: new Date('2020-01-15T00:00:00.000Z'),
+                    tom: new Date('2020-05-05T00:00:00.000Z'),
+                },
+            };
+            const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyEndretSistePeriode];
+            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+            expect(endringstidspunkt).toBe(opprinneligPlan[1].tidsperiode!.fom);
+        });
+
+        it('Hvis endrer en periode til å ha tidligere sluttdato fra opprinnelig plan, skal endringstidspunkt være starten på neste periode i den nye planen .', () => {
+            const nyMidterstePeriode = {
+                id: opprinneligPlan[1].id,
+                tidsperiode: {
+                    fom: opprinneligPlan[1].tidsperiode!.fom,
+                    tom: new Date('2020-01-08T00:00:00.000Z'),
+                },
+                type: opprinneligPlan[1].type,
+            };
+            const nyHullPeriode = {
+                ...opprinneligPlan[2],
+                tidsperiode: {
+                    fom: new Date('2020-01-09T00:00:00.000Z'),
+                    tom: new Date('2020-01-13T00:00:00.000Z'),
+                },
+            };
+            const endretPlan = [opprinneligPlan[0], nyMidterstePeriode, nyHullPeriode, opprinneligPlan[2]];
+            const endringstidspunkt = getEndringstidspunkt(opprinneligPlan as Periode[], endretPlan as Periode[], true);
+
+            expect(endringstidspunkt).toBe(nyHullPeriode.tidsperiode.fom);
+        });
+        it('Hvis endret periode er siste i planen, har samme startdato som i opprinnelig plan men ulik sluttdato, skal endringstidspunkt være starten på perioden .', () => {
             const nySistePeriode = {
                 id: opprinneligPlan[2].id,
                 tidsperiode: {

--- a/src/app/util/dates/__tests__/dateUtils.test.ts
+++ b/src/app/util/dates/__tests__/dateUtils.test.ts
@@ -149,8 +149,8 @@ describe('dateUtils', () => {
             const gradertPeriode: Partial<Uttaksperiode> = {
                 id: guid(),
                 tidsperiode: {
-                    fom: new Date('2019-05-05'),
-                    tom: new Date('2019-05-08'),
+                    fom: new Date('2020-05-05'),
+                    tom: new Date('2020-05-08'),
                 },
                 type: Periodetype.Uttak,
                 gradert: true,

--- a/src/app/util/dates/dates.ts
+++ b/src/app/util/dates/dates.ts
@@ -46,53 +46,32 @@ export const getEndringstidspunkt = (
             if (endringstidspunktNyPlan) {
                 return endringstidspunktNyPlan;
             }
-
-            const { fom } = periode.tidsperiode;
+            const { fom, tom } = periode.tidsperiode;
             const opprinneligPeriodeMedSammeFom = opprinneligPlan.find((opprinneligPeriode) =>
                 moment(opprinneligPeriode.tidsperiode.fom).isSame(fom)
             );
 
-            if (
-                opprinneligPeriodeMedSammeFom !== undefined &&
-                !Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, false, true)
-            ) {
-                endringstidspunktNyPlan = fom;
-            }
-
-            if (opprinneligPeriodeMedSammeFom === undefined) {
-                endringstidspunktNyPlan = fom;
-            }
-
             if (opprinneligPeriodeMedSammeFom !== undefined) {
+                //Hvis forandringer i perioden (utenom tid), eller perioden har blitt forlenget, eller forandringer i siste periode (inkludert tid)
                 if (
-                    Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, false, true) &&
-                    Perioden(periode).slutterEtter(opprinneligPeriodeMedSammeFom.tidsperiode.tom)
+                    !Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, false, true) ||
+                    Perioden(periode).slutterEtter(opprinneligPeriodeMedSammeFom.tidsperiode.tom) ||
+                    (updatedPlan.length - 1 === index &&
+                        !Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, true, true))
                 ) {
                     endringstidspunktNyPlan = fom;
                 }
             }
+            if (opprinneligPeriodeMedSammeFom === undefined) {
+                endringstidspunktNyPlan = fom;
+            }
 
-            if (opprinneligPeriodeMedSammeFom !== undefined && updatedPlan.length - 1 === index) {
-                if (!Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, true, true)) {
-                    endringstidspunktNyPlan = fom;
+            //Sjekk om siste periode er blitt slettet
+            if (index === updatedPlan.length - 1) {
+                const senerePeriodeIOpprinneligPlan = opprinneligPlan.find((p) => Perioden(p).starterEtter(tom));
+                if (senerePeriodeIOpprinneligPlan) {
+                    endringstidspunktNyPlan = senerePeriodeIOpprinneligPlan.tidsperiode.fom;
                 }
-            }
-        });
-
-        opprinneligPlan.forEach((periode) => {
-            if (endringstidspunktOpprinneligPlan) {
-                return endringstidspunktOpprinneligPlan;
-            }
-
-            const { fom } = periode.tidsperiode;
-            const nyPeriodeMedSammeFom = updatedPlan.find((nyPeriode) => moment(nyPeriode.tidsperiode.fom).isSame(fom));
-
-            if (nyPeriodeMedSammeFom !== undefined && !Perioden(periode).erLik(nyPeriodeMedSammeFom, false, true)) {
-                endringstidspunktOpprinneligPlan = nyPeriodeMedSammeFom.tidsperiode.fom;
-            }
-
-            if (nyPeriodeMedSammeFom === undefined) {
-                endringstidspunktOpprinneligPlan = fom;
             }
         });
     } else {

--- a/src/app/util/dates/dates.ts
+++ b/src/app/util/dates/dates.ts
@@ -63,6 +63,15 @@ export const getEndringstidspunkt = (
                 endringstidspunktNyPlan = fom;
             }
 
+            if (opprinneligPeriodeMedSammeFom !== undefined) {
+                if (
+                    Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, false, true) &&
+                    Perioden(periode).slutterEtter(opprinneligPeriodeMedSammeFom.tidsperiode.tom)
+                ) {
+                    endringstidspunktNyPlan = fom;
+                }
+            }
+
             if (opprinneligPeriodeMedSammeFom !== undefined && updatedPlan.length - 1 === index) {
                 if (!Perioden(periode).erLik(opprinneligPeriodeMedSammeFom, true, true)) {
                     endringstidspunktNyPlan = fom;

--- a/src/app/util/uttaksplan/Perioden.ts
+++ b/src/app/util/uttaksplan/Perioden.ts
@@ -17,6 +17,7 @@ export const Perioden = (periode: Periode) => ({
     inneholderFridager: () => Tidsperioden(periode.tidsperiode).getAntallFridager() > 0,
     starterFør: (dato: Date) => moment(periode.tidsperiode.fom).isBefore(dato, 'day'),
     slutterEtter: (dato: Date) => moment(periode.tidsperiode.tom).isAfter(dato, 'day'),
+    starterEtter: (dato: Date) => moment(periode.tidsperiode.fom).isAfter(dato, 'day'),
     slutterSammeDagEllerEtter: (dato: Date) => moment(periode.tidsperiode.tom).isSameOrAfter(dato, 'day'),
 });
 


### PR DESCRIPTION
Bugfix for endringstidspunktet når en periode får endret sluttdato til et senere tidspunkt.
Feilen førte til at en overlappende fri-uttaksperiode ble lagt til etter at søknaden ble sendt inn.

Signed-off-by: Gabriela Rutkowska <gabriela.rutkowska@nav.no>