### PR TITLE
Legg til test for MorOgFarKunFarHarRett hvormye i oppsummeringssteg, …

### DIFF
--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -157,7 +157,7 @@ export const MorOgFarKunFarHarRett: Story = {
             type: HvemPlanleggerType.MOR_OG_FAR,
         },
         hvorMye: {
-            lønnSøker1: 1000,
+            lønnSøker2: 1000,
         },
         hvorLangPeriode: {
             dekningsgrad: Dekningsgrad.HUNDRE_PROSENT,

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -12,6 +12,7 @@ const {
     FarOgFarAdopsjonKunFar1HarRett,
     HarIkkeRett,
     OppsummeringFarOgFarKunFar2HarRett,
+    MorOgFarKunFarHarRett,
 } = composeStories(stories);
 
 describe('<OppsummeringSteg>', () => {
@@ -187,5 +188,16 @@ describe('<OppsummeringSteg>', () => {
         expect(screen.getByText('Dette svarte dere')).toBeInTheDocument();
 
         expect(screen.queryByText('Barnehageplass')).not.toBeInTheDocument();
+    });
+    it('skal kun vise fars vise fars uttak i hvor mye-steget, der det er mor og far og kun far rett til foreldrepenger', async () => {
+        render(<MorOgFarKunFarHarRett />);
+        expect(await screen.findAllByText('Oppsummering')).toHaveLength(2);
+        expect(screen.getAllByText('Hvor mye?')).toHaveLength(2);
+        expect(
+            screen.getByText(
+                'Espen vil få rundt 46 kr per dag hvis dere velger 100 % foreldrepenger eller 37 kr per dag med 80 %.',
+            ),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Klare vil få rundt')).not.toBeInTheDocument();
     });
 });

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -189,7 +189,7 @@ describe('<OppsummeringSteg>', () => {
 
         expect(screen.queryByText('Barnehageplass')).not.toBeInTheDocument();
     });
-    it('skal kun vise fars vise fars uttak i hvor mye-steget, der det er mor og far og kun far rett til foreldrepenger', async () => {
+    it('skal kun vise fars uttak i hvor mye-steget, der det er mor og far, men kun far rett til foreldrepenger', async () => {
         render(<MorOgFarKunFarHarRett />);
         expect(await screen.findAllByText('Oppsummering')).toHaveLength(2);
         expect(screen.getAllByText('Hvor mye?')).toHaveLength(2);


### PR DESCRIPTION
- Legger til test for oppsummeringsteget i tilfellet der Mor og far søker, kun har har rett. 

Copilot-summary:
- This pull request adds a new test scenario for the `OppsummeringSteg` component and updates related stories to reflect the scenario where only the father has the right to parental benefits in a "mother and father" family type.

### Updates to stories:

* [`apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx`](diffhunk://#diff-a01aabbaac7dd92c4f121c147ea8894f6114d99b0d6741a95c09583c64f1b729L160-R160): Changed the `lønnSøker1` field to `lønnSøker2` in the `MorOgFarKunFarHarRett` story to align with the scenario where only the father has the right to parental benefits.

### Updates to tests:

* [`apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx`](diffhunk://#diff-bd9376dc03299749702a0ebc100e33e49dba383a0af84c0f8c7419d121b7e05bR15): Added `MorOgFarKunFarHarRett` to the list of composed stories for testing.
* [`apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx`](diffhunk://#diff-bd9376dc03299749702a0ebc100e33e49dba383a0af84c0f8c7419d121b7e05bR192-R202): Introduced a new test case to verify that the component correctly displays information about the father's parental leave entitlement while excluding the mother's entitlement for the "MorOgFarKunFarHarRett" scenario.…juster story for MorOgFarKunFarHarRett slik at det kun er Far som ahr oppgitt lønn