### PR TITLE
Fix/Ikke vis 'aktivitetskrav' i oppsummeringssteg når bare far har rett

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -387,23 +387,6 @@ export const FarMedAleneOmsorg: Story = {
             antallBarn: 2,
             termindato: '2025-10-01',
         },
-        uttaksplan: [
-            {
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'FORELDREPENGER',
-                fom: '2021-11-24',
-                tom: '2021-12-14',
-                flerbarnsdager: false,
-                morsAktivitet: 'IKKE_OPPGITT',
-            },
-            {
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'FORELDREPENGER',
-                fom: '2021-12-15',
-                tom: '2022-06-07',
-                flerbarnsdager: false,
-            },
-        ],
     },
 };
 
@@ -430,6 +413,23 @@ export const FarMedUførMorUgift: Story = {
             antallBarn: 1,
             termindato: '2025-10-01',
         },
+        uttaksplan: [
+            {
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FORELDREPENGER',
+                fom: '2021-11-24',
+                tom: '2021-12-14',
+                flerbarnsdager: false,
+                morsAktivitet: 'IKKE_OPPGITT',
+            },
+            {
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FORELDREPENGER',
+                fom: '2021-12-15',
+                tom: '2022-06-07',
+                flerbarnsdager: false,
+            },
+        ],
     },
 };
 

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -387,6 +387,23 @@ export const FarMedAleneOmsorg: Story = {
             antallBarn: 2,
             termindato: '2025-10-01',
         },
+        uttaksplan: [
+            {
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FORELDREPENGER',
+                fom: '2021-11-24',
+                tom: '2021-12-14',
+                flerbarnsdager: false,
+                morsAktivitet: 'IKKE_OPPGITT',
+            },
+            {
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FORELDREPENGER',
+                fom: '2021-12-15',
+                tom: '2022-06-07',
+                flerbarnsdager: false,
+            },
+        ],
     },
 };
 

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import dayjs from 'dayjs';
-import { on } from 'events';
 import { vi } from 'vitest';
 
 import { DDMMYYYY_DATE_FORMAT } from '@navikt/fp-constants';

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import dayjs from 'dayjs';
+import { on } from 'events';
 import { vi } from 'vitest';
 
 import { DDMMYYYY_DATE_FORMAT } from '@navikt/fp-constants';
@@ -258,6 +259,22 @@ describe('<Oppsummering>', () => {
                 ),
             ).getByText('Nei'),
         ).toBeInTheDocument();
+    });
+
+    it('Skal vise "Foreldrepenger uten aktivitetskrav" når mor er ufør', async () => {
+        render(<FarMedUførMorUgift />);
+
+        const dinPlanDiv = getCardDiv(screen.getByText('Din plan'));
+        const periodeRow = await screen.findByText('Onsdag 24.11.21 - tirsdag 14.12.21');
+
+        expect(
+            checkAndGetParentDiv(
+                dinPlanDiv.getByText(
+                    'Ønsker du at vi endrer perioden som starter på termin til å starte fra fødselsdato når barnet blir født?',
+                ),
+            ).getByText('Nei'),
+        ).toBeInTheDocument();
+        expect(checkAndGetParentDiv(periodeRow).getByText(/Foreldrepenger uten aktivitetskrav/)).toBeInTheDocument();
     });
 
     it('Skal vise informasjon om at mor har rett til foreldrepenger i EØS', async () => {

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummeringsliste.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummeringsliste.tsx
@@ -10,7 +10,8 @@ import { Alert, BodyLong, FormSummary, VStack } from '@navikt/ds-react';
 
 import {
     EksternArbeidsforholdDto_fpoversikt,
-    KontoTypeUttak,
+    KontoType,
+    MorsAktivitet,
     NavnPåForeldre,
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
@@ -114,14 +115,15 @@ const UttaksplanListe = ({
 
     const erAleneOmOmsorg = erAnnenForelderOppgitt ? annenForelder?.erAleneOmOmsorg : false;
 
-    const getStønadskontoNavnFromKonto = (konto: KontoTypeUttak | undefined) => {
+    const getStønadskontoNavnFromKonto = (konto: KontoType | undefined, morsAktivitet?: MorsAktivitet) => {
         return konto === undefined
             ? ''
-            : getStønadskontoNavn(intl, konto, navnPåForeldre, søkerErFarEllerMedmor, erAleneOmOmsorg);
+            : getStønadskontoNavn(intl, konto, navnPåForeldre, søkerErFarEllerMedmor, erAleneOmOmsorg, morsAktivitet);
     };
 
     const getUttaksperiodeNavn = (periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt) => {
-        const tittel = getStønadskontoNavnFromKonto(periode.kontoType);
+        const morsAktivitet = Uttaksperioden.erIkkeEøsPeriode(periode) ? periode.morsAktivitet : undefined;
+        const tittel = getStønadskontoNavnFromKonto(periode.kontoType, morsAktivitet);
         const termindato = getTermindato(barn) ? getTermindato(barn) : undefined;
         return søkersituasjon.situasjon === 'fødsel' &&
             isUttaksperiodeFarMedmorPgaFødsel(periode, familiehendelsesdato, termindato)

--- a/apps/foreldrepengesoknad/src/utils/stønadskontoerUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/stønadskontoerUtils.ts
@@ -1,14 +1,22 @@
 import { IntlShape } from 'react-intl';
 
-import { KontoBeregningDto, KontoDto, KontoTypeUttak, NavnPåForeldre } from '@navikt/fp-types';
+import {
+    KontoBeregningDto,
+    KontoDto,
+    KontoType,
+    KontoTypeUttak,
+    MorsAktivitet,
+    NavnPåForeldre,
+} from '@navikt/fp-types';
 import { capitalizeFirstLetter, getNavnGenitivEierform } from '@navikt/fp-utils';
 
 export const getStønadskontoNavn = (
     intl: IntlShape,
-    konto: KontoTypeUttak | undefined,
+    konto: KontoType | undefined,
     navnPåForeldre: NavnPåForeldre,
     erFarEllerMedmor: boolean,
     erAleneOmOmsorg?: boolean,
+    morsAktivitet?: MorsAktivitet,
 ) => {
     if ((erFarEllerMedmor && konto === 'FEDREKVOTE') || (!erFarEllerMedmor && konto === 'MØDREKVOTE')) {
         return intl.formatMessage({ id: 'uttaksplan.stønadskontotype.dinKvote' });
@@ -34,7 +42,7 @@ export const getStønadskontoNavn = (
     }
 
     if (erFarEllerMedmor === true && erAleneOmOmsorg === false) {
-        if (konto === 'AKTIVITETSFRI_KVOTE') {
+        if (konto === 'FORELDREPENGER' && morsAktivitet === 'IKKE_OPPGITT') {
             return intl.formatMessage({ id: 'uttaksplan.stønadskontotype.AKTIVITETSFRI_KVOTE_BFHR' });
         }
         if (konto === 'FORELDREPENGER') {


### PR DESCRIPTION
- Legg til at det ikke vises 'Foreldrepenger med aktivitetskrav' i oppsummeringssteg når det bare er far som har rett.
- Legg til test.