### PR TITLE
fjern TODO-workaround for number i context

### DIFF
--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -138,10 +138,8 @@ const finnDeltUttaksdata = (
     hvemPlanlegger: HvemPlanlegger,
     valgtStønadskonto: KontoBeregningDto,
     barnet: OmBarnet,
-    tempAantallDagerFellesperiodeSøker1: number = 0,
+    antallDagerFellesperiodeSøker1: number = 0,
 ): Uttaksdata => {
-    //TODO Fjern denne når ein får lagra number i context
-    const antallDagerFellesperiodeSøker1 = Number.parseInt(tempAantallDagerFellesperiodeSøker1.toString(), 10);
 
     const totaltAntallDagerFellesperiode = getAntallUkerOgDagerFellesperiode(valgtStønadskonto).totaltAntallDager;
     const antallUkerOgDagerFellesperiodeForSøker1 = getUkerOgDager(antallDagerFellesperiodeSøker1);


### PR DESCRIPTION
antallDagerFellesperiodeSøker1 vert no sett via slider med setValue og er alltid eit number – Number.parseInt-konverteringa er ikkje lenger nødvendig.