### PR TITLE
Fiks: Ta hoyde for bruk av fallbacknavn for annen forelder.

### DIFF
--- a/apps/planlegger/src/intl/messages/en_US.json
+++ b/apps/planlegger/src/intl/messages/en_US.json
@@ -185,7 +185,7 @@
     "HvorMyeOppsummering.BasertPå": "Based on the monthly income, {erAlenesøker, select, true {you} other {{hvem}}} has reported an income higher than this, but it is not covered by Nav.",
     "BarnehageplassOppsummering.Tittel": "Kindergarten",
     "BarnehageplassOppsummering.KanHaPlass": "You may have the right to a daycare spot on {barnehagestartdato}",
-    "BarnehageplassOppsummering.Beregnet": "Estimated based on <a>the Kindergarten Act</a>. Based on the {antallBarn, select, 1 {child} other {children}} {erAdopsjon, select, true {being taken over the care for} other {{erFødt, select, true {being born} other {is born on due date}}}} {familiehendelsesdato}, and that you apply for kindergarten the year the {antallBarn, select, 1 {child} other {children}} turns 1.",
+    "BarnehageplassOppsummering.Beregnet": "Estimated based on <a>the Kindergarten Act (opens in a new tab)</a>. Based on the {antallBarn, select, 1 {child} other {children}} {erAdopsjon, select, true {being taken over the care for} other {{erFødt, select, true {being born} other {is born on due date}}}} {familiehendelsesdato}, and that you apply for kindergarten the year the {antallBarn, select, 1 {child} other {children}} turns 1.",
     "BarnehageplassOppsummering.ManKanFå": "You can get a daycare spot before this",
     "BarnehageplassOppsummering.Kommune": "Several municipalities have their own rules that allow for a place in kindergarten before the date. You must check your municipality's website.",
     "OversiktSteg.Mor": "mother",

--- a/apps/planlegger/src/intl/messages/nb_NO.json
+++ b/apps/planlegger/src/intl/messages/nb_NO.json
@@ -185,7 +185,7 @@
     "HvorMyeOppsummering.BasertPå": "Basert på månedsinntekten har {erAlenesøker, select, true {du} other {{hvem}}} oppgitt en inntekt høyere enn dette, men dette dekkes ikke av Nav.",
     "BarnehageplassOppsummering.Tittel": "Barnehageplass",
     "BarnehageplassOppsummering.KanHaPlass": "{erAlenesøker, select, true {Du} other {Dere}} kan ha rett på barnehageplass i {barnehagestartdato}",
-    "BarnehageplassOppsummering.Beregnet": "Beregnet ut fra <a>barnehageloven.</a> Basert på at {antallBarn, select, 1 {barnet} other {barna}} {erAdopsjon, select, true {har overtakelse} other {{erFødt, select, true {ble født} other {blir født på termindato}}}} {familiehendelsesdato}, og at {erAlenesøker, select, true {du} other {dere}} søker om barnehageplass det året {antallBarn, select, 1 {barnet} other {barna}} fyller 1 år.",
+    "BarnehageplassOppsummering.Beregnet": "Beregnet ut fra <a>barnehageloven (åpner i en ny fane)</a>. Basert på at {antallBarn, select, 1 {barnet} other {barna}} {erAdopsjon, select, true {har overtakelse} other {{erFødt, select, true {ble født} other {blir født på termindato}}}} {familiehendelsesdato}, og at {erAlenesøker, select, true {du} other {dere}} søker om barnehageplass det året {antallBarn, select, 1 {barnet} other {barna}} fyller 1 år.",
     "BarnehageplassOppsummering.ManKanFå": "Man kan få barnehageplass før dette",
     "BarnehageplassOppsummering.Kommune": "Flere kommuner har egne regler som gjør at man kan få plass i barnehage før datoen. Det må {erAlenesøker, select, true {du} other {dere}} sjekke opp på {erAlenesøker, select, true {din} other {deres}} kommunes nettsider.",
     "OversiktSteg.Mor": "mor",

--- a/apps/planlegger/src/intl/messages/nn_NO.json
+++ b/apps/planlegger/src/intl/messages/nn_NO.json
@@ -185,7 +185,7 @@
     "HvorMyeOppsummering.BasertPå": "Basert på månadsinntekta har {erAlenesøker, select, true {du} other {{hvem}}} oppgitt ei inntekt høgare enn dette, men dette blir ikkje dekt av Nav.",
     "BarnehageplassOppsummering.Tittel": "Barnehageplass",
     "BarnehageplassOppsummering.KanHaPlass": "{erAlenesøker, select, true {Du} other {De}} kan ha rett på barnehageplass i {barnehagestartdato}",
-    "BarnehageplassOppsummering.Beregnet": "Berekna ut frå <a>barnehageloven.</a> Basert på at {antallBarn, select, 1 {barnet} other {borna}} {erAdopsjon, select, true {har overtaking} other {{erFødt, select, true {vart fødd} other {blir fødd på termindato}}}} {familiehendelsesdato}, og at {erAlenesøker, select, true {du} other {de}} søkjer om barnehageplass det året {antallBarn, select, 1 {barnet} other {borna}} fyller 1 år.",
+    "BarnehageplassOppsummering.Beregnet": "Berekna ut frå <a>barnehageloven (blir opna i ny fane)</a>. Basert på at {antallBarn, select, 1 {barnet} other {borna}} {erAdopsjon, select, true {har overtaking} other {{erFødt, select, true {vart fødd} other {blir fødd på termindato}}}} {familiehendelsesdato}, og at {erAlenesøker, select, true {du} other {de}} søkjer om barnehageplass det året {antallBarn, select, 1 {barnet} other {borna}} fyller 1 år.",
     "BarnehageplassOppsummering.ManKanFå": "Ein kan få barnehageplass før dette",
     "BarnehageplassOppsummering.Kommune": "Fleire kommunar har eigne reglar som gjer at ein kan få plass i barnehage før datoen. Det må {erAlenesøker, select, true {du} other {de}} sjekka opp på {erAlenesøker, select, true {din} other {deira}} kommunes nettsider.",
     "OversiktSteg.Mor": "mor",

--- a/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
+++ b/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
@@ -35,13 +35,13 @@ export const erFarSøker2 = (hvemPlanlegger: HvemPlanlegger): hvemPlanlegger is 
 export const getNavnPåSøker1 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string => {
     if (erMorDelAvSøknaden(hvemPlanlegger)) {
         return (
-            hvemPlanlegger.navnPåMor ??
+            hvemPlanlegger.navnPåMor ||
             capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultMorNavn' }))
         );
     }
     if (erFarDelAvSøknaden(hvemPlanlegger)) {
         return (
-            hvemPlanlegger.navnPåFar ??
+            hvemPlanlegger.navnPåFar ||
             capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
         );
     }
@@ -51,19 +51,19 @@ export const getNavnPåSøker1 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShap
 export const getNavnPåSøker2 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string => {
     if (hvemPlanlegger.type === HvemPlanleggerType.MOR_OG_MEDMOR && hvemPlanlegger.navnPåMedmor) {
         return (
-            hvemPlanlegger.navnPåMedmor ??
+            hvemPlanlegger.navnPåMedmor ||
             capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultMedMorNavn' }))
         );
     }
     if (hvemPlanlegger.type === HvemPlanleggerType.MOR_OG_FAR) {
         return (
-            hvemPlanlegger.navnPåFar ??
+            hvemPlanlegger.navnPåFar ||
             capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
         );
     }
     if (hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR) {
         return (
-            hvemPlanlegger.navnPåMedfar ??
+            hvemPlanlegger.navnPåMedfar ||
             capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
         );
     }

--- a/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
+++ b/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
@@ -2,6 +2,7 @@ import { IntlShape } from 'react-intl';
 import { Far, FarOgFar, HvemPlanlegger, Mor, MorOgFar, MorOgMedmor } from 'types/HvemPlanlegger';
 
 import { HvemPlanleggerType } from '@navikt/fp-types';
+import { capitalizeFirstLetter } from '@navikt/fp-utils';
 
 import { HvemHarRett } from './hvemHarRettUtils';
 
@@ -115,10 +116,10 @@ export const getTekstForDeSomHarRett = (
     }
 
     if (hvemHarRett === 'kunSøker1HarRett') {
-        return getNavnPåSøker1(hvemPlanlegger, intl);
+        return capitalizeFirstLetter(getNavnPåSøker1(hvemPlanlegger, intl));
     }
     if (hvemHarRett === 'kunSøker2HarRett') {
-        return getNavnPåSøker2(hvemPlanlegger, intl);
+        return capitalizeFirstLetter(getNavnPåSøker2(hvemPlanlegger, intl));
     }
     if (hvemHarRett === 'beggeHarRett') {
         return intl.formatMessage({ id: 'Dere' });

--- a/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
+++ b/apps/planlegger/src/utils/HvemPlanleggerUtils.ts
@@ -2,7 +2,6 @@ import { IntlShape } from 'react-intl';
 import { Far, FarOgFar, HvemPlanlegger, Mor, MorOgFar, MorOgMedmor } from 'types/HvemPlanlegger';
 
 import { HvemPlanleggerType } from '@navikt/fp-types';
-import { capitalizeFirstLetter } from '@navikt/fp-utils';
 
 import { HvemHarRett } from './hvemHarRettUtils';
 
@@ -34,40 +33,25 @@ export const erFarSøker2 = (hvemPlanlegger: HvemPlanlegger): hvemPlanlegger is 
 
 export const getNavnPåSøker1 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string => {
     if (erMorDelAvSøknaden(hvemPlanlegger)) {
-        return (
-            hvemPlanlegger.navnPåMor ||
-            capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultMorNavn' }))
-        );
+        return hvemPlanlegger.navnPåMor || intl.formatMessage({ id: 'HvemPlanlegger.DefaultMorNavn' });
     }
     if (erFarDelAvSøknaden(hvemPlanlegger)) {
-        return (
-            hvemPlanlegger.navnPåFar ||
-            capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
-        );
+        return hvemPlanlegger.navnPåFar || intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' });
     }
     throw new Error('Feil i kode: Ugyldig hvemPlanlegger');
 };
 
 export const getNavnPåSøker2 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string => {
     if (hvemPlanlegger.type === HvemPlanleggerType.MOR_OG_MEDMOR && hvemPlanlegger.navnPåMedmor) {
-        return (
-            hvemPlanlegger.navnPåMedmor ||
-            capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultMedMorNavn' }))
-        );
+        return hvemPlanlegger.navnPåMedmor || intl.formatMessage({ id: 'HvemPlanlegger.DefaultMedMorNavn' });
     }
     if (hvemPlanlegger.type === HvemPlanleggerType.MOR_OG_FAR) {
-        return (
-            hvemPlanlegger.navnPåFar ||
-            capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
-        );
+        return hvemPlanlegger.navnPåFar || intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' });
     }
     if (hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR) {
-        return (
-            hvemPlanlegger.navnPåMedfar ||
-            capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' }))
-        );
+        return hvemPlanlegger.navnPåMedfar || intl.formatMessage({ id: 'HvemPlanlegger.DefaultFarNavn' });
     }
-    return capitalizeFirstLetter(intl.formatMessage({ id: 'HvemPlanlegger.DefaultAnnenForelderNavn' }));
+    return intl.formatMessage({ id: 'HvemPlanlegger.DefaultAnnenForelderNavn' });
 };
 
 export const getDefaultNavnSøker1 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string => {
@@ -99,6 +83,10 @@ export const getFornavnPåSøker1 = (hvemPlanlegger: HvemPlanlegger, intl: IntlS
 
 export const getFornavnPåSøker2 = (hvemPlanlegger: HvemPlanlegger, intl: IntlShape): string | undefined => {
     const navn = getNavnPåSøker2(hvemPlanlegger, intl);
+    // For at ikke "Annen forelder" skal bli "Annen"
+    if (navn === intl.formatMessage({ id: 'HvemPlanlegger.DefaultAnnenForelderNavn' })) {
+        return navn;
+    }
     return navn ? navn.split(' ')[0] : undefined;
 };
 

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeaderUtils.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeaderUtils.tsx
@@ -13,6 +13,7 @@ import { IntlShape } from 'react-intl';
 import { NavnPåForeldre } from '@navikt/fp-common';
 import { Forelder } from '@navikt/fp-constants';
 import { Familiesituasjon, UtsettelseÅrsakType } from '@navikt/fp-types';
+import { capitalizeFirstLetter } from '@navikt/fp-utils';
 
 type GetFargeProps = {
     erPeriodeUtenUttak: boolean;
@@ -175,7 +176,9 @@ export const getTekst = ({
 
     return intl.formatMessage(
         { id: 'uttaksplan.periodeListeHeader.HarForeldrepenger' },
-        { navn: erEgenPeriode ? navnPåForelder : navnPåAnnenForelder },
+        {
+            navn: erEgenPeriode ? capitalizeFirstLetter(navnPåForelder) : capitalizeFirstLetter(navnPåAnnenForelder),
+        },
     );
 };
 


### PR DESCRIPTION
- Gjør at "annen forelder" ikke blir trimmet eller får stor forbokstav hvor det er ulogisk. 
- Legger til info om at lenke åpnes i annen fane. 