### PR TITLE
fix: skjul 'Mor/Far skal ha?' til forelder er valgt i uttaksplankalender

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -216,7 +216,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
 
             {forelder !== undefined && <hr className="text-ax-border-neutral-subtle" />}
 
-            {forelder !== 'FAR_MEDMOR' && gyldigeStønadskontoerForMor.length > 0 && (
+            {(forelder === 'MOR' || forelder === 'BEGGE') && gyldigeStønadskontoerForMor.length > 0 && (
                 <RhfRadioGroup
                     name="kontoTypeMor"
                     control={formMethods.control}
@@ -234,7 +234,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                     })}
                 </RhfRadioGroup>
             )}
-            {forelder !== 'MOR' && gyldigeStønadskontoerForFarMedmor.length > 0 && (
+            {(forelder === 'FAR_MEDMOR' || forelder === 'BEGGE') && gyldigeStønadskontoerForFarMedmor.length > 0 && (
                 <RhfRadioGroup
                     name="kontoTypeFarMedmor"
                     control={formMethods.control}


### PR DESCRIPTION
Betingelsene for å vise kontoTypeMor og kontoTypeFarMedmor var negative sjekker (f.eks. forelder !== 'FAR_MEDMOR'), som også er sanne når forelder er undefined. Endret til eksplisitte positive sjekker slik at feltene bare vises etter at brukeren har valgt hvem som skal ha foreldrepenger.