### PR TITLE
Bruk Aksel Page, Page.Block og Box i Page-komponenten

### DIFF
--- a/packages/ui/src/page/Page.tsx
+++ b/packages/ui/src/page/Page.tsx
@@ -1,3 +1,4 @@
+import { Box, Page as AkselPage } from '@navikt/ds-react';
 import { ReactNode } from 'react';
 
 interface Props {
@@ -5,21 +6,25 @@ interface Props {
     children: React.ReactElement | React.ReactElement[];
 }
 
-// TODO (TOR) Ta i bruk Page-komponenten til Aksel (Evt SkjemaRotLayout)
 export const Page = ({ header, children }: Props) => {
     return (
-        <div className="bg-ax-neutral-200 pt-4 pb-4 max-[1024px]:flex max-[1024px]:flex-1 max-[1024px]:flex-col max-[1024px]:pt-0">
-            <div className="bg-ax-bg-default mx-auto max-w-[1004px] rounded-t-[8px] max-[1024px]:m-0 max-[1024px]:w-full max-[1024px]:max-w-none">
-                {header}
-            </div>
-            <div
-                className={
-                    'bg-ax-bg-default mx-auto max-w-[1004px] rounded-b-[8px] p-8 max-[1024px]:m-0 max-[1024px]:flex max-[1024px]:max-w-none ' +
-                    'max-[1024px]:flex-1 max-[1024px]:flex-col max-[1024px]:rounded-none max-[1024px]:px-[1rem] max-[1024px]:py-[1.5rem]'
-                }
+        <AkselPage contentBlockPadding="none" className="bg-ax-neutral-200 pt-4 pb-4 max-[1023px]:pt-0">
+            <AkselPage.Block
+                width="lg"
+                className="max-[1023px]:flex max-[1023px]:flex-col max-[1023px]:h-full"
             >
-                {children}
-            </div>
-        </div>
+                <Box background="default" className="rounded-t-[8px] max-[1023px]:rounded-none">
+                    {header}
+                </Box>
+                <Box
+                    background="default"
+                    paddingInline={{ xs: 'space-16', lg: 'space-32' }}
+                    paddingBlock={{ xs: 'space-24', lg: 'space-32' }}
+                    className="rounded-b-[8px] max-[1023px]:rounded-none max-[1023px]:flex-1 max-[1023px]:flex max-[1023px]:flex-col"
+                >
+                    {children}
+                </Box>
+            </AkselPage.Block>
+        </AkselPage>
     );
 };


### PR DESCRIPTION
Erstattar eigendefinerte div-element med Aksel-komponentar:
- Ytre div → AkselPage (gir flex-col + min-height: 100vh automatisk)
- Sentrert kortblokk → Page.Block width="lg" (max-w 1024px, var mx-auto)
- Bakgrunnsfargar → Box background="default"
- Padding på innhaldsseksjon → Box paddingInline/Block med responsive verdiar

Breakpoint-justeringar:
- max-[1024px] → max-[1023px] for å samsvare med Aksels lg-breakpoint (≥1024px)