### PR TITLE
sett base til ./ for deployete storybooks

### DIFF
--- a/apps/engangsstonad/.storybook/main.ts
+++ b/apps/engangsstonad/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/foreldrepengeoversikt/.storybook/main.ts
+++ b/apps/foreldrepengeoversikt/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/foreldrepengesoknad/.storybook/main.ts
+++ b/apps/foreldrepengesoknad/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/planlegger/.storybook/main.ts
+++ b/apps/planlegger/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/svangerskapspengesoknad/.storybook/main.ts
+++ b/apps/svangerskapspengesoknad/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/veiviser-fp-eller-es/.storybook/main.ts
+++ b/apps/veiviser-fp-eller-es/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/veiviser-hva-skjer-nar/.storybook/main.ts
+++ b/apps/veiviser-hva-skjer-nar/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],

--- a/apps/veiviser-hvor-mye/.storybook/main.ts
+++ b/apps/veiviser-hvor-mye/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    async viteFinal(c) {
+    async viteFinal(c, { configType }) {
         return mergeConfig(c, {
-            base: viteConfig.base,
+            base: configType === 'DEVELOPMENT' ? viteConfig.base : './',
         });
     },
     staticDirs: ['../../../scripts/mock-service-worker'],


### PR DESCRIPTION
Hadde ambisjon om å ikke måtte forholde oss til om det bygges for development eller production når vi setter base path. Viser seg at når storybook deployes så settes det en lenke i en iFrame som blir feil når base er relativt, og ikke "./".

Må derfor skille på om storybook kjører lokalt eller ikke