### PR TITLE
Krev begrunnelse når ts-regler ignoreres

### DIFF
--- a/packages/eslint-config-custom/eslint.config.mjs
+++ b/packages/eslint-config-custom/eslint.config.mjs
@@ -88,7 +88,14 @@ export default [
 
             // TODO (TOR) Ignorert inntil videre grunnet kost/nytte
             '@typescript-eslint/no-explicit-any': OFF,
-            '@typescript-eslint/ban-ts-comment': OFF,
+            '@typescript-eslint/ban-ts-comment': [
+                ERROR,
+                {
+                    'ts-ignore': {
+                        descriptionFormat: '^ fordi .+$',
+                    },
+                },
+            ],
         },
     },
     {


### PR DESCRIPTION
Har hørt av NAV spanderer kake på eksterne bidragsytere, stemmer det? 
Tester med en liten endring som jeg håper kan gi stor glede til dere, når dere bruker regler som er vanskelige å følge konsekvent. Av TODO over tolker jeg det som at det er ønskelig å skru på denne regelen, men at det oppleves som for strengt. Med denne modifikasjonen vil regelen kun gi error dersom ignore mangler begrunnelse. 