### PR TITLE
Renaming av erUfør i annenForelder

### DIFF
--- a/src/app/components/applikasjon/resetSoknad/ResetSoknad.tsx
+++ b/src/app/components/applikasjon/resetSoknad/ResetSoknad.tsx
@@ -71,7 +71,7 @@ const mapStateToProps = (state: AppState): StateProps => {
             annenForelder: {
                 harRettPåForeldrepenger: annenForelder.harRettPåForeldrepenger,
                 erForSyk: annenForelder.erForSyk,
-                erUfør: annenForelder.erUfør,
+                harMorUføretrygd : annenForelder.harMorUføretrygd ,
             },
             barn: {
                 antallBarn: barn.antallBarn,

--- a/src/app/redux/sagas/uttakSaga.ts
+++ b/src/app/redux/sagas/uttakSaga.ts
@@ -52,7 +52,7 @@ function* getStønadskontoer(action: GetTilgjengeligeStønadskontoer) {
 
         const appState: AppState = yield select(stateSelector);
         const annenForelderErUkjent = appState.søknad.annenForelder.kanIkkeOppgis;
-        const erMorUfør = appState.søknad.annenForelder.erUfør;
+        const erMorUfør = appState.søknad.annenForelder.harMorUføretrygd;
         const erAleneOmsorg = appState.søknad.søker.erAleneOmOmsorg;
         const søkerErFarEllerMedmor = selectSøkerErFarEllerMedmor(appState);
         const morHarIkkeRett = !appState.søknad.annenForelder.harRettPåForeldrepenger && søkerErFarEllerMedmor;

--- a/src/app/regler/søknad/morErUfør.ts
+++ b/src/app/regler/søknad/morErUfør.ts
@@ -1,5 +1,5 @@
 import AnnenForelder from '../../types/søknad/AnnenForelder';
 
 export const getMorErUfør = (søkerErFarEllerMedmor: boolean, annenForelder: Partial<AnnenForelder>): boolean => {
-    return søkerErFarEllerMedmor === true && annenForelder.erUfør === true;
+    return søkerErFarEllerMedmor === true && annenForelder.harMorUføretrygd  === true;
 };

--- a/src/app/selectors/søknadsinfoSelector.ts
+++ b/src/app/selectors/søknadsinfoSelector.ts
@@ -172,7 +172,7 @@ const selectOmAnnenForelder = createSelector(
             harRett: annenForelder.harRettPåForeldrepenger === true,
             erFarEllerMedmor: søkerErFarEllerMedmor === false,
             erMor: søkerErFarEllerMedmor === true,
-            erUfør: annenForelder.erUfør === true,
+            erUfør: annenForelder.harMorUføretrygd === true,
             kanIkkeOppgis: annenForelder.kanIkkeOppgis === true,
             kjønn,
         };

--- a/src/app/selectors/utledetSøknadsinfoSelectors.ts
+++ b/src/app/selectors/utledetSøknadsinfoSelectors.ts
@@ -93,7 +93,7 @@ export const selectMorErUfør = createSelector(
     [selectAnnenForelder, selectSøkerErFarEllerMedmor],
     (annenForelder, erFarEllerMedmor): boolean | undefined => {
         if (annenForelder !== undefined) {
-            return erFarEllerMedmor === true && annenForelder.erUfør === true;
+            return erFarEllerMedmor === true && annenForelder.harMorUføretrygd === true;
         }
         return undefined;
     }

--- a/src/app/steg/annenForelder/AnnenForelderSteg.tsx
+++ b/src/app/steg/annenForelder/AnnenForelderSteg.tsx
@@ -85,7 +85,7 @@ class AnnenForelderSteg extends React.Component<Props> {
             harRettPåForeldrepenger: values.harRettPåForeldrepenger === YesOrNo.YES,
             kanIkkeOppgis: values.kanIkkeOppgis,
             utenlandskFnr: values.utenlandskFnr,
-            erUfør: values.erMorUfør === YesOrNo.YES,
+            harMorUføretrygd : values.erMorUfør === YesOrNo.YES,
             bostedsland: values.bostedsland,
         };
 
@@ -226,7 +226,7 @@ const mapStateToProps = (state: AppState, props: Props): StateProps => {
         bostedsland: annenForelder.bostedsland,
         datoForAleneomsorg: barn.datoForAleneomsorg,
         erInformertOmSøknaden: mapBooleanToYesOrNo(annenForelder.erInformertOmSøknaden),
-        erMorUfør: mapBooleanToYesOrNo(annenForelder.erUfør),
+        erMorUfør: mapBooleanToYesOrNo(annenForelder.harMorUføretrygd ),
         etternavn: annenForelder.etternavn,
         fornavn: annenForelder.fornavn,
         fnr: annenForelder.fnr,

--- a/src/app/steg/annenForelder/visibility/annenForelderStegVisibility.ts
+++ b/src/app/steg/annenForelder/visibility/annenForelderStegVisibility.ts
@@ -114,7 +114,7 @@ const annenForelderSpørsmålConfig: QuestionConfig<AnnenForelderSpørsmålPaylo
         },
     },
     [AnnenForelderSpørsmålKeys.erMorUfør]: {
-        isAnswered: ({ annenForelder }) => questionValueIsOk(annenForelder.erUfør),
+        isAnswered: ({ annenForelder }) => questionValueIsOk(annenForelder.harMorUføretrygd ),
         parentQuestion: AnnenForelderSpørsmålKeys.harRettPåForeldrepenger,
         isIncluded: (payload) =>
             payload.søker.erAleneOmOmsorg === false &&

--- a/src/app/steg/oppsummering/components/oppsummering/oppsummeringer/AnnenForelderOppsummering.tsx
+++ b/src/app/steg/oppsummering/components/oppsummering/oppsummeringer/AnnenForelderOppsummering.tsx
@@ -33,7 +33,7 @@ const AnnenForelderOppsummering: React.FunctionComponent<Props> = (props: Props)
         harRettPåForeldrepenger,
         erInformertOmSøknaden,
         erForSyk,
-        erUfør,
+        harMorUføretrygd,
     } = props.annenForelder;
 
     const { datoForAleneomsorg, dokumentasjonAvAleneomsorg } = barn;
@@ -115,10 +115,10 @@ const AnnenForelderOppsummering: React.FunctionComponent<Props> = (props: Props)
                     verdi={erForSyk ? getMessage(intl, 'ja') : getMessage(intl, 'nei')}
                 />
             )}
-            {erUfør !== undefined && (
+            {harMorUføretrygd !== undefined && (
                 <Feltoppsummering
                     feltnavn={getMessage(intl, 'oppsummering.annenForelder.erUfør.label', { navn })}
-                    verdi={erUfør ? getMessage(intl, 'ja') : getMessage(intl, 'nei')}
+                    verdi={harMorUføretrygd ? getMessage(intl, 'ja') : getMessage(intl, 'nei')}
                 />
             )}
         </Oppsummeringsseksjon>

--- a/src/app/steg/uttaksplanSkjema/UttaksplanSkjemaScenarioes.tsx
+++ b/src/app/steg/uttaksplanSkjema/UttaksplanSkjemaScenarioes.tsx
@@ -469,7 +469,7 @@ const Scenario6: React.FunctionComponent<ScenarioProps> = ({
                 />
             </Block>
             <StartdatoUttakFarMedmorSpørsmål
-                visible={søknad.dekningsgrad !== undefined && søknad.annenForelder.erUfør === true}
+                visible={søknad.dekningsgrad !== undefined && søknad.annenForelder.harMorUføretrygd  === true}
                 familiehendelsesdato={førsteUttaksdag}
             />
         </>

--- a/src/app/types/søknad/AnnenForelder.ts
+++ b/src/app/types/søknad/AnnenForelder.ts
@@ -8,7 +8,7 @@ interface AnnenForelder {
     harRettPåForeldrepenger: boolean;
     erInformertOmSøknaden: boolean;
     erForSyk: boolean;
-    erUfør: boolean;
+    harMorUføretrygd : boolean;
 }
 
 export type AnnenForelderPartial = Partial<AnnenForelder>;

--- a/src/app/util/cleanup/__tests__/cleanupAnnenForelder.test.ts
+++ b/src/app/util/cleanup/__tests__/cleanupAnnenForelder.test.ts
@@ -16,7 +16,7 @@ import { dateToISOString } from '@navikt/sif-common-formik/lib';
 const annenForelder: AnnenForelder = {
     bostedsland: 'landet',
     erForSyk: false,
-    erUfør: false,
+    harMorUføretrygd : false,
     erInformertOmSøknaden: false,
     fnr: '123',
     harRettPåForeldrepenger: false,
@@ -139,7 +139,7 @@ describe('Cleanup AnnenForelder', () => {
                     testSøknad.barn as ForeldreansvarBarn
                 ) as ForeldreansvarBarn;
                 expect(af.harRettPåForeldrepenger).toBeUndefined();
-                expect(af.erUfør).toBeUndefined();
+                expect(af.harMorUføretrygd ).toBeUndefined();
                 expect(af.erInformertOmSøknaden).toBeUndefined();
                 expect(b.datoForAleneomsorg).toBeDefined();
             });
@@ -153,7 +153,7 @@ describe('Cleanup AnnenForelder', () => {
                     testVisibility,
                     testSøknad.barn as ForeldreansvarBarn
                 ) as ForeldreansvarBarn;
-                expect(af.erUfør).toBeUndefined();
+                expect(af.harMorUføretrygd ).toBeUndefined();
                 expect(af.erInformertOmSøknaden).toBeUndefined();
                 expect(af.harRettPåForeldrepenger).toBeUndefined();
                 expect(b.datoForAleneomsorg).toBeUndefined();

--- a/src/app/util/cleanup/cleanupAnnenForelderSteg.ts
+++ b/src/app/util/cleanup/cleanupAnnenForelderSteg.ts
@@ -27,7 +27,7 @@ export const cleanupAnnenForelder = (
         utenlandskFnr,
         harRettPåForeldrepenger,
         erInformertOmSøknaden,
-        erUfør,
+        harMorUføretrygd,
         kanIkkeOppgis,
         ...rest
     } = annenForelder;
@@ -52,7 +52,7 @@ export const cleanupAnnenForelder = (
         erInformertOmSøknaden: visibility.isVisible(AnnenForelderSpørsmålKeys.erAnnenForelderInformert)
             ? erInformertOmSøknaden
             : undefined,
-        erUfør: visibility.isVisible(AnnenForelderSpørsmålKeys.erMorUfør) ? erUfør : undefined,
+        harMorUføretrygd : visibility.isVisible(AnnenForelderSpørsmålKeys.erMorUfør) ? harMorUføretrygd : undefined,
     };
     return cleanedAnnenForelder;
 };

--- a/src/app/util/eksisterendeSak/eksisterendeSakUtils.ts
+++ b/src/app/util/eksisterendeSak/eksisterendeSakUtils.ts
@@ -373,7 +373,7 @@ const getAnnenForelderFromSaksgrunnlag = (
                 return {
                     fornavn: annenPart.navn.fornavn,
                     etternavn: annenPart.navn.etternavn,
-                    erUfør: grunnlag.morErUfør,
+                    harMorUføretrygd : grunnlag.morErUfør,
                     harRettPåForeldrepenger: grunnlag.morHarRett,
                     fnr: annenPart.fnr,
                     kanIkkeOppgis: false,

--- a/src/app/util/uttaksplan/__tests__/uttakUtils.test.ts
+++ b/src/app/util/uttaksplan/__tests__/uttakUtils.test.ts
@@ -30,7 +30,7 @@ describe('uttakUtils', () => {
         },
         annenForelder: {
             harRett: true,
-            erUfør: false,
+            harMorUføretrygd : false,
         },
     } as DeepPartial<Søknad>;
 

--- a/src/app/util/validation/steg/uttaksplanSkjema.ts
+++ b/src/app/util/validation/steg/uttaksplanSkjema.ts
@@ -34,7 +34,7 @@ export const uttaksplanSkjemaErGyldig = (søknad: Søknad, søknadsinfo?: Søkna
         case UttaksplanSkjemaScenario.s6_bareFarMedmorRettTilFpFødsel:
             return (
                 skjema.startdatoPermisjon !== undefined ||
-                (søknad.dekningsgrad !== undefined && søknad.annenForelder.erUfør === false)
+                (søknad.dekningsgrad !== undefined && søknad.annenForelder.harMorUføretrygd  === false)
             );
 
         case UttaksplanSkjemaScenario.s7_farMorAdopsjon_morFarAlleredeSøkt_ikkeDeltPlan:


### PR DESCRIPTION
Renamer erUfør til harMorUføretrygd på annenForelder slik at det matcher navnet i APIet

Signed-off-by: Gabriela Rutkowska <gabriela.rutkowska@nav.no>