### PR TITLE
Forbedre kvote visning ved tapte tre uker

### DIFF
--- a/apps/foreldrepengeoversikt/src/sections/din-plan/KvoteOppsummering.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/KvoteOppsummering.tsx
@@ -57,6 +57,7 @@ const KvoterOversiktInner = ({ sak }: { sak: Foreldrepengesak }) => {
 
     return (
         <KvoteOppsummering
+            familiehendelse={sak.familiehendelse}
             konto={konto}
             perioder={aktuellePerioder}
             rettighetType={sak.rettighetType}


### PR DESCRIPTION
Dersom barnet er født går man rett over på mødrekvote. Derfor misvisende å vise at man har ubrukte dager på "fordeldrepenger før fødsel"-visningen