### PR TITLE
planlegger: fiks feil sluttdato for far og far ved fødsel

### DIFF
--- a/apps/planlegger/src/utils/uttakUtils.test.ts
+++ b/apps/planlegger/src/utils/uttakUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { HvemPlanleggerType, KontoBeregningDto } from '@navikt/fp-types';
+
+import { OmBarnet } from '../types/Barnet';
+import { HvemPlanlegger } from '../types/HvemPlanlegger';
+import { finnUttaksdata } from './uttakUtils';
+
+describe('finnUttaksdata', () => {
+    describe('FAR_OG_FAR fødsel', () => {
+        // Totalt 261 stønadsdager (52 uker + 1 dag) ved 80%
+        const stønadskontoer80: KontoBeregningDto = {
+            kontoer: [
+                { konto: 'FORELDREPENGER', dager: 166 },
+                { konto: 'AKTIVITETSFRI_KVOTE', dager: 95 },
+            ],
+            minsteretter: { farRundtFødsel: 0, toTette: 0 },
+        };
+
+        const hvemPlanlegger: HvemPlanlegger = {
+            type: HvemPlanleggerType.FAR_OG_FAR,
+        };
+
+        const barnetFødt: OmBarnet = {
+            erFødsel: true,
+            erBarnetFødt: true,
+            fødselsdato: '2025-07-01',
+            antallBarn: '1',
+        };
+
+        it('sluttdato skal være 30. juni 2026 ved fødsel 1. juli 2025 og 80% dekning (261 stønadsdager)', () => {
+            const resultat = finnUttaksdata('beggeHarRett', hvemPlanlegger, stønadskontoer80, barnetFødt);
+
+            // 261 stønadsdager (95 aktivitetsfri + 166 foreldrepenger = 52 uker + 1 dag)
+            // Startdato = fødselsdato = dag 1, siste dag = dag 261 = 1. juli + 260 stønadsdager = 30. juni 2026
+            expect(resultat.sluttdatoPeriode2).toBe('2026-06-30');
+        });
+
+        it('startdato for periode 1 skal være 6 uker etter fødsel', () => {
+            const resultat = finnUttaksdata('beggeHarRett', hvemPlanlegger, stønadskontoer80, barnetFødt);
+
+            // Søker 1 (far 2) kan starte 6 uker etter fødsel: 1. juli + 6 uker = 12. august 2025
+            expect(resultat.startdatoPeriode1).toBe('2025-08-12');
+        });
+    });
+});

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -206,7 +206,7 @@ const finnEnsligUttaksdata = (
         const aktivitetsfriDager = getAntallDagerAktivitetsfriKvote(valgtStønadskonto);
         const aktivitetskravUkerOgDager = getAntallUkerOgDagerForeldrepenger(valgtStønadskonto);
         const sluttAktivitetsfri = Uttaksdagen(dayjs(getUttaksdagTilOgMedDato(familiehendelsedato)).toDate()).leggTil(
-            aktivitetsfriDager + (erBarnetAdoptert(barnet) ? 0 : 6 * 5 - 1),
+            aktivitetsfriDager - 1,
         );
 
         const startdatoSøker1 = erBarnetAdoptert(barnet)


### PR DESCRIPTION
## Problem

I «Hvor lenge»-steget i planleggeren ble sluttdatoen vist ~6 uker for sent for **far og far** ved fødsel. Eksempel: fødselsdato 1. juli 2025, 80% dekning → sluttdato ble vist som **11. august 2026** i stedet for korrekte **30. juni 2026**.

## Årsak

I `finnEnsligUttaksdata()` i `uttakUtils.ts` ble `sluttAktivitetsfri` beregnet som:

```ts
leggTil(aktivitetsfriDager + 6 * 5 - 1)  // = leggTil(95 + 29 = 124)
```

Tillegget `6 * 5 - 1 = 29` er korrekt i `kunSøker2HarRett`-casen, der far/medmor i et par **ikke kan starte** foreldrepenger før 6 uker etter fødsel. De 6 ukene er da en reell forsinkelse som skal skyve perioden frem.

For **far og far** gjelder derimot ingen slik begrensning — begge fedre kan starte fra fødselsdato. De 6 ukene inngår allerede i de 95 aktivitetsfrie dagene og ble lagt til på nytt ved en feil, noe som ga 30 ekstra stønadsdager og dermed ~6 uker feil sluttdato.

## Løsning

Endret beregningen i FAR_OG_FAR-grenen til:

```ts
leggTil(aktivitetsfriDager - 1)  // = leggTil(94)
```

Dette gir totalt 95 + 166 = **261 stønadsdager** (52 uker + 1 dag) fra fødselsdato, med korrekt sluttdato **30. juni 2026** ved fødsel 1. juli 2025.

## Regresjonstest

Lagt til `uttakUtils.test.ts` som verifiserer sluttdato og startdato for FAR_OG_FAR 80% ved fødsel.