### PR TITLE
Bruk setFocus frå react-hook-form i ErrorSummaryHookForm

### DIFF
--- a/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.test.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.test.tsx
@@ -140,7 +140,7 @@ describe('<FerieSteg>', () => {
         await user.type(screen.getAllByText('Siste feriedag')[2]!, dayjs('2024-11-12').format('DD.MM.YYYY'));
         await user.tab();
         await user.click(screen.getByText('Neste steg'));
-        expect(screen.getAllByText('Overlapper med 2. periode')).toHaveLength(1);
+        expect(screen.getAllByText('Overlapper med 2. periode')).toHaveLength(2);
 
         await user.clear(screen.getAllByLabelText('Første feriedag')[1]!);
         await user.type(screen.getAllByText('Første feriedag')[1]!, dayjs('2024-11-06').format('DD.MM.YYYY'));

--- a/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
+++ b/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
@@ -1,30 +1,26 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { useEffect, useRef } from 'react';
 import { FieldErrors, FieldValues, useFormContext } from 'react-hook-form';
 
 import { ErrorSummaryFp } from '@navikt/fp-ui';
 
-const findAllErrors = (errors: FieldErrors<FieldValues>): FieldErrors<FieldValues> => {
+const findAllErrors = (errors: FieldErrors<FieldValues>, pathPrefix = ''): FieldErrors<FieldValues> => {
     return Object.keys(errors).reduce<FieldErrors<FieldValues>>((acc, fieldKey) => {
         const fieldValue = errors[fieldKey];
+        const fullPath = pathPrefix ? `${pathPrefix}.${fieldKey}` : fieldKey;
 
-        if (fieldValue?.message && !acc[fieldKey]) {
-            const shouldNotAdd = Object.keys(acc).some((key) => acc[key]?.message === fieldValue?.message);
-            if (shouldNotAdd) {
-                return acc;
-            }
+        if (fieldValue?.message) {
             return {
                 ...acc,
-                [fieldKey]: errors[fieldKey],
+                [fullPath]: fieldValue,
             };
         }
 
         if (Array.isArray(fieldValue)) {
-            const alle = fieldValue.reduce((a, f) => {
+            const alle = fieldValue.reduce<FieldErrors<FieldValues>>((a, f, index) => {
                 return {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    ...(f ? findAllErrors(f) : {}),
                     ...a,
+                    ...(f ? findAllErrors(f, `${fullPath}.${index}`) : {}),
                 };
             }, {});
             return {
@@ -33,6 +29,18 @@ const findAllErrors = (errors: FieldErrors<FieldValues>): FieldErrors<FieldValue
             };
         }
         return acc;
+    }, {});
+};
+
+const dedupErrorsByMessage = (errors: FieldErrors<FieldValues>): FieldErrors<FieldValues> => {
+    const seenMessages = new Set<string>();
+    return Object.keys(errors).reduce<FieldErrors<FieldValues>>((acc, key) => {
+        const message = errors[key]?.message;
+        if (typeof message !== 'string' || seenMessages.has(message)) {
+            return acc;
+        }
+        seenMessages.add(message);
+        return { ...acc, [key]: errors[key] };
     }, {});
 };
 
@@ -50,7 +58,7 @@ export const ErrorSummaryHookForm = () => {
         }
     }, [errors]);
 
-    const flattenAndUniqueErrors = findAllErrors(errors);
+    const flattenAndUniqueErrors = dedupErrorsByMessage(findAllErrors(errors));
 
     const mappedErrors = Object.entries(flattenAndUniqueErrors).map(([fieldName, error]) => ({
         message: typeof error?.message === 'string' ? error.message : undefined,

--- a/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
+++ b/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { useEffect, useRef } from 'react';
 import { FieldErrors, FieldValues, useFormContext } from 'react-hook-form';
 
@@ -17,12 +16,15 @@ const findAllErrors = (errors: FieldErrors<FieldValues>, pathPrefix = ''): Field
         }
 
         if (Array.isArray(fieldValue)) {
-            const alle = fieldValue.reduce<FieldErrors<FieldValues>>((a, f, index) => {
-                return {
-                    ...a,
-                    ...(f ? findAllErrors(f, `${fullPath}.${index}`) : {}),
-                };
-            }, {});
+            const alle = (fieldValue as Array<FieldErrors<FieldValues>>).reduce<FieldErrors<FieldValues>>(
+                (a, f, index) => {
+                    return {
+                        ...a,
+                        ...(f ? findAllErrors(f, `${fullPath}.${index}`) : {}),
+                    };
+                },
+                {},
+            );
             return {
                 ...acc,
                 ...alle,

--- a/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
+++ b/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
@@ -41,6 +41,7 @@ export const ErrorSummaryHookForm = () => {
 
     const {
         formState: { errors },
+        setFocus,
     } = useFormContext();
 
     useEffect(() => {
@@ -51,13 +52,9 @@ export const ErrorSummaryHookForm = () => {
 
     const flattenAndUniqueErrors = findAllErrors(errors);
 
-    // TODO Denne er ikkje optimal
-    const mappedErrors = Object.values(flattenAndUniqueErrors).map((error) => ({
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        message: error?.message?.toString(),
-        //@ts-expect-error TODO Burde nok heller bruka setFocus her
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        focus: error?.ref?.focus,
+    const mappedErrors = Object.entries(flattenAndUniqueErrors).map(([fieldName, error]) => ({
+        message: error?.message,
+        focus: () => setFocus(fieldName),
     }));
 
     return (

--- a/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
+++ b/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
@@ -53,7 +53,7 @@ export const ErrorSummaryHookForm = () => {
     const flattenAndUniqueErrors = findAllErrors(errors);
 
     const mappedErrors = Object.entries(flattenAndUniqueErrors).map(([fieldName, error]) => ({
-        message: error?.message,
+        message: typeof error?.message === 'string' ? error.message : undefined,
         focus: () => setFocus(fieldName),
     }));
 


### PR DESCRIPTION
- Byt ut Object.values med Object.entries for å bevare feltnøkkelen
- Bruk setFocus(fieldName) i staden for error?.ref?.focus
- Fjern @ts-expect-error og tilhøyrande eslint-disable-kommentarar