### PR TITLE
fix: aktiver navigate-assertions i ArbeidssituasjonSteg-test

### DIFF
--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
@@ -2,6 +2,7 @@ import { composeStories } from '@storybook/react-vite';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/PlanleggerDataContext';
+import { PlanleggerRoutes } from 'appData/routes';
 import { useNavigate } from 'react-router-dom';
 import { Arbeidsstatus } from 'types/Arbeidssituasjon';
 
@@ -26,7 +27,6 @@ const useNavigateMock = vi.mocked(useNavigate);
 
 describe('<ArbeidssituasjonSteg>', () => {
     it('skal vise arbeidssituasjon for far og mor og velge at begge har rett', async () => {
-        // TODO Fiks test
         const navigateMock = vi.fn();
         useNavigateMock.mockReturnValue(navigateMock);
 
@@ -58,8 +58,8 @@ describe('<ArbeidssituasjonSteg>', () => {
             key: ContextDataType.ARBEIDSSITUASJON,
             type: 'update',
         });
-        // expect(navigateMock).toHaveBeenCalledTimes(1);
-        // expect(navigateMock).toHaveBeenCalledWith(expect.stringMatching(PlanleggerRoutes.HVOR_MYE));
+        expect(navigateMock).toHaveBeenCalledTimes(1);
+        expect(navigateMock).toHaveBeenCalledWith(expect.stringMatching(PlanleggerRoutes.HVOR_MYE));
     });
 
     it('skal vise arbeidssituasjon for far og mor og velge at kun mor har rett', async () => {


### PR DESCRIPTION
Fjerner TODO-kommentar og uncommenterer de to navigate-assertionene som verifiserer at brukeren sendes til HVOR_MYE etter innsending.