### PR TITLE
Fix: Vis alert kun når det finnes arbeidsforhold i oppsummeringen

### DIFF
--- a/packages/steg-oppsummering/src/arbeidsforhold/ArbeidsforholdOppsummering.tsx
+++ b/packages/steg-oppsummering/src/arbeidsforhold/ArbeidsforholdOppsummering.tsx
@@ -61,12 +61,14 @@ export const ArbeidsforholdOppsummering = ({
                             </FormSummary.Answers>
                         )}
                     </FormSummary.Value>
-                    <Alert variant="info" style={{ marginTop: 'var(--a-spacing-2)' }}>
-                        <FormattedMessage
-                            id="ArbeidsforholdOppsummering.inntektsmelding"
-                            values={{ antall: arbeidsforhold.length }}
-                        />
-                    </Alert>
+                    {arbeidsforhold.length > 0 && (
+                        <Alert variant="info" style={{ marginTop: 'var(--a-spacing-2)' }}>
+                            <FormattedMessage
+                                id="ArbeidsforholdOppsummering.inntektsmelding"
+                                values={{ antall: arbeidsforhold.length }}
+                            />
+                        </Alert>
+                    )}
                 </FormSummary.Answer>
                 <FormSummary.Answer>
                     <FormSummary.Label>


### PR DESCRIPTION
This pull request includes a minor change to the `ArbeidsforholdOppsummering` component in the `packages/steg-oppsummering` module. The change ensures that an alert message is only displayed when there are one or more `arbeidsforhold` items.

* [`packages/steg-oppsummering/src/arbeidsforhold/ArbeidsforholdOppsummering.tsx`](diffhunk://#diff-8e40205ec8d60bac5d9b6d183b93f68e2ccdd3a3bbd012c87dbad4e115e89c39R64-R71): Added a conditional rendering check to display an alert message only if `arbeidsforhold.length` is greater than 0.
Før:
![image](https://github.com/user-attachments/assets/1faa0dbc-64da-435d-a8f4-09779f2e6fe2)

Etter: 
![image](https://github.com/user-attachments/assets/4b7f8e99-d473-4f86-b3c1-9195db447130)
