### PR TITLE
Flytt mapping av barn fram og tilbake til OmBarnetSteg

### DIFF
--- a/apps/engangsstonad/src/app-data/EsDataContext.tsx
+++ b/apps/engangsstonad/src/app-data/EsDataContext.tsx
@@ -1,8 +1,7 @@
 import { JSX, ReactNode, createContext, useCallback, useContext, useReducer } from 'react';
 import { Dokumentasjon } from 'types/Dokumentasjon';
-import { OmBarnet } from 'types/OmBarnet';
 
-import { Søkersituasjon, Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
+import { BarnDto, Søkersituasjon, Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import { Path } from './paths';
 
@@ -19,7 +18,7 @@ export enum ContextDataType {
 export type ContextDataMap = {
     [ContextDataType.CURRENT_PATH]?: Path;
     [ContextDataType.SØKERSITUASJON]?: Søkersituasjon;
-    [ContextDataType.OM_BARNET]?: OmBarnet;
+    [ContextDataType.OM_BARNET]?: BarnDto;
     [ContextDataType.DOKUMENTASJON]?: Dokumentasjon;
     [ContextDataType.UTENLANDSOPPHOLD]?: Utenlandsopphold;
     [ContextDataType.UTENLANDSOPPHOLD_SENERE]?: UtenlandsoppholdPeriode[];

--- a/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
+++ b/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
@@ -10,7 +10,7 @@ import { EsPersonopplysningerDto_fpoversikt, FpSoknadProblemDetails } from '@nav
 
 import { ContextDataMap, ContextDataType, useContextComplete, useContextReset } from './EsDataContext';
 
-export const VERSJON_MELLOMLAGRING = 5;
+export const VERSJON_MELLOMLAGRING = 6;
 
 export type EsMellomlagretData = { version: number; personinfo: EsPersonopplysningerDto_fpoversikt } & ContextDataMap;
 

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.test.tsx
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.test.tsx
@@ -5,10 +5,9 @@ import ky, { ResponsePromise } from 'ky';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Dokumentasjon } from 'types/Dokumentasjon';
-import { OmBarnet } from 'types/OmBarnet';
 
 import { AttachmentType, Skjemanummer } from '@navikt/fp-constants';
-import { EngangsstønadDto, EsPersonopplysningerDto_fpoversikt, UtenlandsoppholdPeriode } from '@navikt/fp-types';
+import { BarnDto, EngangsstønadDto, EsPersonopplysningerDto_fpoversikt, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { IntlProvider } from '@navikt/fp-ui';
 
 import nbMessages from '../intl/messages/nb_NO.json';
@@ -71,7 +70,7 @@ const DEFAULT_PERSONINFO = {
 } satisfies EsPersonopplysningerDto_fpoversikt;
 
 const getWrapper =
-    (barnet: OmBarnet, dokumentasjon?: Dokumentasjon) =>
+    (barnet: BarnDto, dokumentasjon?: Dokumentasjon) =>
     ({ children }: { children: ReactNode }) => (
         <IntlProvider locale="nb" messagesGroupedByLocale={MESSAGES_GROUPED_BY_LOCALE}>
             <QueryClientProvider client={queryClient}>
@@ -106,11 +105,11 @@ describe('useEsSendSøknad', () => {
         } as ResponsePromise<void>);
         const deleteMock = vi.mocked(ky.delete);
 
-        const omBarnetAdopsjon = {
+        const omBarnetAdopsjon: BarnDto = {
+            type: 'adopsjon',
             adopsjonsdato: '2024-01-02',
-            termindato: '2024-01-02',
             antallBarn: 1,
-            fødselsdatoer: [{ dato: '2024-01-01' }],
+            fødselsdatoer: ['2024-01-01'],
             adopsjonAvEktefellesBarn: true,
         };
 
@@ -159,8 +158,8 @@ describe('useEsSendSøknad', () => {
         } as ResponsePromise<void>);
         const deleteMock = vi.mocked(ky.delete);
 
-        const omBarnetErFødt = {
-            erBarnetFødt: true,
+        const omBarnetErFødt: BarnDto = {
+            type: 'fødsel',
             antallBarn: 1,
             fødselsdato: '2024-01-01',
             termindato: '2024-01-01',
@@ -202,10 +201,9 @@ describe('useEsSendSøknad', () => {
         } as ResponsePromise<void>);
         const deleteMock = vi.mocked(ky.delete);
 
-        const omBarnetVenterPåFødsel = {
-            erBarnetFødt: false,
+        const omBarnetVenterPåFødsel: BarnDto = {
+            type: 'termin',
             antallBarn: 1,
-            fødselsdato: '2024-01-01',
             termindato: '2024-01-01',
         };
 

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -5,10 +5,11 @@ import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
-import { erTerminDokumentasjon } from 'types/Dokumentasjon';
+import { Dokumentasjon, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
 import { captureMessage } from '@navikt/fp-observability';
 import {
+    BarnDto,
     EngangsstønadDto,
     EsPersonopplysningerDto_fpoversikt,
     FpSoknadProblemDetails,
@@ -34,14 +35,7 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
         const tidligereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
         const senereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
 
-        if (barn.type === 'termin' && !(dokumentasjon && erTerminDokumentasjon(dokumentasjon))) {
-            throw new Error('Det er feil i data om barnet: mangler terminbekreftelse for termin-barn');
-        }
-
-        const barnDto =
-            barn.type === 'termin' && dokumentasjon && erTerminDokumentasjon(dokumentasjon)
-                ? { ...barn, terminbekreftelseDato: dokumentasjon.terminbekreftelsedato }
-                : barn;
+        const barnDto = mapBarn(barn, dokumentasjon);
 
         const søknad = {
             søkerinfo: {
@@ -105,4 +99,14 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
         }),
         [sendSøknad, error],
     );
+};
+
+const mapBarn = (barn: BarnDto, dokumentasjon?: Dokumentasjon): BarnDto => {
+    if (barn.type === 'termin' && !(dokumentasjon && erTerminDokumentasjon(dokumentasjon))) {
+        throw new Error('Det er feil i data om barnet: mangler terminbekreftelse for termin-barn');
+    }
+
+    return barn.type === 'termin' && dokumentasjon && erTerminDokumentasjon(dokumentasjon)
+        ? { ...barn, terminbekreftelseDato: dokumentasjon.terminbekreftelsedato }
+        : barn;
 };

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -35,15 +35,13 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
         const tidligereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
         const senereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
 
-        const barnDto = mapBarn(barn, dokumentasjon);
-
         const søknad = {
             søkerinfo: {
                 fnr: personinfo.fnr,
                 navn: personinfo.navn,
             },
             språkkode: getDecoratorLanguageCookie('decorator-language').toUpperCase() as Målform,
-            barn: barnDto,
+            barn: mapBarn(barn, dokumentasjon),
             utenlandsopphold: (tidligereUtenlandsopphold ?? []).concat(senereUtenlandsopphold ?? []),
             vedlegg:
                 dokumentasjon?.vedlegg.map((vedlegg) => ({

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -5,8 +5,7 @@ import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
-import { Dokumentasjon, erTerminDokumentasjon } from 'types/Dokumentasjon';
-import { OmBarnet, erAdopsjon, erBarnetFødt, harBarnetTermindato } from 'types/OmBarnet';
+import { erTerminDokumentasjon } from 'types/Dokumentasjon';
 
 import { captureMessage } from '@navikt/fp-observability';
 import {
@@ -20,38 +19,6 @@ import { notEmpty } from '@navikt/fp-validation';
 
 import { ContextDataType, useContextGetAnyData } from './EsDataContext';
 
-// TODO Vurder om ein heller bør mappa fram og tilbake i barn-komponenten. Er nok bedre å gjera det
-const mapBarn = (omBarnet: OmBarnet, dokumentasjon?: Dokumentasjon) => {
-    if (erAdopsjon(omBarnet)) {
-        return {
-            type: 'adopsjon' as const,
-            antallBarn: omBarnet.antallBarn,
-            fødselsdatoer: omBarnet.fødselsdatoer.map((f) => f.dato),
-            adopsjonsdato: omBarnet.adopsjonsdato,
-            adopsjonAvEktefellesBarn: omBarnet.adopsjonAvEktefellesBarn,
-        };
-    }
-    if (erBarnetFødt(omBarnet)) {
-        return {
-            type: 'fødsel' as const,
-            antallBarn: omBarnet.antallBarn,
-            fødselsdato: omBarnet.fødselsdato,
-            termindato: omBarnet.termindato,
-        };
-    }
-
-    if (harBarnetTermindato(omBarnet) && dokumentasjon && erTerminDokumentasjon(dokumentasjon)) {
-        return {
-            type: 'termin' as const,
-            antallBarn: omBarnet.antallBarn,
-            termindato: omBarnet.termindato,
-            terminbekreftelseDato: dokumentasjon.terminbekreftelsedato,
-        };
-    }
-
-    throw new Error('Det er feil i data om barnet');
-};
-
 const FEIL_VED_INNSENDING_LOG =
     'Det har oppstått et problem med innsending av søknaden. Vennligst prøv igjen senere. Hvis problemet vedvarer, kontakt oss og oppgi feil-id: ';
 
@@ -62,10 +29,19 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
     const { initAbortSignal } = useAbortSignal();
 
     const send = async () => {
-        const omBarnet = notEmpty(hentData(ContextDataType.OM_BARNET));
+        const barn = notEmpty(hentData(ContextDataType.OM_BARNET));
         const dokumentasjon = hentData(ContextDataType.DOKUMENTASJON);
         const tidligereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
         const senereUtenlandsopphold = hentData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
+
+        if (barn.type === 'termin' && !(dokumentasjon && erTerminDokumentasjon(dokumentasjon))) {
+            throw new Error('Det er feil i data om barnet: mangler terminbekreftelse for termin-barn');
+        }
+
+        const barnDto =
+            barn.type === 'termin' && dokumentasjon && erTerminDokumentasjon(dokumentasjon)
+                ? { ...barn, terminbekreftelseDato: dokumentasjon.terminbekreftelsedato }
+                : barn;
 
         const søknad = {
             søkerinfo: {
@@ -73,7 +49,7 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
                 navn: personinfo.navn,
             },
             språkkode: getDecoratorLanguageCookie('decorator-language').toUpperCase() as Målform,
-            barn: mapBarn(omBarnet, dokumentasjon),
+            barn: barnDto,
             utenlandsopphold: (tidligereUtenlandsopphold ?? []).concat(senereUtenlandsopphold ?? []),
             vedlegg:
                 dokumentasjon?.vedlegg.map((vedlegg) => ({

--- a/apps/engangsstonad/src/app-data/useStepConfig.ts
+++ b/apps/engangsstonad/src/app-data/useStepConfig.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
-import { harBarnetTermindato } from 'types/OmBarnet';
 
 import { notEmpty } from '@navikt/fp-validation';
 
@@ -71,16 +70,11 @@ const showDokumentasjonStep = (
     currentPath: Path,
     getStateData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
 ): boolean => {
-    const omBarnet = getStateData(ContextDataType.OM_BARNET);
-    if (
-        path === Path.TERMINBEKREFTELSE &&
-        omBarnet &&
-        harBarnetTermindato(omBarnet) &&
-        omBarnet.erBarnetFødt === false
-    ) {
+    const barn = getStateData(ContextDataType.OM_BARNET);
+    if (path === Path.TERMINBEKREFTELSE && barn?.type === 'termin') {
         return isVisible(true, ContextDataType.DOKUMENTASJON, Path.OM_BARNET, currentPath, getStateData);
     }
-    if (path === Path.ADOPSJONSBEKREFTELSE && omBarnet && 'adopsjonAvEktefellesBarn' in omBarnet) {
+    if (path === Path.ADOPSJONSBEKREFTELSE && barn?.type === 'adopsjon') {
         return isVisible(true, ContextDataType.DOKUMENTASJON, Path.OM_BARNET, currentPath, getStateData);
     }
     return false;

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.stories.tsx
@@ -6,7 +6,8 @@ import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { action } from 'storybook/actions';
-import { OmBarnet } from 'types/OmBarnet';
+
+import { BarnDto } from '@navikt/fp-types';
 
 import { DokumentasjonSteg } from './DokumentasjonSteg';
 
@@ -17,7 +18,7 @@ const promiseAction = () => (): Promise<void> => {
 
 type StoryArgs = {
     gåTilNesteSide?: (action: Action) => void;
-    omBarnet: OmBarnet;
+    omBarnet: BarnDto;
     path: Path;
 } & ComponentProps<typeof DokumentasjonSteg>;
 
@@ -60,7 +61,7 @@ export const Terminbekreftelse: Story = {
     args: {
         path: Path.TERMINBEKREFTELSE,
         omBarnet: {
-            erBarnetFødt: false,
+            type: 'termin' as const,
             antallBarn: 1,
             termindato: '2023-10-06',
         },
@@ -85,10 +86,11 @@ export const Adopsjonsbekreftelse: Story = {
     args: {
         path: Path.ADOPSJONSBEKREFTELSE,
         omBarnet: {
+            type: 'adopsjon' as const,
             adopsjonAvEktefellesBarn: true,
             adopsjonsdato: '2020-01-01',
             antallBarn: 1,
-            fødselsdatoer: [{ dato: '2020-01-01' }],
+            fødselsdatoer: ['2020-01-01'],
         },
         mellomlagreOgNaviger: promiseAction(),
     },
@@ -103,10 +105,11 @@ export const FeilerOpplastinger: Story = {
     args: {
         path: Path.ADOPSJONSBEKREFTELSE,
         omBarnet: {
+            type: 'adopsjon' as const,
             adopsjonAvEktefellesBarn: true,
             adopsjonsdato: '2020-01-01',
             antallBarn: 1,
-            fødselsdatoer: [{ dato: '2020-01-01' }],
+            fødselsdatoer: ['2020-01-01'],
         },
         mellomlagreOgNaviger: promiseAction(),
     },

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 import { Dokumentasjon } from 'types/Dokumentasjon';
-import { erAdopsjon, harBarnetTermindato } from 'types/OmBarnet';
 
 import { VStack } from '@navikt/ds-react';
 
@@ -30,10 +29,10 @@ export const DokumentasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
 
     const dokumentasjon = useContextGetData(ContextDataType.DOKUMENTASJON);
     const oppdaterDokumentasjon = useContextSaveData(ContextDataType.DOKUMENTASJON);
-    const omBarnet = notEmpty(useContextGetData(ContextDataType.OM_BARNET));
+    const barn = notEmpty(useContextGetData(ContextDataType.OM_BARNET));
 
-    const erBarnetAdoptert = erAdopsjon(omBarnet);
-    const harTermindato = harBarnetTermindato(omBarnet);
+    const erBarnetAdoptert = barn.type === 'adopsjon';
+    const harTermindato = barn.type === 'termin';
 
     const formMethods = useForm<Dokumentasjon>({
         defaultValues: dokumentasjon,
@@ -75,7 +74,7 @@ export const DokumentasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
                             <TerminDokPanel
                                 attachments={dokumentasjon?.vedlegg}
                                 updateAttachments={updateAttachments}
-                                omBarnet={omBarnet}
+                                termindato={barn.type === 'termin' ? barn.termindato : ''}
                             />
                         )}
                         <ScanDocumentInfo />

--- a/apps/engangsstonad/src/steg/dokumentasjon/TerminDokPanel.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/TerminDokPanel.tsx
@@ -4,7 +4,6 @@ import minMax from 'dayjs/plugin/minMax';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
 import { Dokumentasjon } from 'types/Dokumentasjon';
-import { BarnetErIkkeFødt } from 'types/OmBarnet';
 
 import { AttachmentType, Skjemanummer } from '@navikt/fp-constants';
 import { FileUploader } from '@navikt/fp-filopplaster';
@@ -32,10 +31,10 @@ const isUtstedtDatoIUke22 = (termindato: string, intl: IntlShape) => (terminBekr
 interface Props {
     attachments?: Attachment[];
     updateAttachments: (attachments: Attachment[], hasPendingUploads: boolean) => void;
-    omBarnet: BarnetErIkkeFødt;
+    termindato: string;
 }
 
-export const TerminDokPanel = ({ attachments, updateAttachments, omBarnet }: Props) => {
+export const TerminDokPanel = ({ attachments, updateAttachments, termindato }: Props) => {
     const intl = useIntl();
 
     const { control } = useFormContext<Dokumentasjon>();
@@ -46,7 +45,7 @@ export const TerminDokPanel = ({ attachments, updateAttachments, omBarnet }: Pro
                 name="terminbekreftelsedato"
                 control={control}
                 label={<FormattedMessage id="TerminDokPanel.Terminbekreftelsesdato" />}
-                minDate={dayjs(omBarnet.termindato).subtract(18, 'week').subtract(3, 'day')}
+                minDate={dayjs(termindato).subtract(18, 'week').subtract(3, 'day')}
                 maxDate={dayjs()}
                 validate={[
                     isRequired(intl.formatMessage({ id: 'TerminDokPanel.Validering.TerminbekreftelseDato.DuMåOppgi' })),
@@ -56,7 +55,7 @@ export const TerminDokPanel = ({ attachments, updateAttachments, omBarnet }: Pro
                             id: 'TerminDokPanel.Validering.TerminBekreftelsedato.MåVæreIdagEllerTidligere',
                         }),
                     ),
-                    isUtstedtDatoIUke22(omBarnet.termindato, intl),
+                    isUtstedtDatoIUke22(termindato, intl),
                 ]}
             />
             <FileUploader

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.test.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.test.tsx
@@ -47,14 +47,11 @@ describe('<OmBarnetSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
             data: {
+                type: 'adopsjon',
                 adopsjonAvEktefellesBarn: true,
                 adopsjonsdato: dayjs().format(ISO_DATE_FORMAT),
                 antallBarn: 1,
-                fødselsdatoer: [
-                    {
-                        dato: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
+                fødselsdatoer: [dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT)],
             },
             key: ContextDataType.OM_BARNET,
             type: 'update',
@@ -104,14 +101,11 @@ describe('<OmBarnetSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
             data: {
+                type: 'adopsjon',
                 adopsjonAvEktefellesBarn: false,
                 adopsjonsdato: dayjs().format(ISO_DATE_FORMAT),
                 antallBarn: 1,
-                fødselsdatoer: [
-                    {
-                        dato: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-                    },
-                ],
+                fødselsdatoer: [dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT)],
                 søkerAdopsjonAlene: true,
             },
             key: ContextDataType.OM_BARNET,
@@ -167,19 +161,14 @@ describe('<OmBarnetSteg>', () => {
 
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
             data: {
+                type: 'adopsjon',
                 adopsjonAvEktefellesBarn: true,
                 adopsjonsdato: dayjs().format(ISO_DATE_FORMAT),
                 antallBarn: 3,
                 fødselsdatoer: [
-                    {
-                        dato: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-                    },
-                    {
-                        dato: dayjs().subtract(5, 'day').format(ISO_DATE_FORMAT),
-                    },
-                    {
-                        dato: dayjs().subtract(1, 'day').format(ISO_DATE_FORMAT),
-                    },
+                    dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
+                    dayjs().subtract(5, 'day').format(ISO_DATE_FORMAT),
+                    dayjs().subtract(1, 'day').format(ISO_DATE_FORMAT),
                 ],
             },
             key: ContextDataType.OM_BARNET,
@@ -228,7 +217,7 @@ describe('<OmBarnetSteg>', () => {
         expect(gåTilNesteSide).toHaveBeenCalledTimes(3);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
             data: {
-                erBarnetFødt: true,
+                type: 'fødsel',
                 antallBarn: 1,
                 fødselsdato: dayjs().format(ISO_DATE_FORMAT),
                 termindato: dayjs().format(ISO_DATE_FORMAT),
@@ -281,8 +270,8 @@ describe('<OmBarnetSteg>', () => {
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
         expect(gåTilNesteSide).toHaveBeenNthCalledWith(1, {
             data: {
+                type: 'termin',
                 antallBarn: 3,
-                erBarnetFødt: false,
                 termindato: dayjs().format(ISO_DATE_FORMAT),
             },
             key: ContextDataType.OM_BARNET,

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -28,7 +28,7 @@ const utledNesteSteg = (formValues: FormValues, søkersituasjon: Søkersituasjon
     return Path.UTENLANDSOPPHOLD;
 };
 
-const resolveAntallBarn = (formValues: Pick<FormValues, 'antallBarn' | 'antallBarnDropDown'>) =>
+const resolveAntallBarn = (formValues: FormValues) =>
     formValues.antallBarn > 2 && formValues.antallBarnDropDown
         ? Number.parseInt(formValues.antallBarnDropDown, 10)
         : formValues.antallBarn;
@@ -41,7 +41,7 @@ const mapBarnFraFormTilDto = (formValues: FormValues, situasjon: Søkersituasjon
             antallBarn,
             adopsjonAvEktefellesBarn: formValues.adopsjonAvEktefellesBarn,
             adopsjonsdato: formValues.adopsjonsdato,
-            ...(formValues.søkerAdopsjonAlene !== undefined && { søkerAdopsjonAlene: formValues.søkerAdopsjonAlene }),
+            søkerAdopsjonAlene: formValues.søkerAdopsjonAlene,
             fødselsdatoer: formValues.fødselsdatoer.map((f) => f.dato),
         };
     }

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -4,14 +4,13 @@ import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
-import { OmBarnet } from 'types/OmBarnet';
+import { Adopsjon, Fødsel } from 'types/OmBarnet';
 
 import { VStack } from '@navikt/ds-react';
 
 import { ErrorSummaryHookForm, RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
-import { Kjønn_fpoversikt, Søkersituasjon } from '@navikt/fp-types';
+import { BarnDto, Kjønn_fpoversikt, Søkersituasjon } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
-import { omitOne } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { FormValues as AdopsjonFormValues, AdopsjonPanel } from './AdopsjonPanel';
@@ -29,19 +28,70 @@ const utledNesteSteg = (formValues: FormValues, søkersituasjon: Søkersituasjon
     return Path.UTENLANDSOPPHOLD;
 };
 
-const mapOmBarnetFraFormTilState = (formValues: FormValues) => ({
-    ...omitOne(formValues, 'antallBarnDropDown'),
-    antallBarn:
-        formValues.antallBarn > 2 && formValues.antallBarnDropDown
-            ? Number.parseInt(formValues.antallBarnDropDown, 10)
-            : formValues.antallBarn,
-});
+const resolveAntallBarn = (formValues: Pick<FormValues, 'antallBarn' | 'antallBarnDropDown'>) =>
+    formValues.antallBarn > 2 && formValues.antallBarnDropDown
+        ? Number.parseInt(formValues.antallBarnDropDown, 10)
+        : formValues.antallBarn;
 
-const mapOmBarnetFraStateTilForm = (omBarnet: OmBarnet) => ({
-    ...omBarnet,
-    antallBarn: omBarnet.antallBarn > 2 ? 3 : omBarnet.antallBarn,
-    antallBarnDropDown: omBarnet.antallBarn > 2 ? omBarnet.antallBarn.toString() : undefined,
-});
+const mapBarnFraFormTilDto = (formValues: FormValues, situasjon: Søkersituasjon['situasjon']): BarnDto => {
+    const antallBarn = resolveAntallBarn(formValues);
+    if (situasjon === 'adopsjon') {
+        return {
+            type: 'adopsjon' as const,
+            antallBarn,
+            adopsjonAvEktefellesBarn: formValues.adopsjonAvEktefellesBarn,
+            adopsjonsdato: formValues.adopsjonsdato,
+            ...(formValues.søkerAdopsjonAlene !== undefined && { søkerAdopsjonAlene: formValues.søkerAdopsjonAlene }),
+            fødselsdatoer: formValues.fødselsdatoer.map((f) => f.dato),
+        };
+    }
+    if (formValues.erBarnetFødt) {
+        return {
+            type: 'fødsel' as const,
+            antallBarn,
+            fødselsdato: formValues.fødselsdato,
+            termindato: formValues.termindato,
+        };
+    }
+    return {
+        type: 'termin' as const,
+        antallBarn,
+        termindato: formValues.termindato,
+    };
+};
+
+const mapBarnFraDtoTilForm = (barn: BarnDto): Partial<FormValues> => {
+    const antallBarn = barn.antallBarn ?? 1;
+    const base = {
+        antallBarn: antallBarn > 2 ? 3 : antallBarn,
+        antallBarnDropDown: antallBarn > 2 ? antallBarn.toString() : undefined,
+    };
+    if (barn.type === 'adopsjon') {
+        return {
+            ...base,
+            adopsjonAvEktefellesBarn: barn.adopsjonAvEktefellesBarn,
+            adopsjonsdato: barn.adopsjonsdato,
+            søkerAdopsjonAlene: barn.søkerAdopsjonAlene,
+            fødselsdatoer: (barn.fødselsdatoer ?? []).map((dato) => ({ dato })),
+        } satisfies Partial<Adopsjon & { antallBarnDropDown?: string }>;
+    }
+    if (barn.type === 'fødsel') {
+        return {
+            ...base,
+            erBarnetFødt: true,
+            fødselsdato: barn.fødselsdato,
+            termindato: barn.termindato,
+        } satisfies Partial<Fødsel & { antallBarnDropDown?: string }>;
+    }
+    if (barn.type === 'termin') {
+        return {
+            ...base,
+            erBarnetFødt: false,
+            termindato: barn.termindato,
+        } satisfies Partial<Fødsel & { antallBarnDropDown?: string }>;
+    }
+    throw new Error(`Ukjent barn-type: ${barn.type}`);
+};
 
 interface Props {
     kjønn: Kjønn_fpoversikt;
@@ -54,12 +104,13 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
     const stepConfig = useStepConfig();
     const navigator = useEsNavigator(mellomlagreOgNaviger);
 
-    const omBarnet = useContextGetData(ContextDataType.OM_BARNET);
+    const barn = useContextGetData(ContextDataType.OM_BARNET);
     const oppdaterOmBarnet = useContextSaveData(ContextDataType.OM_BARNET);
     const oppdaterDokumentasjon = useContextSaveData(ContextDataType.DOKUMENTASJON);
     const søkersituasjon = notEmpty(useContextGetData(ContextDataType.SØKERSITUASJON));
 
-    const mapOgLagreOmBarnet = (formValues: FormValues) => oppdaterOmBarnet(mapOmBarnetFraFormTilState(formValues));
+    const mapOgLagreOmBarnet = (formValues: FormValues) =>
+        oppdaterOmBarnet(mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon));
 
     const onSubmit = (formValues: FormValues) => {
         mapOgLagreOmBarnet(formValues);
@@ -70,7 +121,7 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
     };
 
     const formMethods = useForm<FormValues>({
-        defaultValues: omBarnet ? mapOmBarnetFraStateTilForm(omBarnet) : {},
+        defaultValues: barn ? mapBarnFraDtoTilForm(barn) : {},
     });
 
     return (

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -18,6 +18,58 @@ import { FødselPanel, FormValues as FødtFormValues } from './FødselPanel';
 
 type FormValues = FødtFormValues & AdopsjonFormValues;
 
+interface Props {
+    kjønn: Kjønn_fpoversikt;
+    mellomlagreOgNaviger: () => Promise<void>;
+}
+
+export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
+    const intl = useIntl();
+
+    const stepConfig = useStepConfig();
+    const navigator = useEsNavigator(mellomlagreOgNaviger);
+
+    const barn = useContextGetData(ContextDataType.OM_BARNET);
+    const søkersituasjon = notEmpty(useContextGetData(ContextDataType.SØKERSITUASJON));
+    const oppdaterOmBarnet = useContextSaveData(ContextDataType.OM_BARNET);
+    const oppdaterDokumentasjon = useContextSaveData(ContextDataType.DOKUMENTASJON);
+
+    const mapOgLagreOmBarnet = (formValues: FormValues) =>
+        oppdaterOmBarnet(mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon));
+
+    const onSubmit = (formValues: FormValues) => {
+        mapOgLagreOmBarnet(formValues);
+        if (formValues.erBarnetFødt === true) {
+            oppdaterDokumentasjon(undefined);
+        }
+        return navigator.goToNextStep(utledNesteSteg(formValues, søkersituasjon));
+    };
+
+    const formMethods = useForm<FormValues>({
+        defaultValues: barn ? mapBarnFraDtoTilForm(barn) : {},
+    });
+
+    return (
+        <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'Søknad.Pageheading' })}>
+            <Step onStepChange={navigator.goToNextStep} steps={stepConfig}>
+                <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
+                    <VStack gap="space-40">
+                        <ErrorSummaryHookForm />
+                        {søkersituasjon?.situasjon === 'adopsjon' && <AdopsjonPanel kjønn={kjønn} />}
+                        {søkersituasjon?.situasjon === 'fødsel' && <FødselPanel />}
+                        <StepButtonsHookForm<FormValues>
+                            onAvsluttOgSlett={navigator.avbrytSøknad}
+                            onFortsettSenere={navigator.fortsettSøknadSenere}
+                            goToPreviousStep={navigator.goToPreviousDefaultStep}
+                            saveDataOnPreviousClick={mapOgLagreOmBarnet}
+                        />
+                    </VStack>
+                </RhfForm>
+            </Step>
+        </SkjemaRotLayout>
+    );
+};
+
 const utledNesteSteg = (formValues: FormValues, søkersituasjon: Søkersituasjon) => {
     if (søkersituasjon.situasjon === 'adopsjon') {
         return Path.ADOPSJONSBEKREFTELSE;
@@ -91,56 +143,4 @@ const mapBarnFraDtoTilForm = (barn: BarnDto): Partial<FormValues> => {
         } satisfies Partial<Fødsel & { antallBarnDropDown?: string }>;
     }
     throw new Error(`Ukjent barn-type: ${barn.type}`);
-};
-
-interface Props {
-    kjønn: Kjønn_fpoversikt;
-    mellomlagreOgNaviger: () => Promise<void>;
-}
-
-export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
-    const intl = useIntl();
-
-    const stepConfig = useStepConfig();
-    const navigator = useEsNavigator(mellomlagreOgNaviger);
-
-    const barn = useContextGetData(ContextDataType.OM_BARNET);
-    const oppdaterOmBarnet = useContextSaveData(ContextDataType.OM_BARNET);
-    const oppdaterDokumentasjon = useContextSaveData(ContextDataType.DOKUMENTASJON);
-    const søkersituasjon = notEmpty(useContextGetData(ContextDataType.SØKERSITUASJON));
-
-    const mapOgLagreOmBarnet = (formValues: FormValues) =>
-        oppdaterOmBarnet(mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon));
-
-    const onSubmit = (formValues: FormValues) => {
-        mapOgLagreOmBarnet(formValues);
-        if (formValues.erBarnetFødt === true) {
-            oppdaterDokumentasjon(undefined);
-        }
-        return navigator.goToNextStep(utledNesteSteg(formValues, søkersituasjon));
-    };
-
-    const formMethods = useForm<FormValues>({
-        defaultValues: barn ? mapBarnFraDtoTilForm(barn) : {},
-    });
-
-    return (
-        <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'Søknad.Pageheading' })}>
-            <Step onStepChange={navigator.goToNextStep} steps={stepConfig}>
-                <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
-                    <VStack gap="space-40">
-                        <ErrorSummaryHookForm />
-                        {søkersituasjon?.situasjon === 'adopsjon' && <AdopsjonPanel kjønn={kjønn} />}
-                        {søkersituasjon?.situasjon === 'fødsel' && <FødselPanel />}
-                        <StepButtonsHookForm<FormValues>
-                            onAvsluttOgSlett={navigator.avbrytSøknad}
-                            onFortsettSenere={navigator.fortsettSøknadSenere}
-                            goToPreviousStep={navigator.goToPreviousDefaultStep}
-                            saveDataOnPreviousClick={mapOgLagreOmBarnet}
-                        />
-                    </VStack>
-                </RhfForm>
-            </Step>
-        </SkjemaRotLayout>
-    );
 };

--- a/apps/engangsstonad/src/steg/oppsummering/OmBarnetOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OmBarnetOppsummering.tsx
@@ -1,23 +1,24 @@
 import { FormattedMessage } from 'react-intl';
-import { OmBarnet, erAdopsjon, erBarnetFødt, harBarnetTermindato } from 'types/OmBarnet';
 
 import { FormSummary } from '@navikt/ds-react';
 
+import { BarnDto } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
 interface Props {
-    readonly omBarnet: OmBarnet;
+    readonly omBarnet: BarnDto;
     readonly onVilEndreSvar: () => void;
 }
 
-function AntallBarnFormattedText({ omBarnet }: { readonly omBarnet: OmBarnet }) {
-    const harAdoptert = erAdopsjon(omBarnet);
+function AntallBarnFormattedText({ omBarnet }: { readonly omBarnet: BarnDto }) {
+    const antallBarn = omBarnet.antallBarn ?? 1;
+    const harAdoptert = omBarnet.type === 'adopsjon';
 
-    if (omBarnet.antallBarn === 1) {
+    if (antallBarn === 1) {
         return <FormattedMessage id={'OmBarnetOppsummering.EttBarn'} />;
-    } else if (omBarnet.antallBarn === 2 && !harAdoptert) {
+    } else if (antallBarn === 2 && !harAdoptert) {
         return <FormattedMessage id={'OmBarnetOppsummering.Tvillinger'} />;
-    } else if (omBarnet.antallBarn === 2 && harAdoptert) {
+    } else if (antallBarn === 2 && harAdoptert) {
         return <FormattedMessage id={'OmBarnetOppsummering.ToBarn'} />;
     } else {
         return <FormattedMessage id={'OmBarnetOppsummering.FlereBarn'} />;
@@ -25,9 +26,9 @@ function AntallBarnFormattedText({ omBarnet }: { readonly omBarnet: OmBarnet }) 
 }
 
 export const OmBarnetOppsummering = ({ omBarnet, onVilEndreSvar }: Props) => {
-    const harAdoptert = erAdopsjon(omBarnet);
-    const harTermin = harBarnetTermindato(omBarnet);
-    const harFødt = erBarnetFødt(omBarnet);
+    const harAdoptert = omBarnet.type === 'adopsjon';
+    const harTermin = omBarnet.type === 'termin';
+    const harFødt = omBarnet.type === 'fødsel';
 
     return (
         <FormSummary>
@@ -53,7 +54,7 @@ export const OmBarnetOppsummering = ({ omBarnet, onVilEndreSvar }: Props) => {
                         <FormSummary.Value>{formatDate(omBarnet.fødselsdato)}</FormSummary.Value>
                     </FormSummary.Answer>
                 )}
-                {harTermin && (
+                {(harTermin || harFødt) && omBarnet.termindato && (
                     <FormSummary.Answer>
                         <FormSummary.Label>
                             <FormattedMessage id={'OmBarnetOppsummering.MedTermindato'} />
@@ -74,11 +75,11 @@ export const OmBarnetOppsummering = ({ omBarnet, onVilEndreSvar }: Props) => {
                             <FormSummary.Label>
                                 <FormattedMessage
                                     id="OmBarnetOppsummering.MedFødselsdato"
-                                    values={{ antall: omBarnet.fødselsdatoer.length }}
+                                    values={{ antall: (omBarnet.fødselsdatoer ?? []).length }}
                                 />
                             </FormSummary.Label>
                             <FormSummary.Value>
-                                {omBarnet.fødselsdatoer.map(({ dato }) => formatDate(dato)).join(', ')}
+                                {(omBarnet.fødselsdatoer ?? []).map((dato) => formatDate(dato)).join(', ')}
                             </FormSummary.Value>
                         </FormSummary.Answer>
                     </>

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
@@ -6,10 +6,9 @@ import { ComponentProps } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { action } from 'storybook/actions';
 import { Dokumentasjon } from 'types/Dokumentasjon';
-import { BarnetErFødt, OmBarnet } from 'types/OmBarnet';
 
 import { AttachmentType, ISO_DATE_FORMAT, Skjemanummer } from '@navikt/fp-constants';
-import { Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
+import { BarnDto, Utenlandsopphold, UtenlandsoppholdPeriode } from '@navikt/fp-types';
 
 import { OppsummeringSteg } from './OppsummeringSteg';
 
@@ -18,12 +17,12 @@ const promiseAction = () => () => {
     return Promise.resolve();
 };
 
-const barnetDefault = {
-    erBarnetFødt: true,
+const barnetDefault: BarnDto = {
+    type: 'fødsel',
     antallBarn: 1,
     fødselsdato: dayjs().subtract(9, 'day').format(ISO_DATE_FORMAT),
     termindato: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-} satisfies BarnetErFødt;
+};
 
 const utenlandsoppholdDefault = {
     harBoddUtenforNorgeSiste12Mnd: false,
@@ -35,7 +34,7 @@ const vedleggDefault = {
 };
 
 type StoryArgs = {
-    omBarnet?: OmBarnet;
+    omBarnet?: BarnDto;
     utenlandsopphold?: Utenlandsopphold;
     tidligereUtenlandsopphold?: UtenlandsoppholdPeriode[];
     senereUtenlandsopphold?: UtenlandsoppholdPeriode[];
@@ -88,10 +87,11 @@ export const AdopsjonAvEktefellesBarn: Story = {
     args: {
         sendSøknad: promiseAction(),
         omBarnet: {
+            type: 'adopsjon',
             adopsjonAvEktefellesBarn: true,
             antallBarn: 1,
             adopsjonsdato: '2023-01-01',
-            fødselsdatoer: [{ dato: '2023-01-01' }],
+            fødselsdatoer: ['2023-01-01'],
         },
         dokumentasjon: {
             vedlegg: [
@@ -116,10 +116,11 @@ export const AdopsjonAvEktefellesFlereBarn: Story = {
     args: {
         sendSøknad: promiseAction(),
         omBarnet: {
+            type: 'adopsjon',
             adopsjonAvEktefellesBarn: true,
             antallBarn: 1,
             adopsjonsdato: '2023-01-01',
-            fødselsdatoer: [{ dato: '2023-01-01' }, { dato: '2020-01-01' }],
+            fødselsdatoer: ['2023-01-01', '2020-01-01'],
         },
         dokumentasjon: {
             vedlegg: [
@@ -144,7 +145,7 @@ export const BarnetErIkkeFodt: Story = {
     args: {
         sendSøknad: promiseAction(),
         omBarnet: {
-            erBarnetFødt: false,
+            type: 'termin',
             antallBarn: 1,
             termindato: '2023-01-02',
         },

--- a/apps/engangsstonad/src/types/OmBarnet.ts
+++ b/apps/engangsstonad/src/types/OmBarnet.ts
@@ -22,17 +22,3 @@ export type Adopsjon = {
         dato: string;
     }>;
 };
-
-export type OmBarnet = Fødsel | Adopsjon;
-
-export const erAdopsjon = (omBarnet: OmBarnet): omBarnet is Adopsjon => {
-    return 'adopsjonsdato' in omBarnet;
-};
-
-export const harBarnetTermindato = (omBarnet: OmBarnet): omBarnet is BarnetErIkkeFødt => {
-    return 'termindato' in omBarnet;
-};
-
-export const erBarnetFødt = (omBarnet: OmBarnet): omBarnet is BarnetErFødt => {
-    return 'erBarnetFødt' in omBarnet && omBarnet.erBarnetFødt;
-};

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -14,11 +14,7 @@ import { getErSøkerFarEllerMedmor, getKjønnFromFnr, getNavnPåForeldre } from 
 import { Alert, BodyLong, Tabs } from '@navikt/ds-react';
 
 import { loggUmamiEvent } from '@navikt/fp-observability';
-import {
-    FpPersonopplysningerDto_fpoversikt,
-    FpSak_fpoversikt,
-    RettighetType_fpoversikt,
-} from '@navikt/fp-types';
+import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt, RettighetType_fpoversikt } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
 import { Uttaksperioden, barnehagestartDato, getFamiliehendelsedato } from '@navikt/fp-utils';
 import {


### PR DESCRIPTION
Konteksten lagrar no BarnDto direkte (API-formatet) i staden for den interne OmBarnet-typen. Alle konverteringar mellom skjemaverdiar og BarnDto skjer i OmBarnetSteg via mapBarnFraFormTilDto og mapBarnFraDtoTilForm. useEsSendSøknad treng berre å leggja til terminbekreftelseDato frå Dokumentasjon-konteksten for termin-tilfelle.

- Bumpa VERSJON_MELLOMLAGRING 5 → 6 (endring i lagra dataskjema)
- Sletta mapBarn-funksjonen og TODO-kommentaren frå useEsSendSøknad
- Fiksa bug: søkerAdopsjonAlene blei tidlegare ikkje med i søknaden
- Oppdaterte DokumentasjonSteg, TerminDokPanel, useStepConfig, OmBarnetOppsummering, stories og testar