### PR TITLE
fix(foreldrepengesoknad): unngå Step-krasj ved navigasjon med stale s…

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -1,6 +1,8 @@
 import { SøknadRoutes } from 'appData/routes';
+import { useRef } from 'react';
+import { flushSync } from 'react-dom';
 
-import { loggUmamiEvent } from '@navikt/fp-observability';
+import { captureMessage, loggUmamiEvent } from '@navikt/fp-observability';
 import { EksternArbeidsforholdDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 
 import { ContextDataType, useContextSaveData } from './FpDataContext';
@@ -15,11 +17,40 @@ export const useFpNavigator = (
     const stepConfig = useStepConfig(arbeidsforhold, erEndringssøknad, eksisterendeSak);
     const oppdaterPath = useContextSaveData(ContextDataType.APP_ROUTE);
 
-    const goToPreviousDefaultStep = () => {
-        const index = stepConfig.findIndex((s) => s.isSelected) - 1;
-        const previousPath = stepConfig[index]?.id ?? SøknadRoutes.VELKOMMEN;
-        oppdaterPath(previousPath);
+    // `stepConfig` er utleia frå context-data. Når kallande kode oppdaterer context (t.d. `oppdaterUttaksplan(...)`)
+    // rett før den navigerer, har den nye contexten ikkje rukke å bli applisert enno – så closure-en ville sett gamal `stepConfig`.
+    // Vi held derfor ein ref som oppdaterast kvar render, og `flushSync` tvingar React til å committa ventande dispatches før vi les ref-en.
+    const stepConfigRef = useRef(stepConfig);
+    stepConfigRef.current = stepConfig;
+
+    const navigerTilDefaultSteg = (retning: 'next' | 'previous') => {
+        // Tøm ut ventande context-dispatches frå same event-handler slik at `stepConfigRef.current` reflekterer den oppdaterte tilstanden.
+        // eslint-disable-next-line @eslint-react/dom-no-flush-sync -- bevisst: må committa context-dispatches frå kallande kode før vi reknar ut neste path
+        flushSync(() => {});
+
+        const ferskStepConfig = stepConfigRef.current;
+        const currentIndex = ferskStepConfig.findIndex((s) => s.isSelected);
+        if (currentIndex === -1) {
+            captureMessage(`useFpNavigator: kunne ikkje finne valgt steg i stepConfig ved ${retning}-navigasjon`);
+            return;
+        }
+
+        const path =
+            retning === 'next'
+                ? ferskStepConfig[currentIndex + 1]?.id
+                : (ferskStepConfig[currentIndex - 1]?.id ?? SøknadRoutes.VELKOMMEN);
+
+        if (path === undefined) {
+            captureMessage(`useFpNavigator: fann ingen ${retning}-path frå steg ${ferskStepConfig[currentIndex]?.id}`);
+            return;
+        }
+
+        oppdaterPath(path);
         void mellomlagreOgNaviger();
+    };
+
+    const goToPreviousDefaultStep = () => {
+        navigerTilDefaultSteg('previous');
     };
 
     const goToNextStep = (path: SøknadRoutes) => {
@@ -28,11 +59,7 @@ export const useFpNavigator = (
     };
 
     const goToNextDefaultStep = () => {
-        const index = stepConfig.findIndex((s) => s.isSelected) + 1;
-        const nextPath = stepConfig[index]?.id;
-
-        oppdaterPath(nextPath);
-        void mellomlagreOgNaviger();
+        navigerTilDefaultSteg('next');
     };
 
     const fortsettSøknadSenere = () => {

--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -20,28 +20,20 @@ export const useFpNavigator = (
     // fordi kallande kode ofte dispatcher context-oppdateringar (t.d. oppdaterUttaksplan)
     // i same handler. Vi triggar derfor ein effekt med eit sekvensnummer; effekten køyrer
     // etter neste render og les då ferskt `stepConfig`.
-    const nextSeqRef = useRef(0);
-    const lastProcessedSeqRef = useRef(0);
     const directionRef = useRef<'next' | 'previous' | null>(null);
     const [seq, setSeq] = useState(0);
 
     const navigerTilDefaultSteg = (retning: 'next' | 'previous') => {
-        nextSeqRef.current += 1;
         directionRef.current = retning;
-        setSeq(nextSeqRef.current);
+        setSeq((s) => s + 1);
     };
 
     useEffect(() => {
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- bevisst: må vente på render etter context-dispatch
-        if (seq === lastProcessedSeqRef.current) {
-            return;
-        }
-        lastProcessedSeqRef.current = seq;
-
         const retning = directionRef.current;
         if (retning === null) {
             return;
         }
+        directionRef.current = null;
 
         const currentIndex = stepConfig.findIndex((s) => s.isSelected);
         if (currentIndex === -1) {

--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -1,6 +1,5 @@
 import { SøknadRoutes } from 'appData/routes';
-import { useRef } from 'react';
-import { flushSync } from 'react-dom';
+import { useEffect, useRef, useState } from 'react';
 
 import { captureMessage, loggUmamiEvent } from '@navikt/fp-observability';
 import { EksternArbeidsforholdDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
@@ -17,19 +16,34 @@ export const useFpNavigator = (
     const stepConfig = useStepConfig(arbeidsforhold, erEndringssøknad, eksisterendeSak);
     const oppdaterPath = useContextSaveData(ContextDataType.APP_ROUTE);
 
-    // `stepConfig` er utleia frå context-data. Når kallande kode oppdaterer context (t.d. `oppdaterUttaksplan(...)`)
-    // rett før den navigerer, har den nye contexten ikkje rukke å bli applisert enno – så closure-en ville sett gamal `stepConfig`.
-    // Vi held derfor ein ref som oppdaterast kvar render, og `flushSync` tvingar React til å committa ventande dispatches før vi les ref-en.
-    const stepConfigRef = useRef(stepConfig);
-    stepConfigRef.current = stepConfig;
+    // Vi kan ikkje rekne ut next/previous path synkront frå closure-fanga `stepConfig`,
+    // fordi kallande kode ofte dispatcher context-oppdateringar (t.d. oppdaterUttaksplan)
+    // i same handler. Vi triggar derfor ein effekt med eit sekvensnummer; effekten køyrer
+    // etter neste render og les då ferskt `stepConfig`.
+    const nextSeqRef = useRef(0);
+    const lastProcessedSeqRef = useRef(0);
+    const directionRef = useRef<'next' | 'previous' | null>(null);
+    const [seq, setSeq] = useState(0);
 
     const navigerTilDefaultSteg = (retning: 'next' | 'previous') => {
-        // Tøm ut ventande context-dispatches frå same event-handler slik at `stepConfigRef.current` reflekterer den oppdaterte tilstanden.
-        // eslint-disable-next-line @eslint-react/dom-no-flush-sync -- bevisst: må committa context-dispatches frå kallande kode før vi reknar ut neste path
-        flushSync(() => {});
+        nextSeqRef.current += 1;
+        directionRef.current = retning;
+        setSeq(nextSeqRef.current);
+    };
 
-        const ferskStepConfig = stepConfigRef.current;
-        const currentIndex = ferskStepConfig.findIndex((s) => s.isSelected);
+    useEffect(() => {
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- bevisst: må vente på render etter context-dispatch
+        if (seq === lastProcessedSeqRef.current) {
+            return;
+        }
+        lastProcessedSeqRef.current = seq;
+
+        const retning = directionRef.current;
+        if (retning === null) {
+            return;
+        }
+
+        const currentIndex = stepConfig.findIndex((s) => s.isSelected);
         if (currentIndex === -1) {
             captureMessage(`useFpNavigator: kunne ikkje finne valgt steg i stepConfig ved ${retning}-navigasjon`);
             return;
@@ -37,17 +51,17 @@ export const useFpNavigator = (
 
         const path =
             retning === 'next'
-                ? ferskStepConfig[currentIndex + 1]?.id
-                : (ferskStepConfig[currentIndex - 1]?.id ?? SøknadRoutes.VELKOMMEN);
+                ? stepConfig[currentIndex + 1]?.id
+                : (stepConfig[currentIndex - 1]?.id ?? SøknadRoutes.VELKOMMEN);
 
         if (path === undefined) {
-            captureMessage(`useFpNavigator: fann ingen ${retning}-path frå steg ${ferskStepConfig[currentIndex]?.id}`);
+            captureMessage(`useFpNavigator: fann ingen ${retning}-path frå steg ${stepConfig[currentIndex]?.id}`);
             return;
         }
 
         oppdaterPath(path);
         void mellomlagreOgNaviger();
-    };
+    }, [seq, stepConfig, mellomlagreOgNaviger, oppdaterPath]);
 
     const goToPreviousDefaultStep = () => {
         navigerTilDefaultSteg('previous');

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
@@ -70,7 +70,7 @@ export const ArbeidsforholdOgInntektSteg = ({ mellomlagreSøknadOgNaviger, avbry
             return navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER);
         }
 
-        return navigator.goToNextStep(SøknadRoutes.ANNEN_FORELDER);
+        return navigator.goToNextDefaultStep();
     };
 
     return (


### PR DESCRIPTION
…tepConfig

Det dukka opp fleire lignande feil, så da fekk eg Claude til å laga ein generell fiks i staden for den fiksen eg laga i går. Litt usikker på bruken av flushSync (ser den blir fraråda brukt), men ser ut til å fungera.

Claude:
Tidlegare las useFpNavigator.goToNextDefaultStep / goToPreviousDefaultStep stepConfig frå closure-en sin. Når kallande kode oppdaterte context rett før navigering (t.d. oppdaterUttaksplan i UttaksplanForm.onSubmit eller gåTilForrigeSteg), brukte navigatoren stale stepConfig og kunne sende brukar til eit steg som etter neste render fall ut av appPathList. Då kasta Step.tsx 'Ingen valgte steg funnet'.

Vi held no ein ref til stepConfig som oppdaterast kvar render, og bruker flushSync til å committa ventande context-dispatches frå same event-handler før vi reknar ut next/previous path frå ferskt stepConfig. Loggar via captureMessage dersom vi ikkje finn valgt steg eller path er udefinert, slik at framtidige tilfelle blir synlege i Sentry i staden for å kasta runtime-feil.

Som ein del av same fiks bruker ArbeidsforholdOgInntektSteg no goToNextDefaultStep i staden for hardkoda goToNextStep(ANNEN_FORELDER), slik at neste steg blir konsistent utleia frå stepConfig.