### PR TITLE
Flytt barnehagestartDato til delt utils-pakke

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useStepConfig } from 'appData/useStepConfig';
-import dayjs from 'dayjs';
 import { ReactNode, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
@@ -14,19 +13,14 @@ import { getErSøkerFarEllerMedmor, getKjønnFromFnr, getNavnPåForeldre } from 
 
 import { Alert, BodyLong, Tabs } from '@navikt/ds-react';
 
-import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { loggUmamiEvent } from '@navikt/fp-observability';
 import {
-    Barn,
     FpPersonopplysningerDto_fpoversikt,
     FpSak_fpoversikt,
     RettighetType_fpoversikt,
-    isAdoptertBarn,
-    isFødtBarn,
 } from '@navikt/fp-types';
-import { isIkkeUtfyltTypeBarn } from '@navikt/fp-types/src/Barn';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
-import { Uttaksperioden, getFamiliehendelsedato } from '@navikt/fp-utils';
+import { Uttaksperioden, barnehagestartDato, getFamiliehendelsedato } from '@navikt/fp-utils';
 import {
     FjernAltIUttaksplanModal,
     HvaErMulig,
@@ -243,54 +237,6 @@ const utledRettighet = (erAleneOmOmsorg: boolean, erDeltUttak: boolean): Rettigh
         return 'BEGGE_RETT';
     }
     return 'BARE_SØKER_RETT';
-};
-
-// TODO (TOR) Flytt denne til felleskode - er lik funksjon i planlegger
-const barnehagestartDato = (barnet: Barn) => {
-    if (isAdoptertBarn(barnet) || isIkkeUtfyltTypeBarn(barnet)) {
-        return undefined;
-    }
-
-    const dato = isFødtBarn(barnet) ? barnet.fødselsdatoer[0]! : barnet.termindato;
-
-    if (dayjs(dato).month() < 8) {
-        const newLocal = dayjs(dato).month(7).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT);
-        return getUttaksdagTilOgMedDato(newLocal);
-    }
-    if (dayjs(dato).month() >= 8 && dayjs(dato).month() < 11) {
-        return getUttaksdagTilOgMedDato(dayjs(dato).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT));
-    }
-    return getUttaksdagTilOgMedDato(
-        dayjs(dato)
-            .startOf('year')
-            .add(2, 'year')
-            .add(7, 'months')
-            .endOf('week')
-            .endOf('month')
-            .format(ISO_DATE_FORMAT),
-    );
-};
-
-/**
- * Sjekker om dato er en ukedag, dersom ikke finner den foregående fredag.
- * Tar hensyn til stilling av klokken ved å gjøre om klokka til kl 12 før antall timer trekkes fra.
- * @param dato
- */
-const getUttaksdagTilOgMedDato = (dato: string): string => {
-    const d = dayjs(dato).toDate();
-    const newDate = dato ? new Date(d.getFullYear(), d.getMonth(), d.getDate(), 12) : dato;
-    switch (getUkedag(dato)) {
-        case 6:
-            return dayjs.utc(newDate).subtract(24, 'hours').format(ISO_DATE_FORMAT);
-        case 7:
-            return dayjs.utc(newDate).subtract(48, 'hours').format(ISO_DATE_FORMAT);
-        default:
-            return dato;
-    }
-};
-
-const getUkedag = (dato: string): number => {
-    return dayjs(dato).isoWeekday();
 };
 
 const loggExpansionCardOpen = (tittel: string) => (open: boolean) => {

--- a/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.tsx
+++ b/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.tsx
@@ -3,44 +3,28 @@ import { ContextDataType, useContextGetData } from 'appData/PlanleggerDataContex
 import { usePlanleggerNavigator } from 'appData/usePlanleggerNavigator';
 import { useStepData } from 'appData/useStepData';
 import { PlanleggerStepPage } from 'components/page/PlanleggerStepPage';
-import dayjs from 'dayjs';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { getFamiliehendelsedato } from 'steps/oppsummering/expansion-cards/BarnehageplassOppsummering';
 import { OmBarnet } from 'types/Barnet';
 import { erAlenesøker as erAlene } from 'utils/HvemPlanleggerUtils';
 import { erBarnetAdoptert, erBarnetFødt } from 'utils/barnetUtils';
-import { Uttaksdata, getUttaksdagTilOgMedDato } from 'utils/uttakUtils';
+import { Uttaksdata } from 'utils/uttakUtils';
 
 import { BodyLong, Heading, Link, VStack } from '@navikt/ds-react';
 
-import { ISO_DATE_FORMAT, links } from '@navikt/fp-constants';
+import { links } from '@navikt/fp-constants';
 import { IconCircleWrapper, Infobox, StepButtons } from '@navikt/fp-ui';
+import { beregnBarnehagestartDato } from '@navikt/fp-utils';
 import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
 import { notEmpty } from '@navikt/fp-validation';
 
-export const barnehagestartDato = (barnet: OmBarnet) => {
+export const barnehagestartDato = (barnet: OmBarnet): string | undefined => {
     if (erBarnetAdoptert(barnet)) {
         return undefined;
     }
 
     const dato = erBarnetFødt(barnet) ? barnet.fødselsdato : barnet.termindato;
-
-    if (dayjs(dato).month() < 8) {
-        const newLocal = dayjs(dato).month(7).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT);
-        return getUttaksdagTilOgMedDato(newLocal);
-    }
-    if (dayjs(dato).month() >= 8 && dayjs(dato).month() < 11) {
-        return getUttaksdagTilOgMedDato(dayjs(dato).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT));
-    }
-    return getUttaksdagTilOgMedDato(
-        dayjs(dato)
-            .startOf('year')
-            .add(2, 'year')
-            .add(7, 'months')
-            .endOf('week')
-            .endOf('month')
-            .format(ISO_DATE_FORMAT),
-    );
+    return beregnBarnehagestartDato(dato);
 };
 
 interface Props {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -32,7 +32,7 @@ export type {
     ArbeidsforholdOgInntektSvp,
 } from './src/ArbeidsforholdOgInntekt';
 export { isArbeidsforholdOgInntektFp, isArbeidsforholdOgInntektSvp } from './src/ArbeidsforholdOgInntekt';
-export { isFødtBarn, isUfødtBarn, isAdoptertBarn, isAdoptertStebarn, isAdoptertAnnetBarn } from './src/Barn';
+export { isFødtBarn, isUfødtBarn, isAdoptertBarn, isAdoptertStebarn, isAdoptertAnnetBarn, isIkkeUtfyltTypeBarn } from './src/Barn';
 export type { Utenlandsopphold, UtenlandsoppholdPeriode } from './src/Utenlandsopphold';
 
 export type { Barn, FødtBarn, UfødtBarn, AdoptertAnnetBarn, AdoptertBarn, IkkeUtfyltTypeBarn } from './src/Barn';

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -84,3 +84,4 @@ export { Uttaksperioden } from './src/uttak/Uttaksperioden';
 export { Tidsperioden } from './src/Tidsperioden';
 export * from './src/cookieUtils';
 export { periodFormat } from './src/periodUtils';
+export { barnehagestartDato } from './src/barnehagestartUtils';

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -84,4 +84,4 @@ export { Uttaksperioden } from './src/uttak/Uttaksperioden';
 export { Tidsperioden } from './src/Tidsperioden';
 export * from './src/cookieUtils';
 export { periodFormat } from './src/periodUtils';
-export { barnehagestartDato } from './src/barnehagestartUtils';
+export { barnehagestartDato, beregnBarnehagestartDato } from './src/barnehagestartUtils';

--- a/packages/utils/src/barnehagestartUtils.test.ts
+++ b/packages/utils/src/barnehagestartUtils.test.ts
@@ -1,0 +1,84 @@
+import { BarnType } from '@navikt/fp-constants';
+import { Barn } from '@navikt/fp-types';
+import { describe, expect, it } from 'vitest';
+
+import { barnehagestartDato, beregnBarnehagestartDato } from './barnehagestartUtils';
+
+describe('beregnBarnehagestartDato', () => {
+    it('skal returnere undefined når dato er undefined', () => {
+        expect(beregnBarnehagestartDato(undefined)).toBeUndefined();
+    });
+
+    it('skal returnere slutt av august neste år for januar-dato (månad < 8)', () => {
+        // Aug 31, 2025 er søndag → justert til fredag Aug 29, 2025
+        expect(beregnBarnehagestartDato('2024-01-15')).toBe('2025-08-29');
+    });
+
+    it('skal returnere slutt av august neste år for august-dato (månad = 7)', () => {
+        // Aug 31, 2025 er søndag → justert til fredag Aug 29, 2025
+        expect(beregnBarnehagestartDato('2024-08-01')).toBe('2025-08-29');
+    });
+
+    it('skal returnere slutt av september neste år for september-dato (månad = 8)', () => {
+        // Sep 30, 2025 er tysdag → ingen justering
+        expect(beregnBarnehagestartDato('2024-09-15')).toBe('2025-09-30');
+    });
+
+    it('skal returnere slutt av oktober neste år for oktober-dato (månad = 9)', () => {
+        // Oct 31, 2025 er fredag → ingen justering
+        expect(beregnBarnehagestartDato('2024-10-15')).toBe('2025-10-31');
+    });
+
+    it('skal returnere slutt av november neste år for november-dato (månad = 10)', () => {
+        // Nov 30, 2025 er søndag → justert til fredag Nov 28, 2025
+        expect(beregnBarnehagestartDato('2024-11-15')).toBe('2025-11-28');
+    });
+
+    it('skal returnere slutt av august to år etter for desember-dato (månad = 11)', () => {
+        // Aug 31, 2026 er måndag → ingen justering
+        expect(beregnBarnehagestartDato('2024-12-15')).toBe('2026-08-31');
+    });
+});
+
+describe('barnehagestartDato', () => {
+    it('skal returnere undefined for adoptert barn', () => {
+        const barn = {
+            type: BarnType.ADOPTERT_STEBARN,
+            antallBarn: 1,
+            adopsjonsdato: '2024-06-01',
+            fødselsdatoer: ['2022-01-15'],
+        } as Barn;
+
+        expect(barnehagestartDato(barn)).toBeUndefined();
+    });
+
+    it('skal returnere undefined for barn med ikkje-utfylt type', () => {
+        const barn = {
+            type: BarnType.IKKE_UTFYLT,
+            antallBarn: 0,
+            fødselsdatoer: [],
+        } as Barn;
+
+        expect(barnehagestartDato(barn)).toBeUndefined();
+    });
+
+    it('skal bruke fødselsdatoer[0] for fødd barn', () => {
+        const barn = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: ['2024-01-15'],
+        } as Barn;
+
+        expect(barnehagestartDato(barn)).toBe('2025-08-29');
+    });
+
+    it('skal bruke termindato for ufødd barn', () => {
+        const barn = {
+            type: BarnType.UFØDT,
+            antallBarn: 1,
+            termindato: '2024-11-15',
+        } as Barn;
+
+        expect(barnehagestartDato(barn)).toBe('2025-11-28');
+    });
+});

--- a/packages/utils/src/barnehagestartUtils.ts
+++ b/packages/utils/src/barnehagestartUtils.ts
@@ -5,12 +5,8 @@ import { Barn, isAdoptertBarn, isFødtBarn, isIkkeUtfyltTypeBarn } from '@navikt
 
 import { Uttaksdagen } from './uttak/Uttaksdagen';
 
-export const barnehagestartDato = (barnet: Barn): string | undefined => {
-    if (isAdoptertBarn(barnet) || isIkkeUtfyltTypeBarn(barnet)) {
-        return undefined;
-    }
-
-    const dato = isFødtBarn(barnet) ? barnet.fødselsdatoer[0]! : barnet.termindato;
+export const beregnBarnehagestartDato = (dato: string | undefined): string | undefined => {
+    if (!dato) return undefined;
 
     if (dayjs(dato).month() < 8) {
         return Uttaksdagen.denneEllerForrige(
@@ -25,4 +21,13 @@ export const barnehagestartDato = (barnet: Barn): string | undefined => {
     return Uttaksdagen.denneEllerForrige(
         dayjs(dato).startOf('year').add(2, 'year').add(7, 'months').endOf('week').endOf('month').format(ISO_DATE_FORMAT),
     ).getDato();
+};
+
+export const barnehagestartDato = (barnet: Barn): string | undefined => {
+    if (isAdoptertBarn(barnet) || isIkkeUtfyltTypeBarn(barnet)) {
+        return undefined;
+    }
+
+    const dato = isFødtBarn(barnet) ? barnet.fødselsdatoer[0]! : barnet.termindato;
+    return beregnBarnehagestartDato(dato);
 };

--- a/packages/utils/src/barnehagestartUtils.ts
+++ b/packages/utils/src/barnehagestartUtils.ts
@@ -6,7 +6,9 @@ import { Barn, isAdoptertBarn, isFødtBarn, isIkkeUtfyltTypeBarn } from '@navikt
 import { Uttaksdagen } from './uttak/Uttaksdagen';
 
 export const beregnBarnehagestartDato = (dato: string | undefined): string | undefined => {
-    if (!dato) return undefined;
+    if (!dato) {
+        return undefined;
+    }
 
     if (dayjs(dato).month() < 8) {
         return Uttaksdagen.denneEllerForrige(

--- a/packages/utils/src/barnehagestartUtils.ts
+++ b/packages/utils/src/barnehagestartUtils.ts
@@ -1,0 +1,28 @@
+import dayjs from 'dayjs';
+
+import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { Barn, isAdoptertBarn, isFødtBarn, isIkkeUtfyltTypeBarn } from '@navikt/fp-types';
+
+import { Uttaksdagen } from './uttak/Uttaksdagen';
+
+export const barnehagestartDato = (barnet: Barn): string | undefined => {
+    if (isAdoptertBarn(barnet) || isIkkeUtfyltTypeBarn(barnet)) {
+        return undefined;
+    }
+
+    const dato = isFødtBarn(barnet) ? barnet.fødselsdatoer[0]! : barnet.termindato;
+
+    if (dayjs(dato).month() < 8) {
+        return Uttaksdagen.denneEllerForrige(
+            dayjs(dato).month(7).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT),
+        ).getDato();
+    }
+    if (dayjs(dato).month() >= 8 && dayjs(dato).month() < 11) {
+        return Uttaksdagen.denneEllerForrige(
+            dayjs(dato).add(1, 'year').endOf('month').format(ISO_DATE_FORMAT),
+        ).getDato();
+    }
+    return Uttaksdagen.denneEllerForrige(
+        dayjs(dato).startOf('year').add(2, 'year').add(7, 'months').endOf('week').endOf('month').format(ISO_DATE_FORMAT),
+    ).getDato();
+};

--- a/packages/utils/src/barnehagestartUtils.ts
+++ b/packages/utils/src/barnehagestartUtils.ts
@@ -21,7 +21,7 @@ export const beregnBarnehagestartDato = (dato: string | undefined): string | und
         ).getDato();
     }
     return Uttaksdagen.denneEllerForrige(
-        dayjs(dato).startOf('year').add(2, 'year').add(7, 'months').endOf('week').endOf('month').format(ISO_DATE_FORMAT),
+        dayjs(dato).startOf('year').add(2, 'year').add(7, 'months').endOf('month').format(ISO_DATE_FORMAT),
     ).getDato();
 };
 


### PR DESCRIPTION
Oppretter packages/utils/src/barnehagestartUtils.ts med barnehagestartDato-funksjonen, eksportert frå @navikt/fp-utils.

Eksporterer isIkkeUtfyltTypeBarn frå @navikt/fp-types offentleg API.

Oppdaterer UttaksplanSteg.tsx til å bruke den delte funksjonen i staden for lokal implementasjon.