### PR TITLE
Fiksar AppContainer-test som feilar på CI

### DIFF
--- a/apps/planlegger/src/AppContainer.test.tsx
+++ b/apps/planlegger/src/AppContainer.test.tsx
@@ -87,47 +87,46 @@ describe('<AppContainer>', () => {
 
             await userEvent.click(screen.getByText('Neste'));
 
-            // TODO (TOR) Dette feilar av ein eller annan grunn kun på github
-            // expect(await screen.findByText('Planen deres')).toBeInTheDocument();
-            // expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
+            expect(await screen.findByText('Planen deres', {}, { timeout: 5000 })).toBeInTheDocument();
+            expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-            // await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
-            // await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+            expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+            await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
 
-            // expect(screen.getByText('Planen deres')).toBeInTheDocument();
-            // expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            expect(screen.getByText('Planen deres')).toBeInTheDocument();
+            expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Fordeling')).toHaveLength(2));
-            // expect(screen.getByText('Steg 7 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Fordeling')).toHaveLength(2));
+            expect(screen.getByText('Steg 7 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Hvor lenge')).toHaveLength(2));
-            // expect(screen.getByText('Steg 6 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Hvor lenge')).toHaveLength(2));
+            expect(screen.getByText('Steg 6 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Hvor mye')).toHaveLength(2));
-            // expect(screen.getByText('Steg 5 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Hvor mye')).toHaveLength(2));
+            expect(screen.getByText('Steg 5 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Arbeidssituasjon')).toHaveLength(2));
-            // expect(screen.getByText('Steg 4 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Arbeidssituasjon')).toHaveLength(2));
+            expect(screen.getByText('Steg 4 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Barnehageplass')).toHaveLength(2));
-            // expect(screen.getByText('Steg 3 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Barnehageplass')).toHaveLength(2));
+            expect(screen.getByText('Steg 3 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Barnet')).toHaveLength(2));
-            // expect(screen.getByText('Steg 2 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Barnet')).toHaveLength(2));
+            expect(screen.getByText('Steg 2 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // await waitFor(() => expect(screen.getAllByText('Hvem planlegger?')).toHaveLength(2));
-            // expect(screen.getByText('Steg 1 av 9')).toBeInTheDocument();
-            // await userEvent.click(screen.getByText('Forrige'));
+            await waitFor(() => expect(screen.getAllByText('Hvem planlegger?')).toHaveLength(2));
+            expect(screen.getByText('Steg 1 av 9')).toBeInTheDocument();
+            await userEvent.click(screen.getByText('Forrige'));
 
-            // expect(screen.getByText('Planleggeren består av to deler:')).toBeInTheDocument();
+            expect(screen.getByText('Planleggeren består av to deler:')).toBeInTheDocument();
         }),
     );
 });


### PR DESCRIPTION
Rotårsak: findByText('Planen deres') timeouta på CI fordi PlanenDeresSteg er ein tung komponent (UttaksplanKalender etc.) og CI-maskiner er 2-4x seinare enn lokalt.

Løysing: Brukar { timeout: 5000 } på den første findByText etter navigasjon til Planen deres, og kommenterer inn resten av testkodens assertions som tidlegare var kommentert ut.