### PR TITLE
Legge til foreldrepengeplanlegger ingress for forward

### DIFF
--- a/.deploy/foreldrepengeoversikt/prod-gcp-foreldrepengeoversikt.json
+++ b/.deploy/foreldrepengeoversikt/prod-gcp-foreldrepengeoversikt.json
@@ -2,7 +2,8 @@
     "app": "foreldrepengeoversikt",
     "dekoratoren": "www.nav.no",
     "ingresses": [
-        "https://foreldrepenger.nav.no"
+        "https://foreldrepenger.nav.no",
+        "https://foreldrepengeplanlegger.nav.no"
     ],
     "env": {
         "APPRES_CMS_URL": "https://www.nav.no/dekoratoren",


### PR DESCRIPTION
Foreldrepengeplanlegger-ingress har blitt borte i overgang til monorepo. Foreldrepengeoversikten har kode for å forwarde til produktsider. Forsøk på å få nais til å legge til forward strandet, så vi gjorde det enkelt med egen forward i koden.

https://github.com/navikt/foreldrepengesoknad/blob/08945cfdf48dd96d227acb2fac8dd8c4853fb4f6/apps/foreldrepengeoversikt/server.cjs#L47-L53