### PR TITLE
fix(planlegger): vis korrekt 46 uker for far og far når begge har rett

### DIFF
--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -33,7 +33,7 @@ const finnRettighetstype = (hvemPlanlegger: HvemPlanlegger, hvemHarRett: HvemHar
     }
 
     if (hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR && !erBarnetAdoptert(omBarnet)) {
-        return 'BARE_SØKER_RETT';
+        return hvemHarRett === 'beggeHarRett' ? 'BEGGE_RETT' : 'BARE_SØKER_RETT';
     }
 
     if (hvemHarRett === 'beggeHarRett') {
@@ -80,25 +80,23 @@ export const PlanleggerDataFetcher = () => {
         select: (data: KontoBeregningResultatDto): KontoBeregningResultatDto => {
             //TODO (TOR) Dette bør ligga i backend. Verkar pussig å henta kontoar for far-og-far, og så modifisera det her
 
-            // Fix for å ikke vise "Foreldrepenger uten aktivitetskrav"
-            // Hvis ikke far-og-far, returner uendret
             if (hvemPlanlegger?.type !== HvemPlanleggerType.FAR_OG_FAR) {
                 return data;
             }
             // Lag en dyp kopi for å unngå å modifisere original data
             const modifiserteData = JSON.parse(JSON.stringify(data)) as KontoBeregningResultatDto;
-            // Liste over dekningsgrader vi skal prosessere
             const dekningsgrader = ['80', '100'] as const;
-            // Bearbeide hver dekningsgrad
             for (const dekningsgrad of dekningsgrader) {
                 const stønadskonto = modifiserteData[dekningsgrad];
-                if (stønadskonto?.kontoer.some((k) => k.konto === 'AKTIVITETSFRI_KVOTE')) {
-                    // Summer antall dager i alle kontoer
-                    const totalDager = stønadskonto.kontoer.reduce((sum, konto) => sum + konto.dager, 0);
-                    // Filtrer og behold kun 'AKTIVITETSFRI_KVOTE' -kontoen
-                    stønadskonto.kontoer = stønadskonto.kontoer
-                        .filter((konto) => konto.konto === 'AKTIVITETSFRI_KVOTE')
-                        .map((konto) => ({ ...konto, dager: totalDager }));
+                if (stønadskonto) {
+                    // Backend returnerer ulike kontoer avhengig av rettighetstype (f.eks. MØDREKVOTE, FEDREKVOTE, FELLESPERIODE).
+                    // For far og far er ikke FORELDREPENGER_FØR_FØDSEL relevant, så den ekskluderes.
+                    // Alle gjenværende dager slås sammen til én AKTIVITETSFRI_KVOTE, slik at resten av
+                    // planleggeren kan forholde seg til én konto for far og far.
+                    const totalDager = stønadskonto.kontoer
+                        .filter((konto) => konto.konto !== 'FORELDREPENGER_FØR_FØDSEL')
+                        .reduce((sum, konto) => sum + konto.dager, 0);
+                    stønadskonto.kontoer = [{ konto: 'AKTIVITETSFRI_KVOTE', dager: totalDager }];
                 }
             }
             return modifiserteData;

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
@@ -16,9 +16,11 @@ import {
     DELT_UTTAK_100_TO_BARN,
     IKKE_DELT_UTTAK_80_FARMEDMOR,
     IKKE_DELT_UTTAK_80_FAR_OG_FAR,
+    IKKE_DELT_UTTAK_80_FAR_OG_FAR_FØDSEL,
     IKKE_DELT_UTTAK_80_MOR,
     IKKE_DELT_UTTAK_100_FARMEDMOR,
     IKKE_DELT_UTTAK_100_FAR_OG_FAR,
+    IKKE_DELT_UTTAK_100_FAR_OG_FAR_FØDSEL,
     IKKE_DELT_UTTAK_100_MOR,
 } from '@navikt/fp-utils-test';
 
@@ -322,20 +324,14 @@ export const FarOgFarBeggeHarRett: Story = {
         },
         stønadskontoer: {
             '100': {
-                kontoer: [
-                    { konto: 'FORELDREPENGER', dager: 125 },
-                    { konto: 'AKTIVITETSFRI_KVOTE', dager: 75 },
-                ],
+                kontoer: IKKE_DELT_UTTAK_100_FAR_OG_FAR_FØDSEL,
                 minsteretter: {
                     farRundtFødsel: 0,
                     toTette: 0,
                 },
             } satisfies KontoBeregningDto,
             '80': {
-                kontoer: [
-                    { konto: 'FORELDREPENGER', dager: 166 },
-                    { konto: 'AKTIVITETSFRI_KVOTE', dager: 95 },
-                ],
+                kontoer: IKKE_DELT_UTTAK_80_FAR_OG_FAR_FØDSEL,
                 minsteretter: {
                     farRundtFødsel: 0,
                     toTette: 0,

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
@@ -117,7 +117,7 @@ describe('<HvorLangPeriodeSteg>', () => {
             />,
         );
         expect(await screen.findAllByText('Hvor lenge')).toHaveLength(2);
-        await userEvent.click(screen.getByText('100 % utbetaling over 40 uker'));
+        await userEvent.click(screen.getByText('100 % utbetaling over 46 uker'));
 
         expect(
             screen.getByText('Denne datoen gjelder om dere har foreldrepenger sammenhengende fra fødsel.'),
@@ -134,7 +134,7 @@ describe('<HvorLangPeriodeSteg>', () => {
 
         expect(await screen.findAllByText('Hvor lenge')).toHaveLength(2);
 
-        await userEvent.click(screen.getByText('100 % utbetaling over 40 uker'));
+        await userEvent.click(screen.getByText('100 % utbetaling over 46 uker'));
 
         expect(screen.queryByText('Når bare far skal ha foreldrepenger')).not.toBeInTheDocument();
         expect(screen.queryByText('Når bare én av fedrene skal ha foreldrepenger')).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem

I foreldrepengerplanleggeren ble det vist **40 uker** ved 100 % dekningsgrad for situasjonen _far og far_ når begge foreldre har rett. Riktig verdi er **46 uker**, og dette er også det som vises korrekt i foreldrepengesøknaden.

## Årsak – to feil i `Planlegger.tsx`

### Feil 1 – feil rettighetstype sendt til backend (`finnRettighetstype`)

Funksjonen `finnRettighetstype` returnerte alltid `'BARE_SØKER_RETT'` for situasjonen _far og far_ + fødsel, uavhengig av om begge foreldre hadde rett:

```typescript
// Før – alltid BARE_SØKER_RETT for far og far + fødsel
    return 'BARE_SØKER_RETT';
}
```

Det førte til at backend returnerte kontoer tilsvarende «bare søker har rett» (200 dager = 40 uker) i stedet for «begge har rett» (230 dager = 46 uker).

**Fiksen:** Sjekk `hvemHarRett` og returner `'BEGGE_RETT'` når begge har rett:

```typescript
    return hvemHarRett === 'beggeHarRett' ? 'BEGGE_RETT' : 'BARE_SØKER_RETT';
}
```

---

### Feil 2 – `select`-transformasjonen håndterte ikke `BEGGE_RETT`-responsen

For _far og far_ transformeres backend-responsen i en `select`-funksjon som slår alle kontoer sammen til én `AKTIVITETSFRI_KVOTE`. Den opprinnelige koden trigget bare denne transformasjonen dersom `AKTIVITETSFRI_KVOTE` allerede fantes i responsen:

```typescript
// Før – trigget bare dersom AKTIVITETSFRI_KVOTE fantes
if (stønadskonto?.kontoer.some((k) => k.konto === 'AKTIVITETSFRI_KVOTE')) {
    const totalDager = stønadskonto.kontoer.reduce((sum, konto) => sum + konto.dager, 0);
    stønadskonto.kontoer = stønadskonto.kontoer
        .filter((konto) => konto.konto === 'AKTIVITETSFRI_KVOTE')
        .map((konto) => ({ ...konto, dager: totalDager }));
}
```

For `BEGGE_RETT` returnerer backend kontoer som `MØDREKVOTE`, `FEDREKVOTE`, `FELLESPERIODE` og `FORELDREPENGER_FØR_FØDSEL` – ingen `AKTIVITETSFRI_KVOTE` – og transformasjonen trigget aldri. Alle kontoer inkludert `FORELDREPENGER_FØR_FØDSEL` (15 dager = 3 uker) ble dermed summert direkte til 245 dager = **49 uker**.

**Fiksen:** Konsolider alltid alle kontoer til `AKTIVITETSFRI_KVOTE` for _far og far_, uavhengig av hvilke kontoer som finnes i responsen, og ekskluder `FORELDREPENGER_FØR_FØDSEL` som ikke er relevant for _far og far_. Dette er konsistent med hvordan `foreldrepengesøknaden` beregner antall uker i `DekningsgradForm.tsx`:

```typescript
// Etter – alltid konsolider, alltid ekskluder FORELDREPENGER_FØR_FØDSEL
const totalDager = stønadskonto.kontoer
    .filter((konto) => konto.konto !== 'FORELDREPENGER_FØR_FØDSEL')
    .reduce((sum, konto) => sum + konto.dager, 0);
stønadskonto.kontoer = [{ konto: 'AKTIVITETSFRI_KVOTE', dager: totalDager }];
```

## Endrede filer

| Fil | Endring |
|-----|---------|
| `apps/planlegger/src/Planlegger.tsx` | Rettet `finnRettighetstype` og `select`-transformasjonen |
| `apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx` | `FarOgFarBeggeHarRett`-story bruker nå riktige kontoer (`IKKE_DELT_UTTAK_100/80_FAR_OG_FAR_FØDSEL` = 230/291 dager) |
| `apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx` | To tester oppdatert fra «40 uker» til «46 uker» for `FarOgFarBeggeHarRett`-casen |

## Testing

Alle 151 eksisterende tester er grønne ✅