### PR TITLE
Bugfiks for duplikate datoer ved periodenormalisering/splitting. 

### DIFF
--- a/apps/foreldrepengesoknad/src/uttaksplan/builder/uttaksplanbuilderUtils.ts
+++ b/apps/foreldrepengesoknad/src/uttaksplan/builder/uttaksplanbuilderUtils.ts
@@ -355,6 +355,7 @@ const splittPeriodePåDatoer = (periode: Periode, alleDatoer: SplittetDatoType[]
     const datoerIPerioden = alleDatoer.filter((datoWrapper) =>
         Tidsperioden(periode.tidsperiode).inneholderDato(datoWrapper.dato)
     );
+
     const oppsplittetPeriode: Periode[] = [];
 
     if (datoerIPerioden.length === 2) {
@@ -418,16 +419,21 @@ export const normaliserPerioder = (perioder: Periode[], annenPartsUttak: Periode
         return d1.dato.getTime() - d2.dato.getTime();
     });
 
+    const alleUnikeDatoer = alleDatoer.filter(
+        (date, i, self) =>
+            self.findIndex((d) => d.dato.getTime() === date.dato.getTime() && d.erFom === date.erFom) === i
+    );
+
     const normaliserteEgnePerioder: Periode[] = [];
     const normaliserteAnnenPartsPerioder: Periode[] = [];
 
     perioder.forEach((p) => {
-        const oppsplittetPeriode = splittPeriodePåDatoer(p, alleDatoer);
+        const oppsplittetPeriode = splittPeriodePåDatoer(p, alleUnikeDatoer);
         normaliserteEgnePerioder.push(...oppsplittetPeriode);
     });
 
     annenPartsUttak.forEach((p) => {
-        const oppsplittetPeriode = splittPeriodePåDatoer(p, alleDatoer);
+        const oppsplittetPeriode = splittPeriodePåDatoer(p, alleUnikeDatoer);
         normaliserteAnnenPartsPerioder.push(...oppsplittetPeriode);
     });
 


### PR DESCRIPTION
Bugfiks for duplikate datoer ved periodenormalisering/splitting. Denne utgjorde et problem i en planen der perioder allerede er normaliserte. Duplikate datoer ble skapt basert på allerede normaliserte perioder. Dette førte til at for mange ulovlige perioder ble laget, og dermed nye perioder med nye id'er ble laget ved endringer i planen. Dette første til at formen for endring av perioden refreshet seg ved endring (så ut som den ble lukket automatisk).