### PR TITLE
Legg til tailwind prettier plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
     "singleQuote": true,
     "printWidth": 120,
     "endOfLine": "auto",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
     "importOrder": ["^@navikt/ds(.*)$", "^@navikt/fp(.*)$", "^app/(.*)$", "^[./]"],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true

--- a/apps/planlegger/package.json
+++ b/apps/planlegger/package.json
@@ -80,6 +80,8 @@
         "http-proxy-middleware": "3.0.5",
         "mockdate": "3.0.5",
         "playwright": "1.54.2",
+        "prettier": "3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "storybook": "9.1.2",
         "tailwindcss": "4.1.12",
         "typescript": "5.9.2",

--- a/apps/planlegger/src/intl/messages/en_US.json
+++ b/apps/planlegger/src/intl/messages/en_US.json
@@ -262,6 +262,7 @@
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Bekreft": "Yes, remove everything",
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Avbryt": "Cancel",
     "TilpassPlanenSteg.EndrePlanen": "Edit the plan",
+    "TilpassPlanenSteg.LukkPerioder": "Close periods",
     "TilpassPlanenSteg.Angre": "Undo",
     "TilpassPlanenSteg.SavnerDuNoe.Tittel": "Are you missing something in the planner?",
     "TilpassPlanenSteg.SavnerDuNoe.Tekst": "We are working to improve the planner. This means that more features are coming soon. There may therefore be differences between what you can enter in the planner and what you can actually apply for.",

--- a/apps/planlegger/src/intl/messages/nb_NO.json
+++ b/apps/planlegger/src/intl/messages/nb_NO.json
@@ -262,6 +262,7 @@
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Bekreft": "Ja, fjern alt",
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Avbryt": "Avbryt",
     "TilpassPlanenSteg.EndrePlanen": "Endre planen",
+    "TilpassPlanenSteg.LukkPerioder": "Lukk perioder",
     "TilpassPlanenSteg.Angre": "Angre",
     "TilpassPlanenSteg.SavnerDuNoe.Tittel": "Savner du noe i planleggeren?",
     "TilpassPlanenSteg.SavnerDuNoe.Tekst": "Vi jobber med å forbedre planleggeren. Det betyr at flere funksjoner kommer snart. Det kan derfor være forskjeller mellom det du kan legge inn i planleggeren og det du faktisk kan søke om.",

--- a/apps/planlegger/src/intl/messages/nn_NO.json
+++ b/apps/planlegger/src/intl/messages/nn_NO.json
@@ -262,6 +262,7 @@
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Bekreft": "Ja, fjerna alt",
     "TilpassPlanenSteg.FjernAlt.Modal.Knapp.Avbryt": "Avbryt",
     "TilpassPlanenSteg.EndrePlanen": "Endre planen",
+    "TilpassPlanenSteg.LukkPerioder": "Lukk periodar",
     "TilpassPlanenSteg.Angre": "Angre",
     "TilpassPlanenSteg.SavnerDuNoe.Tittel": "Saknar du noko i planleggaren?",
     "TilpassPlanenSteg.SavnerDuNoe.Tekst": "Vi arbeider med å forbetra planleggaren. Det betyr at fleire funksjonar kjem snart. Det kan derfor vera skilnader mellom det du kan leggja inn i planleggaren og det du faktisk kan søkja om.",

--- a/apps/planlegger/src/steps/tilpass-planen/TilpassPlanenSteg.tsx
+++ b/apps/planlegger/src/steps/tilpass-planen/TilpassPlanenSteg.tsx
@@ -256,13 +256,11 @@ export const TilpassPlanenSteg = ({ stønadskontoer }: Props) => {
                                     }
                                     onClick={handleToggleAllAccordions}
                                 >
-                                    <FormattedMessage
-                                        id={
-                                            isAllAccordionsOpen
-                                                ? 'TilpassPlanenSteg.LukkPerioder'
-                                                : 'TilpassPlanenSteg.EndrePlanen'
-                                        }
-                                    />
+                                    {isAllAccordionsOpen ? (
+                                        <FormattedMessage id="TilpassPlanenSteg.LukkPerioder" />
+                                    ) : (
+                                        <FormattedMessage id="TilpassPlanenSteg.EndrePlanen" />
+                                    )}
                                 </Button>
                                 <Button
                                     size="small"

--- a/apps/planlegger/src/steps/tilpass-planen/TilpassPlanenSteg.tsx
+++ b/apps/planlegger/src/steps/tilpass-planen/TilpassPlanenSteg.tsx
@@ -1,4 +1,4 @@
-import { ArrowCirclepathIcon, ArrowUndoIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
+import { ArrowCirclepathIcon, ArrowUndoIcon, PencilIcon, TrashIcon, XMarkIcon } from '@navikt/aksel-icons';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/PlanleggerDataContext';
 import { usePlanleggerNavigator } from 'appData/usePlanleggerNavigator';
 import { useStepData } from 'appData/useStepData';
@@ -246,11 +246,23 @@ export const TilpassPlanenSteg = ({ stønadskontoer }: Props) => {
                                 </Button>
                                 <Button
                                     size="small"
-                                    variant="secondary"
-                                    icon={<PencilIcon aria-hidden height={24} width={24} />}
+                                    variant={isAllAccordionsOpen ? 'primary' : 'secondary'}
+                                    icon={
+                                        isAllAccordionsOpen ? (
+                                            <XMarkIcon aria-hidden height={24} width={24} />
+                                        ) : (
+                                            <PencilIcon aria-hidden height={24} width={24} />
+                                        )
+                                    }
                                     onClick={handleToggleAllAccordions}
                                 >
-                                    <FormattedMessage id="TilpassPlanenSteg.EndrePlanen" />
+                                    <FormattedMessage
+                                        id={
+                                            isAllAccordionsOpen
+                                                ? 'TilpassPlanenSteg.LukkPerioder'
+                                                : 'TilpassPlanenSteg.EndrePlanen'
+                                        }
+                                    />
                                 </Button>
                                 <Button
                                     size="small"

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
@@ -65,7 +65,10 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
             </div>
             <div className="flex w-full flex-col md:grow justify-center ">
                 <div
-                    className={`rounded-2xl w-12 h-12 md:w-full md:px-4 md:py-2 md:rounded-xl md:h-auto flex justify-between m-2 md:m-0 ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
+                    className={`rounded-2xl w-12 h-12 md:w-full md:px-4 md:py-2 md:rounded-xl md:h-auto flex justify-between m-2 md:m-0 ${finnBakgrunnsfarge(
+                        permisjonsperiode,
+                        erFamiliehendelse,
+                    )}`}
                 >
                     <HStack flexGrow="1" justify={{ xs: 'center', md: 'space-between' }} wrap={false} gap="space-4">
                         <Show above="md">

--- a/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/ny-uttaksplan/src/components/periode-liste-header/PeriodeListeHeader.tsx
@@ -2,7 +2,7 @@ import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 import dayjs from 'dayjs';
 import { useIntl } from 'react-intl';
 
-import { BodyShort, HStack, Heading, Hide, Show } from '@navikt/ds-react';
+import { BodyShort, HGrid, HStack, Heading, Hide, Show } from '@navikt/ds-react';
 
 import { Tidsperioden, formatDateShortMonth } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
@@ -47,9 +47,9 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
     );
 
     return (
-        <HStack width="100%" gap="0" wrap={false}>
+        <HGrid columns={{ xs: '4fr 4fr 1fr 1fr', md: '3fr 3fr 3fr 1fr' }}>
             <div
-                className={`md:min-w-1/4 w-1/2 px-1 xs:px-2 md:px-4 py-2 ${erPermisjonsperiodeTilbakeITid ? 'opacity-75' : 'opacity-100'}`}
+                className={`px-1 xs:px-2 md:px-4 py-2 ${erPermisjonsperiodeTilbakeITid ? 'opacity-75' : 'opacity-100'}`}
             >
                 <Heading size="xsmall" as="p">
                     {erFamiliehendelse
@@ -60,24 +60,24 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
                     <BodyShort>{tekst}</BodyShort>
                 </Hide>
             </div>
-            <div className="md:min-w-1/4 min-w-3/10 w-1/4 px-1 md:px-4 py-2">
+            <div className="px-1 md:px-4 py-2">
                 {!erFamiliehendelse && <BodyShort>{getVarighetString(antallDager, intl)}</BodyShort>}
             </div>
-            <div className="flex flex-col justify-center md:block">
+            <div className="flex w-full flex-col md:grow justify-center ">
                 <div
-                    className={`md:min-w-2/5 md:p-4 min-w-[2rem] rounded-2xl md:px-4 md:py-2 md:rounded-xl 
-                        md:w-auto md:h-auto flex items-center justify-center m-2 md:m-0 w-10 h-10
-                            ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
+                    className={`rounded-2xl w-12 h-12 md:w-full md:px-4 md:py-2 md:rounded-xl md:h-auto flex justify-between m-2 md:m-0 ${finnBakgrunnsfarge(permisjonsperiode, erFamiliehendelse)}`}
                 >
-                    <HStack justify={{ xs: 'center', md: 'space-between' }} wrap={false}>
+                    <HStack flexGrow="1" justify={{ xs: 'center', md: 'space-between' }} wrap={false} gap="space-4">
                         <Show above="md">
                             <BodyShort>{tekst}</BodyShort>
                         </Show>
-                        <div>{getIkon(permisjonsperiode, familiehendelsedato, erFamiliehendelse)}</div>
+                        <div className="flex items-center">
+                            {getIkon(permisjonsperiode, familiehendelsedato, erFamiliehendelse)}
+                        </div>
                     </HStack>
                 </div>
             </div>
-            <div className="ml-auto flex items-center justify-center p-3 md:px-4 md:py-2 rounded-[2rem] md:rounded-[1.25rem]">
+            <div className="flex items-center justify-center p-3 md:px-4 md:py-2">
                 <div className="flex items-center justify-center w-6 h-6 rounded-2xl bg-ax-bg-accent-moderate">
                     {isOpen ? (
                         <ChevronUpIcon color="var(--ax-bg-accent-strong)" />
@@ -86,6 +86,6 @@ export const PeriodeListeHeader = ({ permisjonsperiode, erFamiliehendelse, isOpe
                     )}
                 </div>
             </div>
-        </HStack>
+        </HGrid>
     );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,12 @@ importers:
       playwright:
         specifier: 1.54.2
         version: 1.54.2
+      prettier:
+        specifier: 3.6.2
+        version: 3.6.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2)
       storybook:
         specifier: 9.1.2
         version: 9.1.2(@testing-library/dom@10.4.1)(msw@2.10.5(@types/node@24.3.0)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.1))
@@ -7327,6 +7333,67 @@ packages:
     resolution: {integrity: sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA==}
     hasBin: true
 
+  prettier-plugin-tailwindcss@0.6.14:
+    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
@@ -13186,6 +13253,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prepin@1.0.3: {}
+
+  prettier-plugin-tailwindcss@0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2):
+    dependencies:
+      prettier: 3.6.2
+    optionalDependencies:
+      '@trivago/prettier-plugin-sort-imports': 5.2.2(prettier@3.6.2)
 
   prettier@3.6.2: {}
 


### PR DESCRIPTION
- Legger til en plugin som gjør at prettier sorterer tailwind-classer etter deres [anbefalte rekkefølge](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted). Fin ved bruk av "format on save" 

![GIF Recording 2025-09-10 at 8 24 38 AM](https://github.com/user-attachments/assets/d7bc4ccd-d235-4a34-a9ff-2f8ed002a999)

Før:
<img width="1832" height="1527" alt="før" src="https://github.com/user-attachments/assets/30ce5c97-07ea-4b65-a865-9b159bc8f1d1" />

Etter:
<img width="1832" height="1527" alt="etter" src="https://github.com/user-attachments/assets/a7a8574e-c145-4c48-b029-d94665d390ed" />
