### PR TITLE
TFP-6370: Forbedre periodelisteview for små enheter

### DIFF
--- a/packages/ny-uttaksplan/src/KvoteOppsummering.tsx
+++ b/packages/ny-uttaksplan/src/KvoteOppsummering.tsx
@@ -6,7 +6,16 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { BodyShort, ExpansionCard, HGrid, HStack, VStack } from '@navikt/ds-react';
 
 import { NavnPåForeldre } from '@navikt/fp-common';
-import { Familiehendelse, FpSak, KontoBeregningDto, KontoDto, SaksperiodeNy, UttaksplanModus } from '@navikt/fp-types';
+import { StønadskontoType } from '@navikt/fp-constants';
+import {
+    Familiehendelse,
+    FpSak,
+    KontoBeregningDto,
+    KontoDto,
+    OppholdÅrsakType,
+    SaksperiodeNy,
+    UttaksplanModus,
+} from '@navikt/fp-types';
 import { TidsperiodenString, formatOppramsing } from '@navikt/fp-utils';
 
 import { Planperiode } from './types/Planperiode';
@@ -823,8 +832,31 @@ const finnAntallDagerÅTrekke = (periode: SaksperiodeNy) => {
     return dager;
 };
 
+const getStønadskontoTypeFromOppholdÅrsakType = (årsak: OppholdÅrsakType): StønadskontoType | undefined => {
+    switch (årsak) {
+        case OppholdÅrsakType.UttakFedrekvoteAnnenForelder:
+            return StønadskontoType.Fedrekvote;
+        case OppholdÅrsakType.UttakFellesperiodeAnnenForelder:
+            return StønadskontoType.Fellesperiode;
+        case OppholdÅrsakType.UttakMødrekvoteAnnenForelder:
+            return StønadskontoType.Mødrekvote;
+        case OppholdÅrsakType.UttakForeldrepengerAnnenForelder:
+            return StønadskontoType.Foreldrepenger;
+        default:
+            return undefined;
+    }
+};
+
 const summerDagerIPerioder = (perioder: SaksperiodeNy[], konto: KontoDto[]) => {
-    const aktuelleKontotyper = new Set(perioder.map((p) => p.kontoType));
+    const aktuelleKontotyper = new Set(
+        perioder.map((p) => {
+            if (p.oppholdÅrsak) {
+                return getStønadskontoTypeFromOppholdÅrsakType(p.oppholdÅrsak);
+            }
+
+            return p.kontoType;
+        }),
+    );
 
     if (aktuelleKontotyper === undefined) {
         return 0;

--- a/packages/ny-uttaksplan/src/components/periode-liste-content/PeriodeListeContent.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-content/PeriodeListeContent.tsx
@@ -208,7 +208,7 @@ const renderKnapper = (
     }
 
     return (
-        <HStack gap="space-16" justify="end">
+        <HStack gap="space-16" justify="end" marginBlock={{ xs: 'space-16 space-0', sm: 'space-0' }}>
             <Button
                 type="button"
                 size="small"

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
@@ -65,11 +65,11 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
             </div>
             <div className="flex flex-col justify-center md:block">
                 <div
-                    className={`md:min-w-2/5 md:p-4 min-w-[2rem] rounded-2xl md:px-4 md:py-2 md:rounded-xl w-1/8 
+                    className={`md:min-w-2/5 md:p-4 min-w-[2rem] rounded-2xl md:px-4 md:py-2 md:rounded-xl 
                         md:w-auto md:h-auto flex items-center justify-center m-2 md:m-0 w-10 h-10
                             ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
                 >
-                    <HStack justify={{ xs: 'center', md: 'space-between' }} wrap={false} className="sm:p-3 md:p-0">
+                    <HStack justify={{ xs: 'center', md: 'space-between' }} wrap={false}>
                         <Show above="md">
                             <BodyShort>{tekst}</BodyShort>
                         </Show>
@@ -77,10 +77,7 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
                     </HStack>
                 </div>
             </div>
-            <div
-                className="sm:p-3 rounded-[2rem] md:px-4 md:py-2 md:rounded-[1.25rem] ml-auto  flex items-center justify-center
-"
-            >
+            <div className="ml-auto flex items-center justify-center p-3 md:px-4 md:py-2 rounded-[2rem] md:rounded-[1.25rem]">
                 <div className="flex items-center justify-center w-6 h-6 rounded-2xl bg-ax-bg-accent-moderate">
                     {isOpen ? (
                         <ChevronUpIcon color="var(--ax-bg-accent-strong)" />

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
@@ -47,9 +47,9 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
     );
 
     return (
-        <HStack gap="0" wrap={false}>
+        <HStack width="100%" gap="0" wrap={false}>
             <div
-                className={`min-w-[60%] md:min-w-[30%] px-4 py-2 ${erPermisjonsperiodeTilbakeITid ? 'opacity-75' : 'opacity-100'}`}
+                className={`md:min-w-1/4 w-1/2 px-1 xs:px-2 md:px-4 py-2 ${erPermisjonsperiodeTilbakeITid ? 'opacity-75' : 'opacity-100'}`}
             >
                 <Heading size="xsmall" as="p">
                     {erFamiliehendelse
@@ -60,21 +60,27 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
                     <BodyShort>{tekst}</BodyShort>
                 </Hide>
             </div>
-            <div className="min-w-[22%] md:min-w-[25%] px-4 py-2">
+            <div className="md:min-w-1/4 min-w-[30%] w-1/4 px-1 md:px-4 py-2">
                 {!erFamiliehendelse && <BodyShort>{getVarighetString(antallDager, intl)}</BodyShort>}
             </div>
-            <div
-                className={`min-w-[60px] md:min-w-[38%] p-4 rounded-2xl md:px-4 md:py-2 md:rounded-xl 
-                        ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
-            >
-                <HStack justify="space-between" wrap={false}>
-                    <Show above="md">
-                        <BodyShort>{tekst}</BodyShort>
-                    </Show>
-                    <div>{getIkon(permisjonsperiode, familiehendelsedato, erFamiliehendelse)}</div>
-                </HStack>
+            <div className="flex flex-col justify-center md:block">
+                <div
+                    className={`md:min-w-2/5 md:p-4 min-w-[2rem] rounded-2xl md:px-4 md:py-2 md:rounded-xl w-1/8 
+                        md:w-auto md:h-auto flex items-center justify-center m-2 md:m-0 w-10 h-10
+                            ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
+                >
+                    <HStack justify={{ xs: 'center', md: 'space-between' }} wrap={false} className="sm:p-3 md:p-0">
+                        <Show above="md">
+                            <BodyShort>{tekst}</BodyShort>
+                        </Show>
+                        <div>{getIkon(permisjonsperiode, familiehendelsedato, erFamiliehendelse)}</div>
+                    </HStack>
+                </div>
             </div>
-            <div className="p-4 rounded-[2rem] md:px-4 md:py-2 md:rounded-[1.25rem]">
+            <div
+                className="sm:p-3 rounded-[2rem] md:px-4 md:py-2 md:rounded-[1.25rem] ml-auto  flex items-center justify-center
+"
+            >
                 <div className="flex items-center justify-center w-6 h-6 rounded-2xl bg-ax-bg-accent-moderate">
                     {isOpen ? (
                         <ChevronUpIcon color="var(--ax-bg-accent-strong)" />

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
@@ -60,7 +60,7 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
                     <BodyShort>{tekst}</BodyShort>
                 </Hide>
             </div>
-            <div className="md:min-w-1/4 min-w-[30%] w-1/4 px-1 md:px-4 py-2">
+            <div className="md:min-w-1/4 min-w-3/10 w-1/4 px-1 md:px-4 py-2">
                 {!erFamiliehendelse && <BodyShort>{getVarighetString(antallDager, intl)}</BodyShort>}
             </div>
             <div className="flex flex-col justify-center md:block">


### PR DESCRIPTION
- Forbedre hvordan periodelisten vises på mindre enheter (tilpassplanensteg)

Se skjermbilder som viser før/etter

Før:
![iPhone 5-SE-1757338693654](https://github.com/user-attachments/assets/21c71b8d-dd94-45ff-a4b9-6112eaa6e488)
![Nokia N9-1757338693654](https://github.com/user-attachments/assets/314a8ec0-f643-4421-be8e-1ad08e79de38)
![iPad Mini-1757338693652](https://github.com/user-attachments/assets/54472177-fdaf-44bc-8336-0ae39750acd7)
![Nest Hub-1757338693652](https://github.com/user-attachments/assets/ba64fade-9a01-4fa3-b450-ab71be832d44)
![Nest Hub Max-1757338693652](https://github.com/user-attachments/assets/411909ca-4529-4924-bd1e-55b4f78840c6)
![MacBook Pro-1757338693631](https://github.com/user-attachments/assets/6cadf002-0f14-42aa-b046-c9eff110c692)

Etter:
![iPad Mini-1757338594523](https://github.com/user-attachments/assets/cc0cfc30-aa93-407a-886f-99aa2e18f677)
![iPhone 5-SE-1757338594481](https://github.com/user-attachments/assets/603734cf-6506-4e36-9dd8-6e075408eb55)
![Nest Hub Max-1757338594481](https://github.com/user-attachments/assets/4ae83021-a9f6-4bf0-a108-513a576acb62)
![MacBook Pro-1757338594481](https://github.com/user-attachments/assets/62dd70bc-b2bc-4502-b19e-ea88bc61a36a)
![Nokia N9-1757338594481](https://github.com/user-attachments/assets/dae55fc4-0b4d-4d53-a97c-0762224875b4)
![Nest Hub-1757338594464](https://github.com/user-attachments/assets/c6322997-181b-4088-8645-84104f30d6e3)
