### PR TITLE
Fiks redirect bug ved refresh

### DIFF
--- a/apps/foreldrepengeoversikt/src/app/pages/forside/Forside.tsx
+++ b/apps/foreldrepengeoversikt/src/app/pages/forside/Forside.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Alert, VStack } from '@navikt/ds-react';
@@ -19,7 +20,7 @@ import OversiktRoutes from 'app/routes/routes';
 import { RedirectSource, UKNOWN_SAKSNUMMER } from 'app/types/RedirectSource';
 import { SakOppslag } from 'app/types/SakOppslag';
 import { SøkerinfoDTO } from 'app/types/SøkerinfoDTO';
-import { getAlleYtelser, grupperSakerPåBarn } from 'app/utils/sakerUtils';
+import { getAlleYtelser, getAntallSaker, grupperSakerPåBarn } from 'app/utils/sakerUtils';
 
 import './forside.css';
 
@@ -42,6 +43,29 @@ const Forside: React.FunctionComponent<Props> = ({ saker, isFirstRender, søkeri
         navigate(OversiktRoutes.HOVEDSIDE);
     }
     const redirectedFromSøknadsnummer = useGetRedirectedFromSøknadsnummer();
+
+    const hasNavigated = useRef(false);
+
+    useEffect(() => {
+        if (!hasNavigated.current) {
+            hasNavigated.current = true;
+            const antallSaker = getAntallSaker(saker);
+            const { foreldrepenger, engangsstønad, svangerskapspenger } = saker;
+            if (antallSaker === 1) {
+                if (foreldrepenger.length === 1) {
+                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${foreldrepenger[0].saksnummer}`);
+                }
+
+                if (engangsstønad.length === 1) {
+                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${engangsstønad[0].saksnummer}`);
+                }
+
+                if (svangerskapspenger.length === 1) {
+                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${svangerskapspenger[0].saksnummer}`);
+                }
+            }
+        }
+    }, [navigate, saker]);
 
     const grupperteSaker = grupperSakerPåBarn(søkerinfo.søker.barn ?? [], saker);
     const alleYtelser = getAlleYtelser(saker);

--- a/apps/foreldrepengeoversikt/src/app/pages/forside/Forside.tsx
+++ b/apps/foreldrepengeoversikt/src/app/pages/forside/Forside.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Alert, VStack } from '@navikt/ds-react';
@@ -20,7 +19,7 @@ import OversiktRoutes from 'app/routes/routes';
 import { RedirectSource, UKNOWN_SAKSNUMMER } from 'app/types/RedirectSource';
 import { SakOppslag } from 'app/types/SakOppslag';
 import { SøkerinfoDTO } from 'app/types/SøkerinfoDTO';
-import { getAlleYtelser, getAntallSaker, grupperSakerPåBarn } from 'app/utils/sakerUtils';
+import { getAlleYtelser, grupperSakerPåBarn } from 'app/utils/sakerUtils';
 
 import './forside.css';
 
@@ -43,29 +42,6 @@ const Forside: React.FunctionComponent<Props> = ({ saker, isFirstRender, søkeri
         navigate(OversiktRoutes.HOVEDSIDE);
     }
     const redirectedFromSøknadsnummer = useGetRedirectedFromSøknadsnummer();
-
-    const hasNavigated = useRef(false);
-
-    useEffect(() => {
-        if (!hasNavigated.current) {
-            hasNavigated.current = true;
-            const antallSaker = getAntallSaker(saker);
-            const { foreldrepenger, engangsstønad, svangerskapspenger } = saker;
-            if (antallSaker === 1) {
-                if (foreldrepenger.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${foreldrepenger[0].saksnummer}`);
-                }
-
-                if (engangsstønad.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${engangsstønad[0].saksnummer}`);
-                }
-
-                if (svangerskapspenger.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${svangerskapspenger[0].saksnummer}`);
-                }
-            }
-        }
-    }, [navigate, saker]);
 
     const grupperteSaker = grupperSakerPåBarn(søkerinfo.søker.barn ?? [], saker);
     const alleYtelser = getAlleYtelser(saker);

--- a/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
+++ b/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
@@ -65,7 +65,7 @@ const ForeldrepengeoversiktRoutes: React.FunctionComponent<Props> = ({ søkerinf
  *
  * Vi ønsker ikke å redirecte til sak dersom bruker allerede er på en underside på saken, eller at bruker navigerer tilbake til forside via breadcrumbs
  */
-function RedirectTilSakHvisDetKunFinnesEn({ saker }: { saker: SakOppslag }) {
+function RedirectTilSakHvisDetKunFinnesEn({ saker }: { readonly saker: SakOppslag }) {
     const navigate = useNavigate();
 
     const alleSaker = getAlleYtelser(saker);

--- a/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
+++ b/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
@@ -1,5 +1,5 @@
-import { ReactNode, useEffect, useRef } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { ReactNode, useRef } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { bemUtils } from '@navikt/fp-utils';
 
@@ -15,7 +15,6 @@ import TidslinjePage from 'app/pages/tidslinje-page/TidslinjePage';
 import KontaktOss from 'app/sections/kontakt-oss/KontaktOss';
 import { SakOppslag } from 'app/types/SakOppslag';
 import { SøkerinfoDTO } from 'app/types/SøkerinfoDTO';
-import { getAntallSaker } from 'app/utils/sakerUtils';
 
 import OversiktRoutes from './routes';
 import './routes-wrapper.css';
@@ -27,30 +26,6 @@ interface Props {
 
 const ForeldrepengeoversiktRoutes: React.FunctionComponent<Props> = ({ søkerinfo, saker }) => {
     const isFirstRender = useRef(true);
-    const hasNavigated = useRef(false);
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        if (!hasNavigated.current) {
-            hasNavigated.current = true;
-            const antallSaker = getAntallSaker(saker);
-            const { foreldrepenger, engangsstønad, svangerskapspenger } = saker;
-            if (antallSaker === 1) {
-                if (foreldrepenger.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${foreldrepenger[0].saksnummer}`);
-                }
-
-                if (engangsstønad.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${engangsstønad[0].saksnummer}`);
-                }
-
-                if (svangerskapspenger.length === 1) {
-                    navigate(`${OversiktRoutes.SAKSOVERSIKT}/${svangerskapspenger[0].saksnummer}`);
-                }
-            }
-        }
-    }, [navigate, saker]);
-
     return (
         <>
             <Routes>


### PR DESCRIPTION
Ganske mye kronglete kode for en veldig enkel funksjon 😬 
I forrige versjon ville denne kjøre uansett hvor du var ved refresh. Det gjorde at besøk til undersider av en sak ville ta deg tilbake til sakssiden, som gir en dårlig opplevelse