### PR TITLE
FIX navigasjonsfeil i arbeid-og-inntekt

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
@@ -70,7 +70,7 @@ export const ArbeidsforholdOgInntektSteg = ({ mellomlagreSøknadOgNaviger, avbry
             return navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER);
         }
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep(SøknadRoutes.ANNEN_FORELDER);
     };
 
     return (


### PR DESCRIPTION
Har fiksa denne feilen https://sentry.gc.nav.no/organizations/nav/issues/616977/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=5

Problemet oppstår når ein til dømes har valgt ja for frilans og fyller ut data for den, og så går tilbake og vel nei på alle. Da vil state i useStepConfig henga igjen og defaultNextStep vil gi feil rute. Dvs at useNextStep-funksjonane nok ikkje er 100%, men fiksar dette spesifikt på ein enkel måte sidan det ser ut som dette er einaste plassen som har problemet.