### PR TITLE
Pass gjeldendeSak as prop to DinPlan

### DIFF
--- a/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
@@ -179,6 +179,7 @@ const SaksoversiktInner = ({ søkerinfo }: Props) => {
                             skeletonProps={{ height: '210px', variant: 'rounded' }}
                         >
                             <DinPlan
+                                sak={gjeldendeSak}
                                 annenPartsPerioder={annenPartsVedtakQuery.data?.perioder ?? []}
                                 navnPåForeldre={getNavnPåForeldre(
                                     gjeldendeSak,

--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
@@ -95,6 +95,7 @@ export const FarSøker: Story = {
                 },
             ],
             dekningsgrad: 'HUNDRE',
+            forelder: 'FAR_MEDMOR',
             ytelse: 'FORELDREPENGER' as const,
         },
         annenPartsPerioder: [

--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { saker } from 'storybookData/saker/saker';
 import { stønadskontoer1 } from 'storybookData/stønadskontoer/stønadskontoer1';
 import { stønadskontoer2 } from 'storybookData/stønadskontoer/stønadskontoer2';
@@ -8,22 +7,12 @@ import { stønadskontoer2 } from 'storybookData/stønadskontoer/stønadskontoer2
 import { withQueryClient } from '@navikt/fp-utils-test';
 
 import { API_URLS } from '../../api/queries.ts';
-import { OversiktRoutes } from '../../routes/routes';
 import { DinPlan } from './DinPlan';
 
 const meta = {
     title: 'DinPlan',
     component: DinPlan,
     decorators: [withQueryClient],
-    render: (props) => {
-        return (
-            <MemoryRouter initialEntries={[`/${OversiktRoutes.DIN_PLAN}/1`]}>
-                <Routes>
-                    <Route element={<DinPlan {...props} />} path={`/${OversiktRoutes.DIN_PLAN}/:saksnummer`} />
-                </Routes>
-            </MemoryRouter>
-        );
-    },
 } satisfies Meta<typeof DinPlan>;
 export default meta;
 
@@ -32,13 +21,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     parameters: {
         msw: {
-            handlers: [
-                http.get(API_URLS.saker, () => HttpResponse.json(saker)),
-                http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer1)),
-            ],
+            handlers: [http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer1))],
         },
     },
     args: {
+        sak: { ...saker.foreldrepenger[0]!, ytelse: 'FORELDREPENGER' as const },
         annenPartsPerioder: [
             {
                 fom: '2022-10-14',
@@ -59,66 +46,57 @@ export const Default: Story = {
 export const FarSøker: Story = {
     parameters: {
         msw: {
-            handlers: [
-                http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer2)),
-                http.get(API_URLS.saker, () =>
-                    HttpResponse.json({
-                        foreldrepenger: [
-                            {
-                                oppdatertTidspunkt: '2024-02-28T21:19:08.911',
-                                saksnummer: '1',
-                                sakAvsluttet: false,
-                                kanSøkeOmEndring: true,
-                                sakTilhørerMor: false,
-                                gjelderAdopsjon: false,
-                                morUføretrygd: false,
-                                harAnnenForelderTilsvarendeRettEØS: false,
-                                ønskerJustertUttakVedFødsel: false,
-                                rettighetType: 'BEGGE_RETT',
-                                annenPart: {
-                                    fnr: '03506715317',
-                                },
-                                familiehendelse: {
-                                    fødselsdato: '2024-10-01',
-                                    termindato: '2024-10-01',
-                                    antallBarn: 1,
-                                },
-                                gjeldendeVedtak: {
-                                    perioder: [
-                                        {
-                                            fom: '2024-10-01',
-                                            tom: '2024-10-14',
-                                            kontoType: 'FEDREKVOTE',
-                                            forelder: 'FAR_MEDMOR',
-                                            samtidigUttak: 100,
-                                            flerbarnsdager: false,
-                                        },
-                                        {
-                                            fom: '2025-01-01',
-                                            tom: '2025-02-04',
-                                            forelder: 'FAR_MEDMOR',
-                                            kontoType: 'MØDREKVOTE',
-                                            overføringÅrsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
-                                            flerbarnsdager: false,
-                                        },
-                                    ],
-                                },
-                                barn: [
-                                    {
-                                        fnr: '01472254177',
-                                    },
-                                ],
-                                dekningsgrad: 'HUNDRE',
-                            },
-                        ],
-                        engangsstønad: [],
-                        svangerskapspenger: [],
-                    }),
-                ),
-            ],
+            handlers: [http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer2))],
         },
     },
     args: {
+        sak: {
+            oppdatertTidspunkt: '2024-02-28T21:19:08.911',
+            saksnummer: '1',
+            sakAvsluttet: false,
+            kanSøkeOmEndring: true,
+            sakTilhørerMor: false,
+            gjelderAdopsjon: false,
+            morUføretrygd: false,
+            harAnnenForelderTilsvarendeRettEØS: false,
+            ønskerJustertUttakVedFødsel: false,
+            rettighetType: 'BEGGE_RETT',
+            annenPart: {
+                fnr: '03506715317',
+            },
+            familiehendelse: {
+                fødselsdato: '2024-10-01',
+                termindato: '2024-10-01',
+                antallBarn: 1,
+            },
+            gjeldendeVedtak: {
+                perioder: [
+                    {
+                        fom: '2024-10-01',
+                        tom: '2024-10-14',
+                        kontoType: 'FEDREKVOTE',
+                        forelder: 'FAR_MEDMOR',
+                        samtidigUttak: 100,
+                        flerbarnsdager: false,
+                    },
+                    {
+                        fom: '2025-01-01',
+                        tom: '2025-02-04',
+                        forelder: 'FAR_MEDMOR',
+                        kontoType: 'MØDREKVOTE',
+                        overføringÅrsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
+                        flerbarnsdager: false,
+                    },
+                ],
+            },
+            barn: [
+                {
+                    fnr: '01472254177',
+                },
+            ],
+            dekningsgrad: 'HUNDRE',
+            ytelse: 'FORELDREPENGER' as const,
+        },
         annenPartsPerioder: [
             {
                 fom: '2024-09-10',
@@ -181,91 +159,82 @@ export const MorOgFarOgFarGraderer: Story = {
     name: 'Mor og far søker - far graderer',
     parameters: {
         msw: {
-            handlers: [
-                http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer2)),
-                http.get(API_URLS.saker, () =>
-                    HttpResponse.json({
-                        foreldrepenger: [
-                            {
-                                saksnummer: '1',
-                                sakAvsluttet: false,
-                                kanSøkeOmEndring: true,
-                                sakTilhørerMor: true,
-                                gjelderAdopsjon: false,
-                                morUføretrygd: false,
-                                harAnnenForelderTilsvarendeRettEØS: false,
-                                ønskerJustertUttakVedFødsel: false,
-                                rettighetType: 'BEGGE_RETT',
-                                annenPart: {
-                                    fnr: '29459848930',
-                                },
-                                familiehendelse: {
-                                    fødselsdato: '2025-03-25',
-                                    termindato: '2025-03-25',
-                                    antallBarn: 1,
-                                },
-                                gjeldendeVedtak: {
-                                    perioder: [
-                                        {
-                                            fom: '2025-03-04',
-                                            tom: '2025-03-24',
-                                            kontoType: 'FORELDREPENGER_FØR_FØDSEL',
-                                            resultat: {
-                                                innvilget: true,
-                                                trekkerMinsterett: true,
-                                                trekkerDager: true,
-                                                årsak: 'ANNET',
-                                            },
-                                            flerbarnsdager: false,
-                                            forelder: 'MOR',
-                                        },
-                                        {
-                                            fom: '2025-03-25',
-                                            tom: '2025-07-07',
-                                            kontoType: 'MØDREKVOTE',
-                                            resultat: {
-                                                innvilget: true,
-                                                trekkerMinsterett: true,
-                                                trekkerDager: true,
-                                                årsak: 'ANNET',
-                                            },
-                                            flerbarnsdager: false,
-                                            forelder: 'MOR',
-                                        },
-                                        {
-                                            fom: '2025-07-08',
-                                            tom: '2025-09-01',
-                                            kontoType: 'FELLESPERIODE',
-                                            resultat: {
-                                                innvilget: true,
-                                                trekkerMinsterett: true,
-                                                trekkerDager: true,
-                                                årsak: 'ANNET',
-                                            },
-                                            flerbarnsdager: false,
-                                            forelder: 'MOR',
-                                        },
-                                    ],
-                                    perioderAnnenpartEøs: [],
-                                },
-                                barn: [
-                                    {
-                                        fnr: '22442356029',
-                                    },
-                                ],
-                                dekningsgrad: 'HUNDRE',
-                                oppdatertTidspunkt: '2025-09-16T14:09:43.208',
-                                forelder: 'MOR',
-                            },
-                        ],
-                        engangsstønad: [],
-                        svangerskapspenger: [],
-                    }),
-                ),
-            ],
+            handlers: [http.post(API_URLS.konto, () => HttpResponse.json(stønadskontoer2))],
         },
     },
     args: {
+        sak: {
+            saksnummer: '1',
+            sakAvsluttet: false,
+            kanSøkeOmEndring: true,
+            sakTilhørerMor: true,
+            gjelderAdopsjon: false,
+            morUføretrygd: false,
+            harAnnenForelderTilsvarendeRettEØS: false,
+            ønskerJustertUttakVedFødsel: false,
+            rettighetType: 'BEGGE_RETT',
+            annenPart: {
+                fnr: '29459848930',
+            },
+            familiehendelse: {
+                fødselsdato: '2025-03-25',
+                termindato: '2025-03-25',
+                antallBarn: 1,
+            },
+            gjeldendeVedtak: {
+                perioder: [
+                    {
+                        fom: '2025-03-04',
+                        tom: '2025-03-24',
+                        kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                        resultat: {
+                            innvilget: true,
+                            trekkerMinsterett: true,
+                            trekkerDager: true,
+                            årsak: 'ANNET',
+                        },
+                        flerbarnsdager: false,
+                        forelder: 'MOR',
+                    },
+                    {
+                        fom: '2025-03-25',
+                        tom: '2025-07-07',
+                        kontoType: 'MØDREKVOTE',
+                        resultat: {
+                            innvilget: true,
+                            trekkerMinsterett: true,
+                            trekkerDager: true,
+                            årsak: 'ANNET',
+                        },
+                        flerbarnsdager: false,
+                        forelder: 'MOR',
+                    },
+                    {
+                        fom: '2025-07-08',
+                        tom: '2025-09-01',
+                        kontoType: 'FELLESPERIODE',
+                        resultat: {
+                            innvilget: true,
+                            trekkerMinsterett: true,
+                            trekkerDager: true,
+                            årsak: 'ANNET',
+                        },
+                        flerbarnsdager: false,
+                        forelder: 'MOR',
+                    },
+                ],
+                perioderAnnenpartEøs: [],
+            },
+            barn: [
+                {
+                    fnr: '22442356029',
+                },
+            ],
+            dekningsgrad: 'HUNDRE',
+            oppdatertTidspunkt: '2025-09-16T14:09:43.208',
+            forelder: 'MOR',
+            ytelse: 'FORELDREPENGER' as const,
+        },
         annenPartsPerioder: [
             {
                 fom: '2025-09-23',
@@ -333,3 +302,4 @@ export const MorOgFarOgFarGraderer: Story = {
         },
     },
 };
+

--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
@@ -16,26 +16,15 @@ import { Uttaksperioden, useMedia } from '@navikt/fp-utils';
 import { KvoteOppsummering, UttaksplanDataProvider, UttaksplanKalender, UttaksplanListe } from '@navikt/fp-uttaksplan';
 
 import { hentUttaksKontoOptions } from '../../api/queries';
-import { useGetSelectedSak } from '../../hooks/useSelectedSak';
 import { getBarnFraSak } from '../../utils/sakerUtils';
 
 interface Props {
+    sak: Foreldrepengesak;
     navnPåForeldre: NavnPåForeldre;
     annenPartsPerioder: UttakPeriode_fpoversikt[];
 }
 
-// TODO (TOR) Send heller med gjeldendeSak som prop
-export const DinPlan = ({ annenPartsPerioder, navnPåForeldre }: Props) => {
-    const gjeldendeSak = useGetSelectedSak();
-
-    if (gjeldendeSak?.ytelse !== 'FORELDREPENGER') {
-        return null;
-    }
-
-    return <DinPlanMedSak annenPartsPerioder={annenPartsPerioder} navnPåForeldre={navnPåForeldre} sak={gjeldendeSak} />;
-};
-
-const DinPlanMedSak = ({ annenPartsPerioder, navnPåForeldre, sak }: Props & { sak: Foreldrepengesak }) => {
+export const DinPlan = ({ annenPartsPerioder, navnPåForeldre, sak }: Props) => {
     const isDesktop = useMedia('screen and (min-width: 768px)');
 
     const [visKalender, setVisKalender] = useState(false);


### PR DESCRIPTION
Remove internal useGetSelectedSak hook from DinPlan and instead accept sak as an explicit prop. The parent (Saksoversikt) already has the sak and only renders DinPlan inside a ytelse === 'FORELDREPENGER' guard, so TypeScript narrows correctly at the call site.

Update stories accordingly: pass sak directly in args and remove the MemoryRouter/Routes wrapper and sakers MSW handler that were only needed to support the hook lookup.