### PR TITLE
- Legg til prettier-plugin-tailwindcss for sortering av tailwind-classer

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
     "singleQuote": true,
     "printWidth": 120,
     "endOfLine": "auto",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
     "importOrder": ["^@navikt/ds(.*)$", "^@navikt/fp(.*)$", "^app/(.*)$", "^[./]"],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true

--- a/apps/planlegger/package.json
+++ b/apps/planlegger/package.json
@@ -80,6 +80,7 @@
         "http-proxy-middleware": "3.0.5",
         "mockdate": "3.0.5",
         "playwright": "1.54.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "storybook": "9.1.2",
         "tailwindcss": "4.1.12",
         "typescript": "5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
       playwright:
         specifier: 1.54.2
         version: 1.54.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2)
       storybook:
         specifier: 9.1.2
         version: 9.1.2(@testing-library/dom@10.4.1)(msw@2.10.5(@types/node@24.3.0)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.1))
@@ -7327,6 +7330,67 @@ packages:
     resolution: {integrity: sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA==}
     hasBin: true
 
+  prettier-plugin-tailwindcss@0.6.14:
+    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
@@ -13186,6 +13250,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prepin@1.0.3: {}
+
+  prettier-plugin-tailwindcss@0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2):
+    dependencies:
+      prettier: 3.6.2
+    optionalDependencies:
+      '@trivago/prettier-plugin-sort-imports': 5.2.2(prettier@3.6.2)
 
   prettier@3.6.2: {}
 


### PR DESCRIPTION
- Legg til pretter-plugin som sørger for at Tailwind-classer sorteres etter [anbefalt rekkefølge](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted) ved formatering (som for eksempel kan trigges ved lagring av fil. 

![GIF Recording 2025-09-10 at 8 24 38 AM](https://github.com/user-attachments/assets/82b7293b-4e78-4e44-b876-6a80772a6b57)


Før formattering:
<img width="1832" height="1527" alt="før" src="https://github.com/user-attachments/assets/fcbb5a55-9d07-48dc-bab4-9247bc34e42f" />

Etter:
<img width="1832" height="1527" alt="etter" src="https://github.com/user-attachments/assets/006abd0b-bf61-4feb-b1da-b601a2ecfea2" />

