### PR TITLE
fix: Fjern negativ margin og bakgrunnsfarge for CustomErrorformatter

### DIFF
--- a/apps/planlegger/src/utils/customErrorFormatter.tsx
+++ b/apps/planlegger/src/utils/customErrorFormatter.tsx
@@ -3,10 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                paddingLeft: 5,
-                paddingRight: 5,
-                paddingBottom: 5,
-                paddingTop: 5,
                 borderRadius: 4,
                 width: '100%',
             }}

--- a/apps/planlegger/src/utils/customErrorFormatter.tsx
+++ b/apps/planlegger/src/utils/customErrorFormatter.tsx
@@ -3,8 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                background: 'white',
-                marginLeft: 1000,
                 paddingLeft: 5,
                 paddingRight: 5,
                 paddingBottom: 5,

--- a/apps/veiviser-fp-eller-es/src/utils/customErrorFormatter.tsx
+++ b/apps/veiviser-fp-eller-es/src/utils/customErrorFormatter.tsx
@@ -3,10 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                paddingLeft: 5,
-                paddingRight: 5,
-                paddingBottom: 5,
-                paddingTop: 5,
                 borderRadius: 4,
                 width: '100%',
             }}

--- a/apps/veiviser-fp-eller-es/src/utils/customErrorFormatter.tsx
+++ b/apps/veiviser-fp-eller-es/src/utils/customErrorFormatter.tsx
@@ -3,8 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                background: 'white',
-                marginLeft: -18,
                 paddingLeft: 5,
                 paddingRight: 5,
                 paddingBottom: 5,

--- a/apps/veiviser-hvor-mye/src/utils/customErrorFormatter.tsx
+++ b/apps/veiviser-hvor-mye/src/utils/customErrorFormatter.tsx
@@ -3,10 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                paddingLeft: 5,
-                paddingRight: 5,
-                paddingBottom: 5,
-                paddingTop: 5,
                 borderRadius: 4,
                 width: '100%',
             }}

--- a/apps/veiviser-hvor-mye/src/utils/customErrorFormatter.tsx
+++ b/apps/veiviser-hvor-mye/src/utils/customErrorFormatter.tsx
@@ -3,8 +3,6 @@ export const formatError = (error?: string) => {
         <span
             role="alert"
             style={{
-                background: 'white',
-                marginLeft: -18,
                 paddingLeft: 5,
                 paddingRight: 5,
                 paddingBottom: 5,


### PR DESCRIPTION
This pull request includes changes to the `formatError` function across multiple files to improve the styling of error messages by removing unnecessary CSS properties.

Fjerner negativ margin slik at icon vises og bakgrunnsfarge droppes ved errormelding ved valideringsfeil

Styling improvements:

* [`apps/planlegger/src/utils/customErrorFormatter.tsx`](diffhunk://#diff-dc853e01fb0d72ae17159eef08383d0b3d6cb0f076b8e8017421cb86f059230fL6-L7): Removed `background` and `marginLeft` properties from the `style` object in the `formatError` function.
* [`apps/veiviser-fp-eller-es/src/utils/customErrorFormatter.tsx`](diffhunk://#diff-dc853e01fb0d72ae17159eef08383d0b3d6cb0f076b8e8017421cb86f059230fL6-L7): Removed `background` and `marginLeft` properties from the `style` object in the `formatError` function.
* [`apps/veiviser-hvor-mye/src/utils/customErrorFormatter.tsx`](diffhunk://#diff-dc853e01fb0d72ae17159eef08383d0b3d6cb0f076b8e8017421cb86f059230fL6-L7): Removed `background` and `marginLeft` properties from the `style` object in the `formatError` function.