### PR TITLE
fix: Vis endre plan-knapp kun når saken er avsluttet

### DIFF
--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
@@ -50,7 +50,7 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre }: Props) => {
 
     return (
         <VStack gap="10">
-            {sakAvsluttet && (
+            {!sakAvsluttet && (
                 <HStack>
                     <Button
                         className="mt-4"
@@ -62,6 +62,7 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre }: Props) => {
                     </Button>
                 </HStack>
             )}
+
             <VStack gap="10">
                 <ToggleGroup
                     defaultValue={visKalender ? 'kalender' : 'plan'}

--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
@@ -35,6 +35,7 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre }: Props) => {
     const sakTilhørerMor = gjeldendeSak.sakTilhørerMor;
     const gjelderAdopsjon = gjeldendeSak.gjelderAdopsjon;
     const rettighetType = gjeldendeSak.rettighetType;
+    const sakAvsluttet = gjeldendeSak.sakAvsluttet;
 
     const relevantePerioder = søkersPerioder ?? perioderSomErSøktOm ?? [];
     const søkerErFarEllerMedmor = !sakTilhørerMor;
@@ -49,16 +50,18 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre }: Props) => {
 
     return (
         <VStack gap="10">
-            <HStack>
-                <Button
-                    className="mt-4"
-                    size={isDesktop ? 'small' : 'medium'}
-                    variant="secondary"
-                    onClick={() => (window.location.href = 'https://www.nav.no/foreldrepenger/soknad')}
-                >
-                    <FormattedMessage id="DinPlan.EndrePlan" />
-                </Button>
-            </HStack>
+            {sakAvsluttet && (
+                <HStack>
+                    <Button
+                        className="mt-4"
+                        size={isDesktop ? 'small' : 'medium'}
+                        variant="secondary"
+                        onClick={() => (window.location.href = 'https://www.nav.no/foreldrepenger/soknad')}
+                    >
+                        <FormattedMessage id="DinPlan.EndrePlan" />
+                    </Button>
+                </HStack>
+            )}
             <VStack gap="10">
                 <ToggleGroup
                     defaultValue={visKalender ? 'kalender' : 'plan'}


### PR DESCRIPTION
This pull request includes changes to the `DinPlan` component in the `apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx` file. The changes introduce a new property to check if the case is closed and conditionally render a button based on this property.

Key changes:

* Added a new constant `sakAvsluttet` to check if the case is closed.
* Conditionally rendered a `Button` component that appears only when `sakAvsluttet` is true. [[1]](diffhunk://#diff-52cf9085d412b82f0551bb647188e9b34ea75a092ec40d15bafb51cc2fd710c4R53) [[2]](diffhunk://#diff-52cf9085d412b82f0551bb647188e9b34ea75a092ec40d15bafb51cc2fd710c4R64)