### PR TITLE
Bruk type-narrowing i stedet for type-cast

### DIFF
--- a/apps/engangsstonad/src/types/Dokumentasjon.ts
+++ b/apps/engangsstonad/src/types/Dokumentasjon.ts
@@ -11,8 +11,5 @@ export type TerminDokumentasjon = {
 export type Dokumentasjon = TerminDokumentasjon | Vedlegg;
 
 export const erTerminDokumentasjon = (dokumentasjon: Dokumentasjon): dokumentasjon is TerminDokumentasjon => {
-    if ((dokumentasjon as TerminDokumentasjon).terminbekreftelsedato) {
-        return true;
-    }
-    return false;
+    return 'terminbekreftelsedato' in dokumentasjon;
 };

--- a/apps/engangsstonad/src/types/OmBarnet.ts
+++ b/apps/engangsstonad/src/types/OmBarnet.ts
@@ -26,22 +26,13 @@ export type Adopsjon = {
 export type OmBarnet = Fødsel | Adopsjon;
 
 export const erAdopsjon = (omBarnet: OmBarnet): omBarnet is Adopsjon => {
-    if ((omBarnet as Adopsjon).adopsjonsdato) {
-        return true;
-    }
-    return false;
+    return 'adopsjonsdato' in omBarnet;
 };
 
 export const harBarnetTermindato = (omBarnet: OmBarnet): omBarnet is BarnetErIkkeFødt => {
-    if ((omBarnet as BarnetErIkkeFødt).termindato) {
-        return true;
-    }
-    return false;
+    return 'termindato' in omBarnet;
 };
 
 export const erBarnetFødt = (omBarnet: OmBarnet): omBarnet is BarnetErFødt => {
-    if ((omBarnet as BarnetErFødt).erBarnetFødt === true) {
-        return true;
-    }
-    return false;
+    return 'fødselsdato' in omBarnet;
 };


### PR DESCRIPTION
Tryggere med type-narrowing enn å bruke casting, dessuten litt unødvendig å returnere true/false når uttrykket allerede er en boolean.