### PR TITLE
u-nøst utenlandsoppholdperioder

### DIFF
--- a/apps/engangsstonad/src/app-data/EsDataContext.tsx
+++ b/apps/engangsstonad/src/app-data/EsDataContext.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactNode, createContext, useCallback, useContext, u
 import Dokumentasjon from 'types/Dokumentasjon';
 import { OmBarnet } from 'types/OmBarnet';
 
-import { Søkersituasjon, Utenlandsopphold, UtenlandsoppholdSenere, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { Søkersituasjon, Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import { Path } from './paths';
 
@@ -22,8 +22,8 @@ export type ContextDataMap = {
     [ContextDataType.OM_BARNET]?: OmBarnet;
     [ContextDataType.DOKUMENTASJON]?: Dokumentasjon;
     [ContextDataType.UTENLANDSOPPHOLD]?: Utenlandsopphold;
-    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdSenere;
-    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdTidligere;
+    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdPeriode[];
+    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdPeriode[];
 };
 
 const defaultInitialState = {} as ContextDataMap;

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -68,9 +68,7 @@ const useEsSendSøknad = (
                 type: 'engangsstønad',
                 språkkode: locale,
                 barn: mapBarn(omBarnet, dokumentasjon),
-                utenlandsopphold: (tidligereUtenlandsopphold?.utenlandsoppholdSiste12Mnd || []).concat(
-                    senereUtenlandsopphold?.utenlandsoppholdNeste12Mnd || [],
-                ),
+                utenlandsopphold: (tidligereUtenlandsopphold ?? []).concat(senereUtenlandsopphold ?? []),
                 vedlegg:
                     dokumentasjon?.vedlegg.map((vedlegg) => ({
                         ...vedlegg,

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
@@ -10,7 +10,7 @@ import { BarnetErFødt, OmBarnet } from 'types/OmBarnet';
 
 import { AttachmentType, ISO_DATE_FORMAT, Skjemanummer } from '@navikt/fp-constants';
 import { initAmplitude } from '@navikt/fp-metrics';
-import { Utenlandsopphold, UtenlandsoppholdSenere, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import OppsummeringSteg from './OppsummeringSteg';
 
@@ -39,8 +39,8 @@ const vedleggDefault = {
 type StoryArgs = {
     omBarnet?: OmBarnet;
     utenlandsopphold?: Utenlandsopphold;
-    tidligereUtenlandsopphold?: UtenlandsoppholdTidligere;
-    senereUtenlandsopphold?: UtenlandsoppholdSenere;
+    tidligereUtenlandsopphold?: UtenlandsoppholdPeriode[];
+    senereUtenlandsopphold?: UtenlandsoppholdPeriode[];
     dokumentasjon?: Dokumentasjon;
 } & ComponentProps<typeof OppsummeringSteg>;
 
@@ -175,29 +175,25 @@ export const HarTidligereOgFremtidigeUtenlandsopphold: Story = {
             harBoddUtenforNorgeSiste12Mnd: true,
             skalBoUtenforNorgeNeste12Mnd: true,
         },
-        senereUtenlandsopphold: {
-            utenlandsoppholdNeste12Mnd: [
-                {
-                    fom: dayjs().format(ISO_DATE_FORMAT),
-                    tom: dayjs().add(100, 'day').format(ISO_DATE_FORMAT),
-                    landkode: 'SE',
-                },
-                {
-                    fom: dayjs().add(101, 'day').format(ISO_DATE_FORMAT),
-                    tom: dayjs().add(200, 'day').format(ISO_DATE_FORMAT),
-                    landkode: 'DK',
-                },
-            ],
-        },
-        tidligereUtenlandsopphold: {
-            utenlandsoppholdSiste12Mnd: [
-                {
-                    fom: dayjs().subtract(100, 'day').format(ISO_DATE_FORMAT),
-                    tom: dayjs().format(ISO_DATE_FORMAT),
-                    landkode: 'IS',
-                },
-            ],
-        },
+        senereUtenlandsopphold: [
+            {
+                fom: dayjs().format(ISO_DATE_FORMAT),
+                tom: dayjs().add(100, 'day').format(ISO_DATE_FORMAT),
+                landkode: 'SE',
+            },
+            {
+                fom: dayjs().add(101, 'day').format(ISO_DATE_FORMAT),
+                tom: dayjs().add(200, 'day').format(ISO_DATE_FORMAT),
+                landkode: 'DK',
+            },
+        ],
+        tidligereUtenlandsopphold: [
+            {
+                fom: dayjs().subtract(100, 'day').format(ISO_DATE_FORMAT),
+                tom: dayjs().format(ISO_DATE_FORMAT),
+                landkode: 'IS',
+            },
+        ],
         mellomlagreOgNaviger: promiseAction(),
     },
 };

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.tsx
@@ -47,8 +47,8 @@ const OppsummeringSteg = ({ sendSøknad, mellomlagreOgNaviger }: Props) => {
                 />
                 <BoIUtlandetOppsummeringspunkt
                     onVilEndreSvar={() => navigator.goToNextStep(Path.UTENLANDSOPPHOLD)}
-                    tidligereUtenlandsopphold={tidligereUtenlandsopphold?.utenlandsoppholdSiste12Mnd ?? []}
-                    senereUtenlandsopphold={senereUtenlandsopphold?.utenlandsoppholdNeste12Mnd ?? []}
+                    tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
+                    senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                 />
                 <DokumentasjonOppsummering dokumentasjon={dokumentasjon} onVilEndreSvar={navigator.goToNextStep} />
             </OppsummeringPanel>

--- a/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import { Path } from 'appData/paths';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './SenereUtenlandsoppholdSteg.stories';
 
@@ -48,20 +49,18 @@ describe('<SenereUtenlandsoppholdSteg>', () => {
 
         expect(nesteStegFn).toHaveBeenCalledTimes(2);
         expect(nesteStegFn).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdNeste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
-                    },
-                    {
-                        landkode: 'AS',
-                        fom: dayjs().add(22, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().add(30, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
+                },
+                {
+                    landkode: 'AS',
+                    fom: dayjs().add(22, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().add(30, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_SENERE,
             type: 'update',
         });

--- a/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { SenereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { UtenlandsoppholdSenere } from '@navikt/fp-types';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 
 type Props = {
@@ -20,7 +20,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({ mellomlagr
     const senereUtenlandsopphold = useContextGetData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
     const oppdaterSenereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
 
-    const lagre = (formValues: UtenlandsoppholdSenere) => {
+    const lagre = (formValues: UtenlandsoppholdPeriode[]) => {
         oppdaterSenereUtenlandsopphold(formValues);
         return navigator.goToNextDefaultStep();
     };
@@ -31,7 +31,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({ mellomlagr
                 <FormattedMessage id="Søknad.Pageheading" />
             </Heading>
             <SenereUtenlandsoppholdPanel
-                senereUtenlandsopphold={senereUtenlandsopphold}
+                senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                 saveOnNext={lagre}
                 saveOnPrevious={oppdaterSenereUtenlandsopphold}
                 onContinueLater={navigator.fortsettSøknadSenere}

--- a/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import { Path } from 'appData/paths';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './TidligereUtenlandsoppholdSteg.stories';
 
@@ -48,20 +49,18 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
 
         expect(nesteStegFn).toHaveBeenCalledTimes(2);
         expect(nesteStegFn).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdSiste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
-                    },
-                    {
-                        landkode: 'AS',
-                        fom: dayjs().subtract(22, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
+                },
+                {
+                    landkode: 'AS',
+                    fom: dayjs().subtract(22, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });

--- a/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { TidligereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
@@ -23,7 +23,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({ melloml
     const tidligereUtenlandsopphold = useContextGetData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     const oppdaterTidligereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
 
-    const lagre = (formValues: UtenlandsoppholdTidligere) => {
+    const lagre = (formValues: UtenlandsoppholdPeriode[]) => {
         oppdaterTidligereUtenlandsopphold(formValues);
         return navigator.goToNextStep(
             utenlandsopphold.skalBoUtenforNorgeNeste12Mnd ? Path.SENERE_UTENLANDSOPPHOLD : Path.OPPSUMMERING,
@@ -36,7 +36,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({ melloml
                 <FormattedMessage id="Søknad.Pageheading" />
             </Heading>
             <TidligereUtenlandsoppholdPanel
-                tidligereUtenlandsopphold={tidligereUtenlandsopphold}
+                tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
                 saveOnNext={lagre}
                 saveOnPrevious={oppdaterTidligereUtenlandsopphold}
                 onContinueLater={navigator.fortsettSøknadSenere}

--- a/apps/foreldrepengesoknad/src/api/apiUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/api/apiUtils.test.ts
@@ -78,7 +78,7 @@ const getStateMock = (annenForelderInput: AnnenForelder, barnInput: Barn, uttaks
                 situasjon: 'fødsel',
             };
         }
-        return {};
+        return undefined;
     };
 };
 

--- a/apps/foreldrepengesoknad/src/api/apiUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/api/apiUtils.test.ts
@@ -65,6 +65,18 @@ const getStateMock = (annenForelderInput: AnnenForelder, barnInput: Barn, uttaks
         if (type === ContextDataType.UTTAKSPLAN) {
             return uttaksplanInput;
         }
+        if (type === ContextDataType.UTENLANDSOPPHOLD) {
+            return {
+                harBoddUtenforNorgeSiste12Mnd: false,
+                skalBoUtenforNorgeNeste12Mnd: false,
+            };
+        }
+        if (type === ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE) {
+            return [];
+        }
+        if (type === ContextDataType.UTENLANDSOPPHOLD_SENERE) {
+            return [];
+        }
         if (type === ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT) {
             return {
                 harHattAndreInntektskilder: false,
@@ -78,7 +90,8 @@ const getStateMock = (annenForelderInput: AnnenForelder, barnInput: Barn, uttaks
                 situasjon: 'fødsel',
             };
         }
-        return undefined;
+
+        return {};
     };
 };
 

--- a/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
+++ b/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
@@ -8,13 +8,7 @@ import { AnnenForelder, Barn, BarnFraNesteSak, EksisterendeSak, Periode } from '
 import { ArbeidsforholdOgInntektFp } from '@navikt/fp-steg-arbeidsforhold-og-inntekt';
 import { EgenNæring } from '@navikt/fp-steg-egen-naering';
 import { Frilans } from '@navikt/fp-steg-frilans';
-import {
-    Dekningsgrad,
-    SøkersituasjonFp,
-    Utenlandsopphold,
-    UtenlandsoppholdSenere,
-    UtenlandsoppholdTidligere,
-} from '@navikt/fp-types';
+import { Dekningsgrad, SøkersituasjonFp, Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import Fordeling from '../types/Fordeling';
 
@@ -51,8 +45,8 @@ export type ContextDataMap = {
     [ContextDataType.FRILANS]?: Frilans;
     [ContextDataType.ANDRE_INNTEKTSKILDER]?: AndreInntektskilder[];
     [ContextDataType.UTENLANDSOPPHOLD]?: Utenlandsopphold;
-    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdSenere;
-    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdTidligere;
+    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdPeriode[];
+    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdPeriode[];
     [ContextDataType.PERIODE_MED_FORELDREPENGER]?: Dekningsgrad;
     [ContextDataType.FORDELING]?: Fordeling;
     [ContextDataType.UTTAKSPLAN]?: Periode[];

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/Oppsummering.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/Oppsummering.stories.tsx
@@ -22,8 +22,7 @@ import {
     Søkerinfo,
     SøkersituasjonFp,
     Utenlandsopphold,
-    UtenlandsoppholdSenere,
-    UtenlandsoppholdTidligere,
+    UtenlandsoppholdPeriode,
 } from '@navikt/fp-types';
 
 import AxiosMock from '../../__mocks__/AxiosMock';
@@ -186,8 +185,8 @@ type StoryArgs = {
     søkersituasjon?: SøkersituasjonFp;
     annenForelder?: AnnenForelder;
     utenlandsopphold?: Utenlandsopphold;
-    utenlandsoppholdSenere?: UtenlandsoppholdSenere;
-    utenlandsoppholdTidligere?: UtenlandsoppholdTidligere;
+    utenlandsoppholdSenere?: UtenlandsoppholdPeriode[];
+    utenlandsoppholdTidligere?: UtenlandsoppholdPeriode[];
     barn?: Barn;
     sivilstand?: Sivilstand;
     arbeidsforholdOgInntekt?: ArbeidsforholdOgInntektFp;
@@ -449,24 +448,21 @@ export const MorMedUtenlandsopphold: Story = {
             skalBoUtenforNorgeNeste12Mnd: true,
             harBoddUtenforNorgeSiste12Mnd: true,
         },
-        utenlandsoppholdSenere: {
-            utenlandsoppholdNeste12Mnd: [
-                {
-                    landkode: 'SE',
-                    fom: dayjs().format(ISO_DATE_FORMAT),
-                    tom: dayjs().add(100, 'days').format(ISO_DATE_FORMAT),
-                },
-            ],
-        },
-        utenlandsoppholdTidligere: {
-            utenlandsoppholdSiste12Mnd: [
-                {
-                    landkode: 'SE',
-                    fom: dayjs().subtract(10, 'months').format(ISO_DATE_FORMAT),
-                    tom: dayjs().subtract(1, 'days').format(ISO_DATE_FORMAT),
-                },
-            ],
-        },
+        utenlandsoppholdSenere: [
+            {
+                landkode: 'SE',
+                fom: dayjs().format(ISO_DATE_FORMAT),
+                tom: dayjs().add(100, 'days').format(ISO_DATE_FORMAT),
+            },
+        ],
+
+        utenlandsoppholdTidligere: [
+            {
+                landkode: 'SE',
+                fom: dayjs().subtract(10, 'months').format(ISO_DATE_FORMAT),
+                tom: dayjs().subtract(1, 'days').format(ISO_DATE_FORMAT),
+            },
+        ],
     },
 };
 

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/Oppsummering.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/Oppsummering.tsx
@@ -131,10 +131,8 @@ const Oppsummering: FunctionComponent<Props> = (props) => {
                             {!erEndringssøknad && (
                                 <BoIUtlandetOppsummeringspunkt
                                     onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.UTENLANDSOPPHOLD)}
-                                    tidligereUtenlandsopphold={
-                                        tidligereUtenlandsopphold?.utenlandsoppholdSiste12Mnd ?? []
-                                    }
-                                    senereUtenlandsopphold={senereUtenlandsopphold?.utenlandsoppholdNeste12Mnd ?? []}
+                                    tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
+                                    senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                                 />
                             )}
                         </OppsummeringPanel.Punkt>

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './SenereUtenlandsoppholdSteg.stories';
 
@@ -36,15 +37,13 @@ describe('<SenereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdNeste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_SENERE,
             type: 'update',
         });

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
@@ -6,7 +6,6 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import { UtenlandsoppholdSenere } from '@navikt/fp-types';
 
 import * as stories from './SenereUtenlandsoppholdSteg.stories';
 
@@ -45,7 +44,7 @@ describe('<SenereUtenlandsoppholdSteg>', () => {
                         tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
                     },
                 ],
-            } satisfies UtenlandsoppholdSenere,
+            },
             key: ContextDataType.UTENLANDSOPPHOLD_SENERE,
             type: 'update',
         });

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -43,7 +43,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <SenereUtenlandsoppholdPanel
-                senereUtenlandsopphold={{ utenlandsoppholdNeste12Mnd: senereUtenlandsopphold ?? [] }}
+                senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 cancelApplication={avbrytSøknad}

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { SenereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { Arbeidsforhold, UtenlandsoppholdSenere } from '@navikt/fp-types';
+import { Arbeidsforhold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 
 type Props = {
@@ -27,7 +27,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
 
     const oppdaterSenereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
 
-    const save = (values: UtenlandsoppholdSenere) => {
+    const save = (values: UtenlandsoppholdPeriode[]) => {
         oppdaterSenereUtenlandsopphold(values);
 
         return navigator.goToNextDefaultStep();
@@ -43,7 +43,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <SenereUtenlandsoppholdPanel
-                senereUtenlandsopphold={senereUtenlandsopphold}
+                senereUtenlandsopphold={{ utenlandsoppholdNeste12Mnd: senereUtenlandsopphold ?? [] }}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 cancelApplication={avbrytSøknad}

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './TidligereUtenlandsoppholdSteg.stories';
 
@@ -36,15 +37,13 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdSiste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });
@@ -85,15 +84,13 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdSiste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
@@ -6,7 +6,6 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import { UtenlandsoppholdTidligere } from '@navikt/fp-types';
 
 import * as stories from './TidligereUtenlandsoppholdSteg.stories';
 
@@ -45,7 +44,7 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
                         tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
                     },
                 ],
-            } satisfies UtenlandsoppholdTidligere,
+            },
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });
@@ -94,7 +93,7 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
                         tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
                     },
                 ],
-            } satisfies UtenlandsoppholdTidligere,
+            },
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -48,7 +48,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <TidligereUtenlandsoppholdPanel
-                tidligereUtenlandsopphold={{ utenlandsoppholdSiste12Mnd: tidligereUtenlandsopphold ?? [] }}
+                tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 cancelApplication={avbrytSøknad}

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { TidligereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { Arbeidsforhold, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { Arbeidsforhold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
@@ -29,7 +29,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
     const tidligereUtenlandsopphold = useContextGetData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     const oppdaterTidligereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
 
-    const save = (values: UtenlandsoppholdTidligere) => {
+    const save = (values: UtenlandsoppholdPeriode[]) => {
         oppdaterTidligereUtenlandsopphold(values);
 
         const nesteSide = utenlandsopphold.skalBoUtenforNorgeNeste12Mnd
@@ -48,7 +48,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <TidligereUtenlandsoppholdPanel
-                tidligereUtenlandsopphold={tidligereUtenlandsopphold}
+                tidligereUtenlandsopphold={{ utenlandsoppholdSiste12Mnd: tidligereUtenlandsopphold ?? [] }}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 cancelApplication={avbrytSøknad}

--- a/apps/foreldrepengesoknad/src/types/Søknad.ts
+++ b/apps/foreldrepengesoknad/src/types/Søknad.ts
@@ -11,8 +11,7 @@ import {
     Dekningsgrad,
     InformasjonOmUtenlandsoppholdDTO,
     Utenlandsopphold,
-    UtenlandsoppholdSenere,
-    UtenlandsoppholdTidligere,
+    UtenlandsoppholdPeriode,
 } from '@navikt/fp-types';
 
 export interface Søknad {
@@ -26,8 +25,8 @@ export interface Søknad {
     frilans: Frilans;
     andreInntektskilder: AndreInntektskilder[];
     utenlandsopphold: Utenlandsopphold;
-    utenlandsoppholdNeste12Mnd: UtenlandsoppholdSenere;
-    utenlandsoppholdSiste12Mnd: UtenlandsoppholdTidligere;
+    utenlandsoppholdNeste12Mnd: UtenlandsoppholdPeriode[];
+    utenlandsoppholdSiste12Mnd: UtenlandsoppholdPeriode[];
     erEndringssøknad: boolean;
     dekningsgrad: Dekningsgrad;
     uttaksplan: Periode[];

--- a/apps/foreldrepengesoknad/src/utils/mellomlagringUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/mellomlagringUtils.ts
@@ -1,7 +1,7 @@
 import { FpMellomlagretData } from 'api/api';
 import SøknadRoutes from 'appData/routes';
 
-export const MELLOMLAGRET_VERSJON = 12;
+export const MELLOMLAGRET_VERSJON = 13;
 
 const isEndringssøknadRoute = (route: SøknadRoutes): boolean => {
     switch (route) {

--- a/apps/svangerskapspengesoknad/src/app-data/SvpDataContext.tsx
+++ b/apps/svangerskapspengesoknad/src/app-data/SvpDataContext.tsx
@@ -6,7 +6,7 @@ import Tilrettelegging from 'types/Tilrettelegging';
 import { ArbeidsforholdOgInntektSvp } from '@navikt/fp-steg-arbeidsforhold-og-inntekt';
 import { EgenNæring } from '@navikt/fp-steg-egen-naering';
 import { Frilans } from '@navikt/fp-steg-frilans';
-import { Utenlandsopphold, UtenlandsoppholdSenere, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import SøknadRoutes from './routes';
 
@@ -28,8 +28,8 @@ export type ContextDataMap = {
     [ContextDataType.APP_ROUTE]?: SøknadRoutes;
     [ContextDataType.OM_BARNET]?: Barn;
     [ContextDataType.UTENLANDSOPPHOLD]?: Utenlandsopphold;
-    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdSenere;
-    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdTidligere;
+    [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdPeriode[];
+    [ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE]?: UtenlandsoppholdPeriode[];
     [ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT]?: ArbeidsforholdOgInntektSvp;
     [ContextDataType.FRILANS]?: Frilans;
     [ContextDataType.ARBEID_I_UTLANDET]?: ArbeidIUtlandet;

--- a/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -8,7 +8,7 @@ import { Kvittering, LocaleNo } from '@navikt/fp-types';
 
 import { ContextDataMap, ContextDataType, useContextComplete, useContextReset } from './SvpDataContext';
 
-export const VERSJON_MELLOMLAGRING = 2;
+export const VERSJON_MELLOMLAGRING = 3;
 
 const FEIL_VED_INNSENDING =
     'Det har oppstått et problem med innsending av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil id: ';

--- a/apps/svangerskapspengesoknad/src/steps/oppsummering/Oppsummering.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/oppsummering/Oppsummering.tsx
@@ -92,8 +92,8 @@ const Oppsummering: React.FunctionComponent<Props> = ({
                 </FormSummary>
                 <BoIUtlandetOppsummeringspunkt
                     onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.UTENLANDSOPPHOLD)}
-                    tidligereUtenlandsopphold={utenlandsoppholdTidligere?.utenlandsoppholdSiste12Mnd ?? []}
-                    senereUtenlandsopphold={utenlandsoppholdSenere?.utenlandsoppholdNeste12Mnd ?? []}
+                    tidligereUtenlandsopphold={utenlandsoppholdTidligere ?? []}
+                    senereUtenlandsopphold={utenlandsoppholdSenere ?? []}
                 />
                 <ArbeidsforholdOppsummering
                     arbeidsforhold={aktiveArbeidsforhold}

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './SenereUtenlandsoppholdSteg.stories';
 
@@ -36,15 +37,13 @@ describe('<SenereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdNeste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().add(1, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().add(20, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_SENERE,
             type: 'update',
         });

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { SenereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { Arbeidsforhold, UtenlandsoppholdSenere } from '@navikt/fp-types';
+import { Arbeidsforhold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 
 type Props = {
@@ -27,7 +27,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
 
     const oppdaterSenereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
 
-    const save = (values: UtenlandsoppholdSenere) => {
+    const save = (values: UtenlandsoppholdPeriode[]) => {
         oppdaterSenereUtenlandsopphold(values);
         return navigator.goToNextDefaultStep();
     };
@@ -42,7 +42,7 @@ const SenereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <SenereUtenlandsoppholdPanel
-                senereUtenlandsopphold={senereUtenlandsopphold}
+                senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 onStepChange={navigator.goToNextStep}

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.test.tsx
@@ -6,6 +6,7 @@ import SøknadRoutes from 'appData/routes';
 import dayjs from 'dayjs';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import * as stories from './TidligereUtenlandsoppholdSteg.stories';
 
@@ -36,15 +37,13 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdSiste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });
@@ -85,15 +84,13 @@ describe('<TidligereUtenlandsoppholdSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
-            data: {
-                utenlandsoppholdSiste12Mnd: [
-                    {
-                        landkode: 'CA',
-                        fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
-                        tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
-            },
+            data: [
+                {
+                    landkode: 'CA',
+                    fom: dayjs().subtract(30, 'day').format(ISO_DATE_FORMAT),
+                    tom: dayjs().subtract(25, 'day').format(ISO_DATE_FORMAT),
+                },
+            ] satisfies UtenlandsoppholdPeriode[],
             key: ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
             type: 'update',
         });

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading } from '@navikt/ds-react';
 
 import { TidligereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
-import { Arbeidsforhold, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { Arbeidsforhold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { ContentWrapper } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
@@ -29,7 +29,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
     const tidligereUtenlandsopphold = useContextGetData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     const oppdaterTidligereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
 
-    const save = (values: UtenlandsoppholdTidligere) => {
+    const save = (values: UtenlandsoppholdPeriode[]) => {
         oppdaterTidligereUtenlandsopphold(values);
 
         const nesteSide = utenlandsopphold.skalBoUtenforNorgeNeste12Mnd
@@ -48,7 +48,7 @@ const TidligereUtenlandsoppholdSteg: React.FunctionComponent<Props> = ({
                 <FormattedMessage id="søknad.pageheading" />
             </Heading>
             <TidligereUtenlandsoppholdPanel
-                tidligereUtenlandsopphold={tidligereUtenlandsopphold}
+                tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
                 saveOnNext={save}
                 saveOnPrevious={saveOnPrevious}
                 onStepChange={navigator.goToNextStep}

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.stories.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.stories.tsx
@@ -17,6 +17,7 @@ export const Default: Story = {
         goToPreviousStep: action('button-click'),
         onStepChange: action('button-click'),
         saveOnPrevious: action('button-click'),
+        senereUtenlandsopphold: [],
         stepConfig: [
             {
                 id: 'UTENLANDSOPPHOLD_PATH',

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from '@navikt/aksel-icons';
-import { Fragment, useCallback, useMemo } from 'react';
+import { Fragment, useCallback } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
@@ -11,7 +11,7 @@ import { HorizontalLine, ProgressStep, Step } from '@navikt/fp-ui';
 
 import SenereUtenlandsoppholdPeriode from './SenereUtenlandsoppholdPeriode';
 
-type UtenlandsoppholdSenere = {
+type FormType = {
     utenlandsoppholdNeste12Mnd: UtenlandsoppholdPeriode[];
 };
 
@@ -21,14 +21,10 @@ const DEFAULT_PERIODE = {
     landkode: '',
 } satisfies UtenlandsoppholdPeriode;
 
-const DEFAULT_FORM_VALUES = {
-    utenlandsoppholdNeste12Mnd: [DEFAULT_PERIODE],
-} satisfies UtenlandsoppholdSenere;
-
 export interface Props<TYPE> {
-    senereUtenlandsopphold?: UtenlandsoppholdSenere;
+    senereUtenlandsopphold: UtenlandsoppholdPeriode[];
     saveOnNext: (formValues: UtenlandsoppholdPeriode[]) => void;
-    saveOnPrevious: (formValues: UtenlandsoppholdSenere | undefined) => void;
+    saveOnPrevious: (formValues: UtenlandsoppholdPeriode[]) => void;
     onStepChange?: (id: TYPE) => void;
     cancelApplication: () => void;
     onContinueLater?: () => void;
@@ -46,9 +42,11 @@ const SenereUtenlandsoppholdPanel = <TYPE extends string>({
     senereUtenlandsopphold,
     stepConfig,
 }: Props<TYPE>) => {
-    const defaultValues = useMemo(() => senereUtenlandsopphold || DEFAULT_FORM_VALUES, [senereUtenlandsopphold]);
-    const formMethods = useForm<UtenlandsoppholdSenere>({
-        defaultValues,
+    const formMethods = useForm<FormType>({
+        defaultValues: {
+            utenlandsoppholdNeste12Mnd:
+                senereUtenlandsopphold.length === 0 ? [DEFAULT_PERIODE] : senereUtenlandsopphold,
+        },
     });
     const { fields, append, remove } = useFieldArray({
         name: 'utenlandsoppholdNeste12Mnd',
@@ -86,9 +84,9 @@ const SenereUtenlandsoppholdPanel = <TYPE extends string>({
                             <FormattedMessage id="SenereUtenlandsoppholdSteg.Knapp.LeggTilLand" />
                         </Button>
                     </VStack>
-                    <StepButtonsHookForm<UtenlandsoppholdSenere>
+                    <StepButtonsHookForm<FormType>
                         goToPreviousStep={goToPreviousStep}
-                        saveDataOnPreviousClick={saveOnPrevious}
+                        saveDataOnPreviousClick={(values) => saveOnPrevious(values.utenlandsoppholdNeste12Mnd)}
                     />
                 </VStack>
             </RhfForm>

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-senere/SenereUtenlandsoppholdPanel.tsx
@@ -6,24 +6,28 @@ import { FormattedMessage } from 'react-intl';
 import { Button, VStack } from '@navikt/ds-react';
 
 import { ErrorSummaryHookForm, RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
-import { UtenlandsoppholdPeriode, UtenlandsoppholdSenere } from '@navikt/fp-types';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { HorizontalLine, ProgressStep, Step } from '@navikt/fp-ui';
 
 import SenereUtenlandsoppholdPeriode from './SenereUtenlandsoppholdPeriode';
+
+type UtenlandsoppholdSenere = {
+    utenlandsoppholdNeste12Mnd: UtenlandsoppholdPeriode[];
+};
 
 const DEFAULT_PERIODE = {
     fom: '',
     tom: '',
     landkode: '',
-} as UtenlandsoppholdPeriode;
+} satisfies UtenlandsoppholdPeriode;
 
 const DEFAULT_FORM_VALUES = {
     utenlandsoppholdNeste12Mnd: [DEFAULT_PERIODE],
-} as UtenlandsoppholdSenere;
+} satisfies UtenlandsoppholdSenere;
 
 export interface Props<TYPE> {
     senereUtenlandsopphold?: UtenlandsoppholdSenere;
-    saveOnNext: (formValues: UtenlandsoppholdSenere) => void;
+    saveOnNext: (formValues: UtenlandsoppholdPeriode[]) => void;
     saveOnPrevious: (formValues: UtenlandsoppholdSenere | undefined) => void;
     onStepChange?: (id: TYPE) => void;
     cancelApplication: () => void;
@@ -62,7 +66,7 @@ const SenereUtenlandsoppholdPanel = <TYPE extends string>({
             steps={stepConfig}
             onStepChange={onStepChange}
         >
-            <RhfForm formMethods={formMethods} onSubmit={saveOnNext}>
+            <RhfForm formMethods={formMethods} onSubmit={(values) => saveOnNext(values.utenlandsoppholdNeste12Mnd)}>
                 <VStack gap="10">
                     <ErrorSummaryHookForm />
                     <VStack gap="10" align="start">

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.stories.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.stories.tsx
@@ -17,6 +17,7 @@ export const Default: Story = {
         goToPreviousStep: action('button-click'),
         onStepChange: action('button-click'),
         saveOnPrevious: action('button-click'),
+        tidligereUtenlandsopphold: [],
         stepConfig: [
             {
                 id: 'UTENLANDSOPPHOLD_PATH',

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.tsx
@@ -6,24 +6,28 @@ import { FormattedMessage } from 'react-intl';
 import { Button, VStack } from '@navikt/ds-react';
 
 import { ErrorSummaryHookForm, RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
-import { UtenlandsoppholdPeriode, UtenlandsoppholdTidligere } from '@navikt/fp-types';
+import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { HorizontalLine, ProgressStep, Step } from '@navikt/fp-ui';
 
 import TidligereUtenlandsoppholdPeriode from './TidligereUtenlandsoppholdPeriode';
+
+type UtenlandsoppholdTidligere = {
+    utenlandsoppholdSiste12Mnd: UtenlandsoppholdPeriode[];
+};
 
 const DEFAULT_PERIODE = {
     fom: '',
     tom: '',
     landkode: '',
-} as UtenlandsoppholdPeriode;
+} satisfies UtenlandsoppholdPeriode;
 
 const DEFAULT_FORM_VALUES = {
     utenlandsoppholdSiste12Mnd: [DEFAULT_PERIODE],
-} as UtenlandsoppholdTidligere;
+} satisfies UtenlandsoppholdTidligere;
 
 export interface Props<TYPE> {
     tidligereUtenlandsopphold?: UtenlandsoppholdTidligere;
-    saveOnNext: (formValues: UtenlandsoppholdTidligere) => void;
+    saveOnNext: (formValues: UtenlandsoppholdPeriode[]) => void;
     saveOnPrevious: (data: UtenlandsoppholdTidligere | undefined) => void;
     onStepChange?: (id: TYPE) => void;
     cancelApplication: () => void;
@@ -68,7 +72,7 @@ const TidligereUtenlandsoppholdPanel = <TYPE extends string>({
             steps={stepConfig}
             onStepChange={onStepChange}
         >
-            <RhfForm formMethods={formMethods} onSubmit={saveOnNext}>
+            <RhfForm formMethods={formMethods} onSubmit={(values) => saveOnNext(values.utenlandsoppholdSiste12Mnd)}>
                 <VStack gap="10">
                     <ErrorSummaryHookForm />
                     <VStack gap="10" align="start">

--- a/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.tsx
+++ b/packages/steg-utenlandsopphold/src/utenlandsopphold-tidligere/TidligereUtenlandsoppholdPanel.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from '@navikt/aksel-icons';
-import { Fragment, useCallback, useMemo } from 'react';
+import { Fragment, useCallback } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
@@ -11,7 +11,7 @@ import { HorizontalLine, ProgressStep, Step } from '@navikt/fp-ui';
 
 import TidligereUtenlandsoppholdPeriode from './TidligereUtenlandsoppholdPeriode';
 
-type UtenlandsoppholdTidligere = {
+type FormType = {
     utenlandsoppholdSiste12Mnd: UtenlandsoppholdPeriode[];
 };
 
@@ -21,14 +21,10 @@ const DEFAULT_PERIODE = {
     landkode: '',
 } satisfies UtenlandsoppholdPeriode;
 
-const DEFAULT_FORM_VALUES = {
-    utenlandsoppholdSiste12Mnd: [DEFAULT_PERIODE],
-} satisfies UtenlandsoppholdTidligere;
-
 export interface Props<TYPE> {
-    tidligereUtenlandsopphold?: UtenlandsoppholdTidligere;
+    tidligereUtenlandsopphold: UtenlandsoppholdPeriode[];
     saveOnNext: (formValues: UtenlandsoppholdPeriode[]) => void;
-    saveOnPrevious: (data: UtenlandsoppholdTidligere | undefined) => void;
+    saveOnPrevious: (data: UtenlandsoppholdPeriode[]) => void;
     onStepChange?: (id: TYPE) => void;
     cancelApplication: () => void;
     onContinueLater?: () => void;
@@ -46,9 +42,11 @@ const TidligereUtenlandsoppholdPanel = <TYPE extends string>({
     goToPreviousStep,
     stepConfig,
 }: Props<TYPE>) => {
-    const defaultValues = useMemo(() => tidligereUtenlandsopphold || DEFAULT_FORM_VALUES, [tidligereUtenlandsopphold]);
-    const formMethods = useForm<UtenlandsoppholdTidligere>({
-        defaultValues,
+    const formMethods = useForm<FormType>({
+        defaultValues: {
+            utenlandsoppholdSiste12Mnd:
+                tidligereUtenlandsopphold.length === 0 ? [DEFAULT_PERIODE] : tidligereUtenlandsopphold,
+        },
     });
     const { fields, append, remove } = useFieldArray({
         name: 'utenlandsoppholdSiste12Mnd',
@@ -92,9 +90,9 @@ const TidligereUtenlandsoppholdPanel = <TYPE extends string>({
                             <FormattedMessage id="TidligereUtenlandsoppholdSteg.Knapp.LeggTilLand" />
                         </Button>
                     </VStack>
-                    <StepButtonsHookForm<UtenlandsoppholdTidligere>
+                    <StepButtonsHookForm<FormType>
                         goToPreviousStep={goToPreviousStep}
-                        saveDataOnPreviousClick={saveOnPrevious}
+                        saveDataOnPreviousClick={(values) => saveOnPrevious(values.utenlandsoppholdSiste12Mnd)}
                     />
                 </VStack>
             </RhfForm>

--- a/packages/steg-utenlandsopphold/src/utils.ts
+++ b/packages/steg-utenlandsopphold/src/utils.ts
@@ -1,9 +1,4 @@
-import {
-    Utenlandsopphold,
-    UtenlandsoppholdPeriode,
-    UtenlandsoppholdSenere,
-    UtenlandsoppholdTidligere,
-} from '@navikt/fp-types';
+import { Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 const mapBostedUtlandTilDTO = (utenlandsopphold: UtenlandsoppholdPeriode) => {
     return {
@@ -17,13 +12,13 @@ const mapBostedUtlandTilDTO = (utenlandsopphold: UtenlandsoppholdPeriode) => {
 
 export const mapUtenlandsOppholdForInnsending = (
     utenlandsopphold: Utenlandsopphold,
-    senereUtenlandsopphold?: UtenlandsoppholdSenere,
-    tidligereUtenlandsopphold?: UtenlandsoppholdTidligere,
+    senereUtenlandsopphold?: UtenlandsoppholdPeriode[],
+    tidligereUtenlandsopphold?: UtenlandsoppholdPeriode[],
 ) => {
     return {
         iNorgeSiste12Mnd: !utenlandsopphold.harBoddUtenforNorgeSiste12Mnd,
         iNorgeNeste12Mnd: !utenlandsopphold.skalBoUtenforNorgeNeste12Mnd,
-        tidligereOpphold: (tidligereUtenlandsopphold?.utenlandsoppholdSiste12Mnd ?? []).map(mapBostedUtlandTilDTO),
-        senereOpphold: (senereUtenlandsopphold?.utenlandsoppholdNeste12Mnd ?? []).map(mapBostedUtlandTilDTO),
+        tidligereOpphold: (tidligereUtenlandsopphold ?? []).map(mapBostedUtlandTilDTO),
+        senereOpphold: (senereUtenlandsopphold ?? []).map(mapBostedUtlandTilDTO),
     };
 };

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -35,8 +35,6 @@ export type {
     InformasjonOmUtenlandsoppholdDTO,
     Utenlandsopphold,
     UtenlandsoppholdPeriode,
-    UtenlandsoppholdSenere,
-    UtenlandsoppholdTidligere,
 } from './src/Utenlandsopphold';
 
 export type { Barn } from './src/Barn';

--- a/packages/types/src/Utenlandsopphold.ts
+++ b/packages/types/src/Utenlandsopphold.ts
@@ -10,14 +10,6 @@ export type UtenlandsoppholdPeriode = {
     landkode: string;
 };
 
-export type UtenlandsoppholdSenere = {
-    utenlandsoppholdNeste12Mnd: UtenlandsoppholdPeriode[];
-};
-
-export type UtenlandsoppholdTidligere = {
-    utenlandsoppholdSiste12Mnd: UtenlandsoppholdPeriode[];
-};
-
 // API representasjon
 type UtenlandsoppholdDTO = {
     land: string;


### PR DESCRIPTION
Endret type for utenlandsopphold til å være en ren liste av perioder. Det er kun Form-komponenten som fremdeles forholder seg til det nøstede objektet. Fra utsiden forholder man seg kun til liste av perioder