### PR TITLE
Fiks lokalisering av feilmeldingar i useEsMellomlagring og useEsSendS…

### DIFF
--- a/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
+++ b/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { API_URLS } from 'appData/queries';
 import ky, { HTTPError } from 'ky';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
 import { captureMessage } from '@navikt/fp-observability';
@@ -13,15 +14,15 @@ export const VERSJON_MELLOMLAGRING = 5;
 
 export type EsMellomlagretData = { version: number; personinfo: EsPersonopplysningerDto_fpoversikt } & ContextDataMap;
 
-// TODO (TOR) Fiks lokalisering
 const UKJENT_UUID = 'ukjent uuid';
-const FEIL_VED_INNSENDING =
+const FEIL_VED_MELLOMLAGRING_LOG =
     'Det har oppstått et problem med mellomlagring av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil-id: ';
 
 export const useEsMellomlagring = (
     personinfo: EsPersonopplysningerDto_fpoversikt,
     setVelkommen: (erVelkommen: boolean) => void,
 ) => {
+    const intl = useIntl();
     const navigate = useNavigate();
     const state = useContextComplete();
     const resetState = useContextReset();
@@ -57,9 +58,15 @@ export const useEsMellomlagring = (
                             }
 
                             const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                            const callId = jsonResponse?.callId ?? UKJENT_UUID;
-                            captureMessage(FEIL_VED_INNSENDING + callId);
-                            throw new Error(FEIL_VED_INNSENDING + callId.substring(0, 6), { cause: error });
+                            const callId = jsonResponse?.callId;
+                            captureMessage(FEIL_VED_MELLOMLAGRING_LOG + (callId ?? UKJENT_UUID));
+                            const feilmelding = callId
+                                ? intl.formatMessage(
+                                      { id: 'useEsMellomlagring.FeilVedMellomlagring.MedCallId' },
+                                      { callId: callId.substring(0, 6) },
+                                  )
+                                : intl.formatMessage({ id: 'useEsMellomlagring.FeilVedMellomlagring.UtenCallId' });
+                            throw new Error(feilmelding, { cause: error });
                         }
                         if (error instanceof Error) {
                             throw error;

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -3,6 +3,7 @@ import { Path } from 'appData/paths';
 import { API_URLS } from 'appData/queries';
 import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { Dokumentasjon, erTerminDokumentasjon } from 'types/Dokumentasjon';
 import { OmBarnet, erAdopsjon, erBarnetFødt, harBarnetTermindato } from 'types/OmBarnet';
@@ -51,12 +52,11 @@ const mapBarn = (omBarnet: OmBarnet, dokumentasjon?: Dokumentasjon) => {
     throw new Error('Det er feil i data om barnet');
 };
 
-// TODO (TOR) Fiks lokalisering
-const UKJENT_UUID = 'ukjent uuid';
-const FEIL_VED_INNSENDING =
+const FEIL_VED_INNSENDING_LOG =
     'Det har oppstått et problem med innsending av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil-id: ';
 
 export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt) => {
+    const intl = useIntl();
     const navigate = useNavigate();
     const hentData = useContextGetAnyData();
     const { initAbortSignal } = useAbortSignal();
@@ -101,9 +101,15 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
                 }
 
                 const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                captureMessage(`${FEIL_VED_INNSENDING}${JSON.stringify(jsonResponse)}`);
-                const callId = jsonResponse?.callId ?? UKJENT_UUID;
-                throw new Error(FEIL_VED_INNSENDING + callId.substring(0, 6), { cause: error });
+                captureMessage(`${FEIL_VED_INNSENDING_LOG}${JSON.stringify(jsonResponse)}`);
+                const callId = jsonResponse?.callId;
+                const feilmelding = callId
+                    ? intl.formatMessage(
+                          { id: 'useEsSendSøknad.FeilVedInnsending.MedCallId' },
+                          { callId: callId.substring(0, 6) },
+                      )
+                    : intl.formatMessage({ id: 'useEsSendSøknad.FeilVedInnsending.UtenCallId' });
+                throw new Error(feilmelding, { cause: error });
             }
             if (error instanceof Error) {
                 throw error;

--- a/apps/engangsstonad/src/intl/messages/en_US.json
+++ b/apps/engangsstonad/src/intl/messages/en_US.json
@@ -115,5 +115,9 @@
     "UseStepConfig.Utenlandsopphold": "Stays abroad",
     "UseStepConfig.TidligereUtenlandsopphold": "Stays abroad",
     "UseStepConfig.FremtidigUtenlandsopphold": "Stay abroad",
-    "UseStepConfig.Oppsummering": "Summary"
+    "UseStepConfig.Oppsummering": "Summary",
+    "useEsMellomlagring.FeilVedMellomlagring.MedCallId": "A problem occurred while saving the application. Please try again later. If the problem persists, contact us and provide the error ID: {callId}",
+    "useEsMellomlagring.FeilVedMellomlagring.UtenCallId": "A problem occurred while saving the application. Please try again later. If the problem persists, please contact us.",
+    "useEsSendSøknad.FeilVedInnsending.MedCallId": "A problem occurred while submitting the application. Please try again later. If the problem persists, contact us and provide the error ID: {callId}",
+    "useEsSendSøknad.FeilVedInnsending.UtenCallId": "A problem occurred while submitting the application. Please try again later. If the problem persists, please contact us."
 }

--- a/apps/engangsstonad/src/intl/messages/nb_NO.json
+++ b/apps/engangsstonad/src/intl/messages/nb_NO.json
@@ -115,5 +115,9 @@
     "UseStepConfig.Utenlandsopphold": "Bo i utlandet",
     "UseStepConfig.TidligereUtenlandsopphold": "Har bodd i utlandet",
     "UseStepConfig.FremtidigUtenlandsopphold": "Skal bo i utlandet",
-    "UseStepConfig.Oppsummering": "Oppsummering"
+    "UseStepConfig.Oppsummering": "Oppsummering",
+    "useEsMellomlagring.FeilVedMellomlagring.MedCallId": "Det har oppstått et problem med mellomlagring av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil-id: {callId}",
+    "useEsMellomlagring.FeilVedMellomlagring.UtenCallId": "Det har oppstått et problem med mellomlagring av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, ta kontakt med oss.",
+    "useEsSendSøknad.FeilVedInnsending.MedCallId": "Det har oppstått et problem med innsending av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil-id: {callId}",
+    "useEsSendSøknad.FeilVedInnsending.UtenCallId": "Det har oppstått et problem med innsending av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, ta kontakt med oss."
 }

--- a/apps/engangsstonad/src/intl/messages/nn_NO.json
+++ b/apps/engangsstonad/src/intl/messages/nn_NO.json
@@ -115,5 +115,9 @@
     "UseStepConfig.Utenlandsopphold": "Bu i utlandet",
     "UseStepConfig.TidligereUtenlandsopphold": "Har budd i utlandet",
     "UseStepConfig.FremtidigUtenlandsopphold": "Skal bu i utlandet",
-    "UseStepConfig.Oppsummering": "Oppsummering"
+    "UseStepConfig.Oppsummering": "Oppsummering",
+    "useEsMellomlagring.FeilVedMellomlagring.MedCallId": "Det har oppstått eit problem med mellomlagring av søknaden. Ver venleg og prøv igjen seinare. Viss problemet vedvarar, kontakt oss og oppgje feil-id: {callId}",
+    "useEsMellomlagring.FeilVedMellomlagring.UtenCallId": "Det har oppstått eit problem med mellomlagring av søknaden. Ver venleg og prøv igjen seinare. Viss problemet vedvarar, ta kontakt med oss.",
+    "useEsSendSøknad.FeilVedInnsending.MedCallId": "Det har oppstått eit problem med innsending av søknaden. Ver venleg og prøv igjen seinare. Viss problemet vedvarar, kontakt oss og oppgje feil-id: {callId}",
+    "useEsSendSøknad.FeilVedInnsending.UtenCallId": "Det har oppstått eit problem med innsending av søknaden. Ver venleg og prøv igjen seinare. Viss problemet vedvarar, ta kontakt med oss."
 }


### PR DESCRIPTION
…øknad

Hardkoda bokmålstekstar er erstatta med lokaliserte meldingsnøklar via useIntl(). Feilmeldingane som vises til brukar vil no bruke app-språket (bokmål/nynorsk/engelsk).

- Legg til 4 nye meldingsnøklar i nb_NO, nn_NO og en_US
- useEsMellomlagring: brukar intl.formatMessage for kasta feilar
- useEsSendSøknad: brukar intl.formatMessage for kasta feilar
- captureMessage-kall for ops-logging held fram med norsk teknisk tekst
- Skil mellom feilmelding med og utan callId