### PR TITLE
Fix: Lag workaround for å ikke vise 'foreldrepenger uten aktivitetskrav' ved farOgFar

### DIFF
--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -10,6 +10,7 @@ import { HvemHarRett, harMorRett, utledHvemSomHarRett } from 'utils/hvemHarRettU
 
 import { Loader } from '@navikt/ds-react';
 
+import { StønadskontoType } from '@navikt/fp-constants';
 import { LocaleAll, Satser, TilgjengeligeStønadskontoer } from '@navikt/fp-types';
 import { SimpleErrorPage } from '@navikt/fp-ui';
 import { decodeBase64 } from '@navikt/fp-utils';
@@ -102,9 +103,9 @@ export const PlanleggerDataFetcher = ({ locale, changeLocale }: Props) => {
                 if (stønadskonto?.kontoer) {
                     // Summer antall dager i alle kontoer
                     const totalDager = stønadskonto.kontoer.reduce((sum, konto) => sum + konto.dager, 0);
-                    // Filtrer og behold kun 'FORELDREPENGER' -kontoen
+                    // Filtrer og behold kun 'AKTIVITETSFRI_KVOTE' -kontoen
                     stønadskonto.kontoer = stønadskonto.kontoer
-                        .filter((konto) => konto.konto === 'FORELDREPENGER')
+                        .filter((konto) => konto.konto === StønadskontoType.AktivitetsfriKvote)
                         .map((konto) => ({ ...konto, dager: totalDager }));
                 }
             });

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -100,10 +100,14 @@ export const PlanleggerDataFetcher = ({ locale, changeLocale }: Props) => {
             dekningsgrader.forEach((dekningsgrad) => {
                 const stønadskonto = modifiserteData[dekningsgrad];
                 if (stønadskonto?.kontoer) {
-                    stønadskonto.kontoer = stønadskonto.kontoer.filter((konto) => konto.konto === 'FORELDREPENGER');
+                    // Summer antall dager i alle kontoer
+                    const totalDager = stønadskonto.kontoer.reduce((sum, konto) => sum + konto.dager, 0);
+                    // Filtrer og behold kun 'FORELDREPENGER' -kontoen
+                    stønadskonto.kontoer = stønadskonto.kontoer
+                        .filter((konto) => konto.konto === 'FORELDREPENGER')
+                        .map((konto) => ({ ...konto, dager: totalDager }));
                 }
             });
-
             return modifiserteData;
         },
     });

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -268,7 +268,16 @@ export const FarOgFarAdopsjonKunFar1HarRett: Story = {
             status: Arbeidsstatus.JOBBER,
             jobberAnnenPart: false,
         },
-        stønadskontoer: MorOgFarKunFarHarRett.args?.stønadskontoer,
+        stønadskontoer: {
+            '80': {
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 261 }],
+                minsteretter: MINSTERETTER_FAR_RUNDT_FØDSEL_10,
+            },
+            '100': {
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 200 }],
+                minsteretter: MINSTERETTER_FAR_RUNDT_FØDSEL_10,
+            },
+        },
     },
 };
 export const FarOgFarAdopsjonBeggeHarRett: Story = {
@@ -567,14 +576,14 @@ export const OppsummeringFarOgFarKunFar2HarRett: Story = {
         },
         stønadskontoer: {
             '80': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 291 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 291 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
                 },
             },
             '100': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 230 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 230 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,

--- a/apps/planlegger/src/steps/oppsummering/expansion-cards/OppsummeringHarRett.tsx
+++ b/apps/planlegger/src/steps/oppsummering/expansion-cards/OppsummeringHarRett.tsx
@@ -87,6 +87,7 @@ export const OppsummeringHarRett = ({
         startdato,
         erMorUfør: arbeidssituasjon?.status === Arbeidsstatus.UFØR,
         erAleneOmOmsorg: hvemPlanlegger.type === Situasjon.FAR || hvemPlanlegger.type === Situasjon.MOR,
+        farOgFar: hvemPlanlegger.type === Situasjon.FAR_OG_FAR,
     });
 
     const ukerOgDagerMedForeldrepenger = finnAntallUkerOgDagerMedForeldrepenger(valgtStønadskonto);

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
@@ -137,6 +137,7 @@ export const PlanenDeresSteg = ({ stønadskontoer, locale }: Props) => {
         erFarEllerMedmor: erFarEllerMedmor,
         erMorUfør: arbeidssituasjon?.status === Arbeidsstatus.UFØR,
         erAleneOmOmsorg: hvemPlanlegger.type === Situasjon.FAR || hvemPlanlegger.type === Situasjon.MOR,
+        farOgFar: hvemPlanlegger.type === Situasjon.FAR_OG_FAR,
     });
 
     const fornavnSøker1 = getFornavnPåSøker1(hvemPlanlegger, intl);

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.stories.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.stories.tsx
@@ -293,20 +293,14 @@ export const FarOgFarKunFarHarRett: Story = {
         },
         stønadskontoer: {
             '80': {
-                kontoer: [
-                    { konto: StønadskontoType.Foreldrepenger, dager: 211 },
-                    { konto: StønadskontoType.AktivitetsfriKvote, dager: 50 },
-                ],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 261 }],
                 minsteretter: {
                     farRundtFødsel: 0,
                     toTette: 0,
                 },
             },
             '100': {
-                kontoer: [
-                    { konto: StønadskontoType.Foreldrepenger, dager: 150 },
-                    { konto: StønadskontoType.AktivitetsfriKvote, dager: 50 },
-                ],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 200 }],
                 minsteretter: {
                     farRundtFødsel: 0,
                     toTette: 0,

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.test.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.test.tsx
@@ -338,7 +338,7 @@ describe('<PlanenDeresSteg - adopsjon>', () => {
         expect(screen.queryByRole('option')).not.toBeInTheDocument();
 
         expect(screen.getByText('Uten aktivitetskrav')).toBeInTheDocument();
-        expect(screen.getByText('Med aktivitetskrav')).toBeInTheDocument();
+
         expect(screen.getByText('Omsorgsovertakelse')).toBeInTheDocument();
 
         const juli = screen.getByTestId('year:2024;month:6');
@@ -348,8 +348,8 @@ describe('<PlanenDeresSteg - adopsjon>', () => {
         expect(within(juli).getAllByTestId('dayColor:BLUE', { exact: false })).toHaveLength(17);
 
         const april2025 = screen.getByTestId('year:2025;month:3');
-        expect(within(april2025).getByTestId('day:11;dayColor:LIGHTGREEN;dayType:LAST_DAY')).toBeInTheDocument();
-        expect(within(april2025).getAllByTestId('dayColor:LIGHTGREEN', { exact: false })).toHaveLength(9);
+        expect(within(april2025).getByTestId('day:11;dayColor:BLUE;dayType:LAST_DAY')).toBeInTheDocument();
+        expect(within(april2025).getAllByTestId('dayColor:BLUE', { exact: false })).toHaveLength(9);
     });
 
     it('skal vise korrekt data for fødsel - far og far søker - kun medfar har rett', async () => {

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.stories.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.stories.tsx
@@ -300,14 +300,14 @@ export const FarOgFarBeggeHarRett: Story = {
         },
         stønadskontoer: {
             '80': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 291 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 291 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
                 },
             },
             '100': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 230 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 230 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
@@ -327,14 +327,14 @@ export const FarOgFarKunFarHarRett: Story = {
         },
         stønadskontoer: {
             '80': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 291 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 291 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
                 },
             },
             '100': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 230 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 230 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
@@ -354,14 +354,14 @@ export const FarOgFarKunMedfarHarRett: Story = {
         },
         stønadskontoer: {
             '80': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 291 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 291 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,
                 },
             },
             '100': {
-                kontoer: [{ konto: StønadskontoType.Foreldrepenger, dager: 230 }],
+                kontoer: [{ konto: StønadskontoType.AktivitetsfriKvote, dager: 230 }],
                 minsteretter: {
                     farRundtFødsel: 10,
                     toTette: 0,

--- a/apps/planlegger/src/utils/ikkeDeltUttak.test.ts
+++ b/apps/planlegger/src/utils/ikkeDeltUttak.test.ts
@@ -34,6 +34,7 @@ describe('ikkeDeltUttak - Fødsel - Far/Medmor - WLB gjelder', () => {
             erMorUfør,
             bareFarMedmorHarRett,
             erAleneOmOmsorg: false,
+            farOgFar: false,
         });
 
         expect(forslag.søker1.length).toEqual(2);
@@ -56,6 +57,7 @@ describe('ikkeDeltUttak - Fødsel - Far/Medmor - WLB gjelder', () => {
             erMorUfør,
             bareFarMedmorHarRett,
             erAleneOmOmsorg: false,
+            farOgFar: false,
         });
         expect(forslag.søker1.length).toEqual(2);
         expect(forslag.søker1[0].fom).toEqual(famDato);

--- a/apps/planlegger/src/utils/ikkeDeltUttak.ts
+++ b/apps/planlegger/src/utils/ikkeDeltUttak.ts
@@ -9,29 +9,39 @@ const ikkeDeltUttakAdopsjonFarMedmor = (
     erMorUfør: boolean | undefined,
     aktivitetsfriKvote: Stønadskonto | undefined,
     bareFarMedmorHarRett: boolean,
+    farOgFar: boolean,
 ): PlanForslag => {
     const førsteUttaksdag = UttaksdagenString(famDato).denneEllerNeste();
     const perioder: SaksperiodeNy[] = [];
 
     if (erMorUfør !== true) {
-        let startDatoNestePeriode = førsteUttaksdag;
-        if (andreAugust2022ReglerGjelder(famDato) && !!bareFarMedmorHarRett && aktivitetsfriKvote) {
-            const aktivitetsFriPeriode: SaksperiodeNy = {
+        if (farOgFar) {
+            const periode: SaksperiodeNy = {
                 kontoType: StønadskontoType.AktivitetsfriKvote,
                 fom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).fom,
                 tom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).tom,
             };
+            perioder.push(periode);
+        } else {
+            let startDatoNestePeriode = førsteUttaksdag;
+            if (andreAugust2022ReglerGjelder(famDato) && !!bareFarMedmorHarRett && aktivitetsfriKvote) {
+                const aktivitetsFriPeriode: SaksperiodeNy = {
+                    kontoType: StønadskontoType.AktivitetsfriKvote,
+                    fom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).fom,
+                    tom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).tom,
+                };
 
-            perioder.push(aktivitetsFriPeriode);
-            startDatoNestePeriode = UttaksdagenString(aktivitetsFriPeriode.tom).neste();
+                perioder.push(aktivitetsFriPeriode);
+                startDatoNestePeriode = UttaksdagenString(aktivitetsFriPeriode.tom).neste();
+            }
+            const periode: SaksperiodeNy = {
+                kontoType: foreldrepengerKonto.konto,
+                fom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).fom,
+                tom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).tom,
+            };
+
+            perioder.push(periode);
         }
-        const periode: SaksperiodeNy = {
-            kontoType: foreldrepengerKonto.konto,
-            fom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).fom,
-            tom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).tom,
-        };
-
-        perioder.push(periode);
     } else {
         const aktivitetsFriPeriode: SaksperiodeNy = {
             kontoType: StønadskontoType.AktivitetsfriKvote,
@@ -71,6 +81,7 @@ const ikkeDeltUttakAdopsjon = (
     erMorUfør: boolean | undefined,
     aktivitetsfriKvote: Stønadskonto | undefined,
     bareFarMedmorHarRett: boolean,
+    farOgFar: boolean,
 ) => {
     if (!erFarEllerMedmor) {
         return ikkeDeltUttakAdopsjonMor(famDato, foreldrepengerKonto);
@@ -81,6 +92,7 @@ const ikkeDeltUttakAdopsjon = (
             erMorUfør,
             aktivitetsfriKvote,
             bareFarMedmorHarRett,
+            farOgFar,
         );
     }
 };
@@ -123,31 +135,46 @@ const ikkeDeltUttakFødselFarMedmor = (
     aktivitetsfriKvote: Stønadskonto | undefined,
     bareFarMedmorHarRett: boolean,
     erAleneOmOmsorg: boolean,
+    farOgFar: boolean,
     startdato?: string,
 ): PlanForslag => {
     const startDato = UttaksdagenString(startdato ?? famDato).denneEllerNeste();
     const perioder: SaksperiodeNy[] = [];
 
     if (erMorUfør !== true) {
-        let startDatoNestePeriode = startDato;
-        if (andreAugust2022ReglerGjelder(famDato) && bareFarMedmorHarRett && !erAleneOmOmsorg && aktivitetsfriKvote) {
-            const aktivitetsFriPeriode: SaksperiodeNy = {
+        if (farOgFar) {
+            const periode: SaksperiodeNy = {
                 kontoType: StønadskontoType.AktivitetsfriKvote,
                 fom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).fom,
                 tom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).tom,
             };
+            perioder.push(periode);
+        } else {
+            let startDatoNestePeriode = startDato;
+            if (
+                andreAugust2022ReglerGjelder(famDato) &&
+                bareFarMedmorHarRett &&
+                !erAleneOmOmsorg &&
+                aktivitetsfriKvote
+            ) {
+                const aktivitetsFriPeriode: SaksperiodeNy = {
+                    kontoType: StønadskontoType.AktivitetsfriKvote,
+                    fom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).fom,
+                    tom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).tom,
+                };
 
-            perioder.push(aktivitetsFriPeriode);
-            startDatoNestePeriode = UttaksdagenString(aktivitetsFriPeriode.tom).neste();
+                perioder.push(aktivitetsFriPeriode);
+                startDatoNestePeriode = UttaksdagenString(aktivitetsFriPeriode.tom).neste();
+            }
+
+            const periode: SaksperiodeNy = {
+                kontoType: foreldrepengerKonto.konto,
+                fom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).fom,
+                tom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).tom,
+            };
+
+            perioder.push(periode);
         }
-
-        const periode: SaksperiodeNy = {
-            kontoType: foreldrepengerKonto.konto,
-            fom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).fom,
-            tom: getTidsperiodeString(startDatoNestePeriode, foreldrepengerKonto.dager).tom,
-        };
-
-        perioder.push(periode);
     } else {
         if (!erAleneOmOmsorg) {
             const aktivitetsFriPeriode: SaksperiodeNy = {
@@ -194,6 +221,7 @@ const ikkeDeltUttakFødsel = (
     aktivitetsfriKvote: Stønadskonto | undefined,
     bareFarMedmorHarRett: boolean,
     erAleneOmOmsorg: boolean,
+    farOgFar: boolean,
     startdato?: string,
 ) => {
     if (!erFarEllerMedmor) {
@@ -206,6 +234,7 @@ const ikkeDeltUttakFødsel = (
             aktivitetsfriKvote,
             bareFarMedmorHarRett,
             erAleneOmOmsorg,
+            farOgFar,
             startdato,
         );
     }
@@ -219,6 +248,7 @@ interface IkkeDeltUttakProps {
     erMorUfør: boolean | undefined;
     bareFarMedmorHarRett: boolean;
     erAleneOmOmsorg: boolean;
+    farOgFar: boolean;
     startdato?: string;
 }
 
@@ -231,6 +261,7 @@ export const ikkeDeltUttak = ({
     bareFarMedmorHarRett,
     erAleneOmOmsorg,
     startdato,
+    farOgFar,
 }: IkkeDeltUttakProps): PlanForslag => {
     const foreldrepengerKonto = tilgjengeligeStønadskontoer.find(
         (konto) => konto.konto === StønadskontoType.Foreldrepenger,
@@ -250,6 +281,7 @@ export const ikkeDeltUttak = ({
             erMorUfør,
             aktivitetsfriKvote,
             bareFarMedmorHarRett,
+            farOgFar,
         );
     }
     return ikkeDeltUttakFødsel(
@@ -261,6 +293,7 @@ export const ikkeDeltUttak = ({
         aktivitetsfriKvote,
         bareFarMedmorHarRett,
         erAleneOmOmsorg,
+        farOgFar,
         startdato,
     );
 };

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -360,6 +360,7 @@ interface LagForslagProps {
     erMorUfør: boolean;
     bareFarMedmorHarRett: boolean;
     erAleneOmOmsorg: boolean;
+    farOgFar: boolean;
     startdato?: string;
 }
 
@@ -374,6 +375,7 @@ export const lagForslagTilPlan = ({
     bareFarMedmorHarRett,
     erAleneOmOmsorg,
     startdato,
+    farOgFar,
 }: LagForslagProps): PlanForslag => {
     if (erDeltUttak) {
         return deltUttak({ famDato, tilgjengeligeStønadskontoer, fellesperiodeDagerMor, startdato });
@@ -388,5 +390,6 @@ export const lagForslagTilPlan = ({
         bareFarMedmorHarRett,
         erAleneOmOmsorg,
         startdato,
+        farOgFar,
     });
 };


### PR DESCRIPTION
- Fiks som gjør at 'foreldrepenger uten aktivitetskrav' ikke er mulig å velge som kontotype når man forsøker å tilpasse planen ved farOgFar. Ref: https://trello.com/c/JLs3R99e/293-feil-kontotyper-med-far-og-far

This pull request includes several changes to improve the handling of "Foreldrepenger uten aktivitetskrav" for different family situations, particularly for "far og far" scenarios. The key changes involve modifying the logic for selecting and processing support account types (`StønadskontoType`) and updating the related stories and tests.

### Key Changes:

#### Logic Adjustments:
* Added logic to handle "far og far" scenarios by modifying the selection and processing of support accounts to ensure only "AktivitetsfriKvote" is displayed and correctly calculated. (`apps/planlegger/src/Planlegger.tsx`)

#### Story Updates:
* Updated various story files to reflect the changes in support account types, replacing `Foreldrepenger` with `AktivitetsfriKvote` for relevant scenarios. (`apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx`, `apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.stories.tsx`, `apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.stories.tsx`) [[1]](diffhunk://#diff-a01aabbaac7dd92c4f121c147ea8894f6114d99b0d6741a95c09583c64f1b729L271-R280) [[2]](diffhunk://#diff-bbad6a3249dfb610a5b31cee9e61987b15d3e9cb9391d504ac3dd639043f5498L303-R310) [[3]](diffhunk://#diff-00e03d22eaa6764cbd023a003928a057e8c5a3c122bf8f7f2f19b3ecf76bb799L296-R303)

#### Test Adjustments:
* Adjusted tests to ensure the new logic for "far og far" scenarios is correctly validated, including changes to expected output and removing checks for "Med aktivitetskrav". (`apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.test.tsx`, `apps/planlegger/src/utils/ikkeDeltUttak.test.ts`) [[1]](diffhunk://#diff-6664d68db985a35683d144cebb5588b984b90600297bb42ac2d0d0ba0481d06cL341-R341) [[2]](diffhunk://#diff-95fc51bd10f5b9803048dbb9cb37a93dd7cfc2953142f8dc9cf9c550b0f734deR37)

#### Utility Function Updates:
* Updated utility functions to include the new `farOgFar` parameter and adjusted the logic to handle this new parameter correctly. (`apps/planlegger/src/utils/ikkeDeltUttak.ts`, `apps/planlegger/src/utils/uttakUtils.ts`) [[1]](diffhunk://#diff-0ecbb72a6782f7802bf5b76165682b5671184c75039ca27df7500d35a93e78b5R12-R25) [[2]](diffhunk://#diff-54523cf4019641306a80654c6d1ad9b553fe083175a427393683618335d5042bR363)