### PR TITLE
Ny tekst for kontonummer

### DIFF
--- a/apps/foreldrepengeoversikt/src/app/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.tsx
@@ -5,12 +5,11 @@ import { BodyShort, HStack, Heading, VStack } from '@navikt/ds-react';
 
 import { formatDate, formatTime } from '@navikt/fp-utils';
 
+import { KontonummerInfo } from 'app/components/kontonummer-info/KontonummerInfo';
 import DokumentHendelse from 'app/sections/tidslinje/DokumentHendelse';
 import Bankkonto from 'app/types/Bankkonto';
 import { Tidslinjehendelse } from 'app/types/Tidslinjehendelse';
 import { Ytelse } from 'app/types/Ytelse';
-
-import KontonummerInfo from '../kontonummer-info/KontonummerInfo';
 
 interface Props {
     relevantNyTidslinjehendelse: Tidslinjehendelse | undefined;

--- a/apps/foreldrepengeoversikt/src/app/components/breadcrumb/Breadcrumb.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/breadcrumb/Breadcrumb.tsx
@@ -1,14 +1,11 @@
 import { onBreadcrumbClick, setBreadcrumbs } from '@navikt/nav-dekoratoren-moduler';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import { assertUnreachable } from '@navikt/fp-validation';
 
+import { useGetSelectedRoute } from 'app/hooks/useSelectedRoute';
 import { useGetSelectedSak } from 'app/hooks/useSelectedSak';
 import OversiktRoutes from 'app/routes/routes';
-
-type Props = {
-    selectedRoute: OversiktRoutes;
-};
 
 const minSide = {
     title: 'Min side',
@@ -96,7 +93,8 @@ const getRoute = (route: string, saksnummer: string | undefined): string => {
     return route;
 };
 
-const Breadcrumb: React.FunctionComponent<Props> = ({ selectedRoute }) => {
+export const Breadcrumb = () => {
+    const selectedRoute = useGetSelectedRoute();
     const breadcrumbs = getBreadcrumbs(selectedRoute);
     const navigate = useNavigate();
     const sak = useGetSelectedSak();
@@ -109,7 +107,5 @@ const Breadcrumb: React.FunctionComponent<Props> = ({ selectedRoute }) => {
         navigate(breadcrumb.url);
     });
 
-    return null;
+    return <Outlet />;
 };
-
-export default Breadcrumb;

--- a/apps/foreldrepengeoversikt/src/app/components/header/Header.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/header/Header.tsx
@@ -82,7 +82,6 @@ function BabyIkon({ ytelse }: { ytelse: Ytelse | undefined }) {
 }
 
 export function ForsideHeader() {
-    console.log('header');
     return (
         <HeaderWrapper>
             <HGrid columns="max-content 1fr" gap="6" align="start">

--- a/apps/foreldrepengeoversikt/src/app/components/header/Header.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/header/Header.tsx
@@ -7,7 +7,6 @@ import { useParams } from 'react-router-dom';
 import { Detail, HGrid, HStack, Heading, Show, VStack } from '@navikt/ds-react';
 
 import { hentSakerOptions, søkerInfoOptions } from 'app/api/api';
-import { useGetSelectedRoute } from 'app/hooks/useSelectedRoute';
 import { LayoutWrapper } from 'app/sections/LayoutWrapper';
 import { Sak } from 'app/types/Sak';
 import { Ytelse } from 'app/types/Ytelse';
@@ -19,7 +18,6 @@ import {
     utledFamiliesituasjon,
 } from 'app/utils/sakerUtils';
 
-import Breadcrumb from '../breadcrumb/Breadcrumb';
 import StatusTag from '../status-tag/StatusTag';
 
 export const getSaksoversiktHeading = (ytelse: Ytelse | undefined) => {
@@ -35,20 +33,16 @@ export const getSaksoversiktHeading = (ytelse: Ytelse | undefined) => {
 };
 
 function HeaderWrapper({ children }: { children: ReactNode }) {
-    const selectedRoute = useGetSelectedRoute();
     return (
         <div className={`bg-bg-default border-b-2 border-deepblue-200 mb-8`}>
-            <Breadcrumb selectedRoute={selectedRoute} />
             <LayoutWrapper className="pt-1 pb-6 pl-4 pr-4">{children}</LayoutWrapper>
         </div>
     );
 }
 
 function SimpleHeaderWrapper({ children }: { children: ReactNode }) {
-    const selectedRoute = useGetSelectedRoute();
     return (
         <div className={`bg-bg-default`}>
-            <Breadcrumb selectedRoute={selectedRoute} />
             <LayoutWrapper className="pt-1 pb-6 pl-4 pr-4">{children}</LayoutWrapper>
         </div>
     );
@@ -88,6 +82,7 @@ function BabyIkon({ ytelse }: { ytelse: Ytelse | undefined }) {
 }
 
 export function ForsideHeader() {
+    console.log('header');
     return (
         <HeaderWrapper>
             <HGrid columns="max-content 1fr" gap="6" align="start">

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react/*';
 
+import { KontonummerInfo } from 'app/components/kontonummer-info/KontonummerInfo';
 import { Ytelse } from 'app/types/Ytelse';
-
-import KontonummerInfo from './KontonummerInfo';
 
 const meta = {
     title: 'KontonummerInfo',

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
@@ -1,4 +1,4 @@
-import { Accordion, BodyShort, Detail, Link, VStack } from '@navikt/ds-react';
+import { Accordion, BodyLong, BodyShort, Button, Detail, Link, VStack } from '@navikt/ds-react';
 
 import { links } from '@navikt/fp-constants';
 
@@ -17,44 +17,77 @@ const getKontonummerTittel = (ytelse: Ytelse | undefined) => {
     return 'KONTONUMMER';
 };
 
-const getKontonummerInfoTekst = (harKontonummer: boolean, ytelse: Ytelse | undefined) => {
-    if (!harKontonummer) {
-        return 'Hvis søknaden din blir innvilget, må du ha kontonummer registrert for å motta utbetaling fra NAV.';
-    }
-    if (harKontonummer && ytelse === Ytelse.ENGANGSSTØNAD) {
-        return 'NAV vil utbetale engangsstønaden til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du endre det.';
-    }
-    if (harKontonummer && ytelse === Ytelse.FORELDREPENGER) {
-        return 'NAV vil utbetale foreldrepengene til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du endre det.';
-    }
-    if (harKontonummer && ytelse === Ytelse.SVANGERSKAPSPENGER) {
-        return 'NAV vil utbetale svangerskapspengene til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du endre det.';
-    }
-    return 'NAV vil utbetale til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du endre det.';
-};
-
 const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, ytelse }) => {
     const harKontonummer = !!bankkonto?.kontonummer && bankkonto?.kontonummer.trim().length > 0;
+    console.log(bankkonto);
     const kontonummerTittel = getKontonummerTittel(ytelse);
     const kontonummerTekst = harKontonummer ? bankkonto?.kontonummer : 'Du har ikke kontonummer registrert hos NAV. ';
-    const kontonummerInfoTekst = getKontonummerInfoTekst(harKontonummer, ytelse);
     const kontonummerEndreTekst = harKontonummer ? 'Endre kontonummer' : 'Registrer kontonummer';
 
     return (
-        <Accordion>
+        <Accordion headingSize="small" size="large">
             <Accordion.Item title={kontonummerTittel}>
                 <Accordion.Header>
-                    <Detail>{kontonummerTittel}</Detail>
-                    <BodyShort>{kontonummerTekst}</BodyShort>
+                    <Detail textColor="subtle">{kontonummerTittel}</Detail>
+                    <BodyShort size="large" weight="semibold">
+                        {kontonummerTekst}
+                    </BodyShort>
                 </Accordion.Header>
                 <Accordion.Content>
-                    <VStack gap="7">
-                        <BodyShort>{kontonummerInfoTekst}</BodyShort>
-                        <Link href={links.brukerprofil}>{kontonummerEndreTekst}</Link>
+                    <VStack gap="4">
+                        <KontonummerInfoTekst harKontonummer={harKontonummer} ytelse={ytelse} />
+                        <Button
+                            size="small"
+                            className="w-fit no-underline"
+                            variant="secondary"
+                            as={Link}
+                            href={links.brukerprofil}
+                        >
+                            {kontonummerEndreTekst}
+                        </Button>
                     </VStack>
                 </Accordion.Content>
             </Accordion.Item>
         </Accordion>
+    );
+};
+
+const KontonummerInfoTekst = ({ harKontonummer, ytelse }: { harKontonummer: boolean; ytelse: Ytelse | undefined }) => {
+    if (!harKontonummer) {
+        return (
+            <>
+                <BodyLong size="small">
+                    Arbeidsgiveren din vil opplyse i inntektsmeldingen om de betaler deg eller om du får utbetalt fra
+                    NAV.
+                </BodyLong>
+                <BodyLong size="small">
+                    Hvis du får utbetaling direkte fra NAV, vil NAV trenge et kontonummer for å utbetale foreldrepengene
+                    dine til deg.
+                </BodyLong>
+            </>
+        );
+    }
+    if (harKontonummer && ytelse === Ytelse.ENGANGSSTØNAD) {
+        return (
+            <BodyLong size="small">
+                NAV vil utbetale engangsstønaden til dette kontonummeret, hvis søknaden blir innvilget. Hvis
+                kontonummeret er feil kan du endre det.
+            </BodyLong>
+        );
+    }
+    if ((harKontonummer && ytelse === Ytelse.FORELDREPENGER) || ytelse === Ytelse.SVANGERSKAPSPENGER) {
+        return (
+            <BodyLong size="small">
+                Arbeidsgiveren din vil opplyse i inntektsmeldingen om de betaler deg eller om du får utbetalt fra NAV.
+                Hvis du får utbetaling direkte fra NAV, vil pengene komme til det registrerte kontonummeret.
+            </BodyLong>
+        );
+    }
+    return (
+        <BodyLong size="small">
+            NAV vil utbetale til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du
+            endre det.
+        </BodyLong>
     );
 };
 

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
@@ -16,13 +16,11 @@ export const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, yte
     const kontonummerEndreTekst = harKontonummer ? 'Endre kontonummer' : 'Registrer kontonummer';
 
     return (
-        <Accordion headingSize="small" size="large">
+        <Accordion>
             <Accordion.Item>
                 <Accordion.Header>
                     <Detail textColor="subtle">KONTONUMMER</Detail>
-                    <BodyShort size="large" weight="semibold">
-                        {kontonummerTekst}
-                    </BodyShort>
+                    <BodyShort weight="semibold">{kontonummerTekst}</BodyShort>
                 </Accordion.Header>
                 <Accordion.Content>
                     <VStack gap="4">

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
@@ -10,25 +10,16 @@ interface Props {
     ytelse: Ytelse | undefined;
 }
 
-const getKontonummerTittel = (ytelse: Ytelse | undefined) => {
-    if (ytelse === Ytelse.ENGANGSSTØNAD) {
-        return 'KONTONUMMER FOR UTBETALING';
-    }
-    return 'KONTONUMMER';
-};
-
-const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, ytelse }) => {
+export const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, ytelse }) => {
     const harKontonummer = !!bankkonto?.kontonummer && bankkonto?.kontonummer.trim().length > 0;
-    console.log(bankkonto);
-    const kontonummerTittel = getKontonummerTittel(ytelse);
-    const kontonummerTekst = harKontonummer ? bankkonto?.kontonummer : 'Du har ikke kontonummer registrert hos NAV. ';
+    const kontonummerTekst = harKontonummer ? bankkonto?.kontonummer : 'NAV mangler kontonummeret ditt';
     const kontonummerEndreTekst = harKontonummer ? 'Endre kontonummer' : 'Registrer kontonummer';
 
     return (
         <Accordion headingSize="small" size="large">
-            <Accordion.Item title={kontonummerTittel}>
+            <Accordion.Item>
                 <Accordion.Header>
-                    <Detail textColor="subtle">{kontonummerTittel}</Detail>
+                    <Detail textColor="subtle">KONTONUMMER</Detail>
                     <BodyShort size="large" weight="semibold">
                         {kontonummerTekst}
                     </BodyShort>
@@ -90,5 +81,3 @@ const KontonummerInfoTekst = ({ harKontonummer, ytelse }: { harKontonummer: bool
         </BodyLong>
     );
 };
-
-export default KontonummerInfo;

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
@@ -44,6 +44,22 @@ export const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, yte
 };
 
 const KontonummerInfoTekst = ({ harKontonummer, ytelse }: { harKontonummer: boolean; ytelse: Ytelse | undefined }) => {
+    if (ytelse === Ytelse.ENGANGSSTØNAD) {
+        if (harKontonummer) {
+            return (
+                <BodyLong size="small">
+                    Dette er kontonummeret NAV kommer til å betale engangsstønaden til, hvis søknaden blir innvilget.
+                    Hvis det er feil kan du endre det.
+                </BodyLong>
+            );
+        } else {
+            return (
+                <BodyLong size="small">
+                    NAV mangler kontonummeret som engangsstønaden vil bli betalt til hvis du får søknaden din innvilget.
+                </BodyLong>
+            );
+        }
+    }
     if (!harKontonummer) {
         return (
             <>
@@ -58,15 +74,8 @@ const KontonummerInfoTekst = ({ harKontonummer, ytelse }: { harKontonummer: bool
             </>
         );
     }
-    if (harKontonummer && ytelse === Ytelse.ENGANGSSTØNAD) {
-        return (
-            <BodyLong size="small">
-                NAV vil utbetale engangsstønaden til dette kontonummeret, hvis søknaden blir innvilget. Hvis
-                kontonummeret er feil kan du endre det.
-            </BodyLong>
-        );
-    }
-    if ((harKontonummer && ytelse === Ytelse.FORELDREPENGER) || ytelse === Ytelse.SVANGERSKAPSPENGER) {
+
+    if (ytelse === Ytelse.FORELDREPENGER || ytelse === Ytelse.SVANGERSKAPSPENGER) {
         return (
             <BodyLong size="small">
                 Arbeidsgiveren din vil opplyse i inntektsmeldingen om de betaler deg eller om du får utbetalt fra NAV.
@@ -74,6 +83,8 @@ const KontonummerInfoTekst = ({ harKontonummer, ytelse }: { harKontonummer: bool
             </BodyLong>
         );
     }
+
+    // Kan kun inntreffe dersom ytelse ikke er tilgjengelig fra saken.
     return (
         <BodyLong size="small">
             NAV vil utbetale til dette kontonummeret, hvis søknaden blir innvilget. Hvis kontonummeret er feil kan du

--- a/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
+++ b/apps/foreldrepengeoversikt/src/app/components/kontonummer-info/KontonummerInfo.tsx
@@ -19,8 +19,10 @@ export const KontonummerInfo: React.FunctionComponent<Props> = ({ bankkonto, yte
         <Accordion>
             <Accordion.Item>
                 <Accordion.Header>
-                    <Detail textColor="subtle">KONTONUMMER</Detail>
-                    <BodyShort weight="semibold">{kontonummerTekst}</BodyShort>
+                    <VStack gap="1">
+                        <Detail textColor="subtle">KONTONUMMER</Detail>
+                        <BodyShort weight="semibold">{kontonummerTekst}</BodyShort>
+                    </VStack>
                 </Accordion.Header>
                 <Accordion.Content>
                     <VStack gap="4">

--- a/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
+++ b/apps/foreldrepengeoversikt/src/app/routes/ForeldrepengeoversiktRoutes.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { Navigate, Outlet, Route, Routes, useMatch, useNavigate } from 'react-router-dom';
 
+import { Breadcrumb } from 'app/components/breadcrumb/Breadcrumb';
 import Snarveier from 'app/components/snarveier/Snarveier';
 import { default as SakComponent } from 'app/pages/Sak';
 import DinPlanPage from 'app/pages/din-plan-page/DinPlanPage';
@@ -29,26 +30,34 @@ const ForeldrepengeoversiktRoutes: React.FunctionComponent<Props> = ({ søkerinf
     return (
         <>
             <Routes>
-                <Route element={<RedirectTilSakHvisDetKunFinnesEn saker={saker} />}>
-                    <Route
-                        path={`${OversiktRoutes.HOVEDSIDE}/:redirect?`}
-                        element={<Forside saker={saker} isFirstRender={isFirstRender} søkerinfo={søkerinfo} />}
-                    />
-                    <Route path={`${OversiktRoutes.SAKSOVERSIKT}/:saksnummer/:redirect?`} element={<SakComponent />}>
-                        <Route index element={<Saksoversikt søkerinfo={søkerinfo} isFirstRender={isFirstRender} />} />
-                        <Route path={OversiktRoutes.DIN_PLAN} element={<DinPlanPage søkerinfo={søkerinfo} />} />
-                        <Route path={OversiktRoutes.DOKUMENTER} element={<DokumenterPage />} />
+                <Route element={<Breadcrumb />}>
+                    <Route element={<RedirectTilSakHvisDetKunFinnesEn saker={saker} />}>
                         <Route
-                            path={OversiktRoutes.TIDSLINJEN}
-                            element={<TidslinjePage søkersBarn={søkerinfo.søker.barn ?? []} />}
+                            path={`${OversiktRoutes.HOVEDSIDE}/:redirect?`}
+                            element={<Forside saker={saker} isFirstRender={isFirstRender} søkerinfo={søkerinfo} />}
                         />
                         <Route
-                            path={`${OversiktRoutes.OPPGAVER}/:oppgaveId`}
-                            element={<MinidialogPage fnr={søkerinfo.søker.fnr} />}
-                        />
-                        <Route path={OversiktRoutes.ETTERSEND} element={<EttersendingPage saker={saker} />} />
+                            path={`${OversiktRoutes.SAKSOVERSIKT}/:saksnummer/:redirect?`}
+                            element={<SakComponent />}
+                        >
+                            <Route
+                                index
+                                element={<Saksoversikt søkerinfo={søkerinfo} isFirstRender={isFirstRender} />}
+                            />
+                            <Route path={OversiktRoutes.DIN_PLAN} element={<DinPlanPage søkerinfo={søkerinfo} />} />
+                            <Route path={OversiktRoutes.DOKUMENTER} element={<DokumenterPage />} />
+                            <Route
+                                path={OversiktRoutes.TIDSLINJEN}
+                                element={<TidslinjePage søkersBarn={søkerinfo.søker.barn ?? []} />}
+                            />
+                            <Route
+                                path={`${OversiktRoutes.OPPGAVER}/:oppgaveId`}
+                                element={<MinidialogPage fnr={søkerinfo.søker.fnr} />}
+                            />
+                            <Route path={OversiktRoutes.ETTERSEND} element={<EttersendingPage saker={saker} />} />
+                        </Route>
+                        <Route path="*" element={<Navigate to={OversiktRoutes.HOVEDSIDE} />} />
                     </Route>
-                    <Route path="*" element={<Navigate to={OversiktRoutes.HOVEDSIDE} />} />
                 </Route>
             </Routes>
             <KontaktOss />


### PR DESCRIPTION
Oppdaterer tekst de forskjellige ytelsene om kontonr: https://trello.com/c/qiDmNzgM/201-ny-beskrivelse-av-kontonummer-n%C3%A5r-man-kommer-rett-fra-s%C3%B8knad-svp-og-fp

Endret samtidig slik at breadcrumbs kun settes ett sted som en Layout Route