### PR TITLE
Remove undefined from ValidationReturnType

### DIFF
--- a/apps/foreldrepengeoversikt/src/utils/validationUtils.ts
+++ b/apps/foreldrepengeoversikt/src/utils/validationUtils.ts
@@ -4,7 +4,7 @@ import { textGyldigRegex, textRegex } from '@navikt/fp-validation';
 
 //TODO (TOR) Ser ut som funksjonane i denne fila har duplikatar i foreldrepengesoknad. Flytt ut i felles-pakke
 
-type SkjemaelementFeil = string | undefined;
+type SkjemaelementFeil = string | null;
 
 const getIllegalChars = (value: string): string => {
     const kunUgyldigeTegn = value.replace(textGyldigRegex, '');
@@ -29,7 +29,7 @@ const validateTextInputField = (value: string, feltNavn: string, intl: IntlShape
     if (!validateTextHasLegalChars(value)) {
         return getIllegalCharsErrorMessage(value, feltNavn, intl);
     }
-    return undefined;
+    return null;
 };
 
 export const validateFritekstFelt = (intl: IntlShape, label: string, inputText?: string) => {

--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-form/fordelingFormUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-form/fordelingFormUtils.ts
@@ -17,7 +17,7 @@ const validateMaxValueAntallUkerFellesperiode = (
         const maxValue = getVarighetString(tilgjengeligeDager, intl);
         return intl.formatMessage({ id: 'fordeling.antallDagerUker.forStor' }, { maxValue });
     }
-    return undefined;
+    return null;
 };
 
 export const isValidAntallUkerFellesperiode =
@@ -42,7 +42,7 @@ export const isValidAntallUkerFellesperiode =
                 intl,
             );
         }
-        return undefined;
+        return null;
     };
 
 export const isValidAntallDagerFellesperiode =
@@ -67,7 +67,7 @@ export const isValidAntallDagerFellesperiode =
                 intl,
             );
         }
-        return undefined;
+        return null;
     };
 
 export const validateOppstartsdato =
@@ -84,5 +84,5 @@ export const validateOppstartsdato =
             return intl.formatMessage({ id: 'fordeling.oppstartsdato.ukedag' });
         }
 
-        return undefined;
+        return null;
     };

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/ValgteRegistrerteBarn.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/ValgteRegistrerteBarn.tsx
@@ -99,7 +99,7 @@ export const ValgteRegistrerteBarn = ({ valgteRegistrerteBarn, skalInkludereTerm
                                 });
                             }
 
-                            return undefined;
+                            return null;
                         },
                     ]}
                 />

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/adopsjon/FødselsdatoerFieldArray.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/adopsjon/FødselsdatoerFieldArray.tsx
@@ -10,10 +10,10 @@ import { isBeforeOrSame, isBeforeTodayOrToday, isDateBeforeToday as isBeforeToda
 
 const erBarnetUnder15årPåAdopsjonsdato = (i18nText: string, adopsjonsdato?: string) => (fødselsdato: string) => {
     if (!adopsjonsdato) {
-        return undefined;
+        return null;
     }
     const datoBarnetFyllerFemten = dayjs(fødselsdato).startOf('day').add(15, 'year');
-    return dayjs(adopsjonsdato).isBetween(fødselsdato, datoBarnetFyllerFemten, null, '[]') ? undefined : i18nText;
+    return dayjs(adopsjonsdato).isBetween(fødselsdato, datoBarnetFyllerFemten, null, '[]') ? null : i18nText;
 };
 
 const finnAntallBarnTekst = (antall: number) => {

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/ErFødtPanel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/ErFødtPanel.tsx
@@ -36,7 +36,7 @@ export const ErFødtPanel = () => {
                     isValidDate(intl.formatMessage({ id: 'valideringsfeil.omBarnet.termindato.ugyldigDatoFormat' })),
                     (termindato) => {
                         if (!fødselsdato) {
-                            return undefined;
+                            return null;
                         }
                         if (!dayjs(termindato).subtract(6, 'months').isSameOrBefore(dayjs(fødselsdato), 'day')) {
                             return intl.formatMessage({ id: 'valideringsfeil.omBarnet.termindato.forLangtFremITid' });
@@ -46,7 +46,7 @@ export const ErFødtPanel = () => {
                                 id: 'valideringsfeil.omBarnet.termindato.forLangtTilbakeITid',
                             });
                         }
-                        return undefined;
+                        return null;
                     },
                 ]}
             />
@@ -71,7 +71,7 @@ export const ErFødtPanel = () => {
                                 ? intl.formatMessage({
                                       id: 'valideringsfeil.omBarnet.fødselsdato.ikkeMerEnn3År3MndTilbake',
                                   })
-                                : undefined,
+                                : null,
                     ]}
                 />
             )}

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
@@ -86,7 +86,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
                                     });
                                 }
 
-                                return undefined;
+                                return null;
                             },
                         ]}
                     />

--- a/apps/foreldrepengesoknad/src/utils/validationUtil.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/validationUtil.test.ts
@@ -27,7 +27,7 @@ describe('validationUtil', () => {
 
         const resultat = validateFødselsnummer(intl, søkerFnr, 'fødselsnummer')(andrePartFnr);
 
-        expect(resultat).toBeUndefined();
+        expect(resultat).toBeNull();
     });
 
     it('skal gi feilmelding når søker oppgir sitt eget fnr som andre parts fnr', () => {
@@ -74,7 +74,7 @@ describe('validationUtil', () => {
 
         const resultat = validateFødselsnummer(intl, søkerFnr, 'fødselsnummer', erUtenlandskFnr)(andrePartFnr);
 
-        expect(resultat).toBeUndefined();
+        expect(resultat).toBeNull();
     });
     it('skal ikke gi feilmelding når frn er utenlandsk og fnr inneholder ulovlige tegn', () => {
         const søkerFnr = '05510552883';

--- a/apps/foreldrepengesoknad/src/utils/validationUtil.ts
+++ b/apps/foreldrepengesoknad/src/utils/validationUtil.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import minMax from 'dayjs/plugin/minMax';
 import { IntlShape } from 'react-intl';
-import { SkjemaelementFeil } from 'types/SkjemaelementFeil';
 
 import { textGyldigRegex, textRegex } from '@navikt/fp-validation';
 

--- a/apps/foreldrepengesoknad/src/utils/validationUtil.ts
+++ b/apps/foreldrepengesoknad/src/utils/validationUtil.ts
@@ -17,7 +17,7 @@ export const hasValue = (v: string | number | boolean | undefined | null) => v !
 
 export const validateFødselsnummer =
     (intl: IntlShape, søkersFødselsnummer: string, label: string, erUtenlandskFnr?: boolean) =>
-    (fnr: string): string | undefined => {
+    (fnr: string): string | null => {
         if (erUtenlandskFnr) {
             if (fnr === undefined || fnr.trim() === '') {
                 return intl.formatMessage({ id: 'valideringsfeil.fødselsnummer.required' });
@@ -41,7 +41,7 @@ export const validateFødselsnummer =
         }
 
         return validFnrResult === 'fnr' || validFnrResult === 'dnr' || validFnrResult === 'hnr'
-            ? undefined
+            ? null
             : intl.formatMessage({ id: 'valideringsfeil.fødselsnummer.ugyldigFødselsnummer' });
     };
 
@@ -80,9 +80,9 @@ const getIllegalCharsErrorMessage = (value: string, feltNavn: string, intl: Intl
 
 const validateTextHasLegalChars = (value: string): boolean => textRegex.test(value);
 
-export const validateTextInputField = (value: string, feltNavn: string, intl: IntlShape): SkjemaelementFeil => {
+export const validateTextInputField = (value: string, feltNavn: string, intl: IntlShape): string | null => {
     if (!validateTextHasLegalChars(value)) {
         return getIllegalCharsErrorMessage(value, feltNavn, intl);
     }
-    return undefined;
+    return null;
 };

--- a/apps/svangerskapspengesoknad/src/steps/perioder/perioderValidation.ts
+++ b/apps/svangerskapspengesoknad/src/steps/perioder/perioderValidation.ts
@@ -13,7 +13,7 @@ const validerStillingsprosentInput = (intl: IntlShape, value: string) => {
     const stillingsprosent = getFloatFromString(value);
     return stillingsprosent === undefined
         ? intl.formatMessage({ id: 'valideringsfeil.stillingsprosent.måVæreEtTall' })
-        : undefined;
+        : null;
 };
 
 export const validateStillingsprosentPåPerioder =
@@ -85,7 +85,7 @@ export const validateStillingsprosentPåPerioder =
                 },
             );
         }
-        return undefined;
+        return null;
     };
 
 export const validatePeriodeFom =
@@ -147,7 +147,7 @@ export const validatePeriodeTom =
             );
         }
 
-        return undefined;
+        return null;
     };
 
 const validateAtPeriodeIkkeOverlapper = (
@@ -191,7 +191,7 @@ const validateAtPeriodeIkkeOverlapper = (
             }
         }
     }
-    return undefined;
+    return null;
 };
 
 const validateSammenhengendePerioderFom = (
@@ -203,7 +203,7 @@ const validateSammenhengendePerioderFom = (
     const alleFom = allePerioder.filter((p) => p.fom).map((periode) => dayjs(periode.fom));
     const minstAvAlleFom = alleFom.length > 0 ? dayjs.min(alleFom) : undefined;
     if (minstAvAlleFom && dayjs(fom).isSameOrBefore(minstAvAlleFom, 'day')) {
-        return undefined;
+        return null;
     }
     const alleTom = allePerioder
         .filter((p) => p.tom || p.tomType === TilOgMedDatoType.SISTE_DAG_MED_SVP)
@@ -216,5 +216,5 @@ const validateSammenhengendePerioderFom = (
     if (!tomSomErDagenFørFom) {
         return intl.formatMessage({ id: 'valideringsfeil.periode.ikkeSammenhengende' });
     }
-    return undefined;
+    return null;
 };

--- a/apps/svangerskapspengesoknad/src/steps/tilrettelegging/tilretteleggingValidation.ts
+++ b/apps/svangerskapspengesoknad/src/steps/tilrettelegging/tilretteleggingValidation.ts
@@ -17,7 +17,7 @@ const validerStillingsprosentInput = (intl: IntlShape, value: string) => {
         return intl.formatMessage({ id: 'valideringsfeil.stillingsprosent.måVæreEtTall' });
     }
 
-    return undefined;
+    return null;
 };
 
 export const validateStillingsprosentEnDelvisPeriode =
@@ -48,7 +48,7 @@ export const validateStillingsprosentEnDelvisPeriode =
                 },
             );
         }
-        return undefined;
+        return null;
     };
 export const validateTilretteleggingstiltak = (intl: IntlShape) => (value: string) => {
     if (!hasValue(value) || value.trim() === '') {
@@ -131,7 +131,7 @@ export const validateSammePeriodeFremTilTerminFom =
                       },
                   );
         }
-        return undefined;
+        return null;
     };
 
 export const validateSammePeriodeFremTilTerminTilbakeIJobbDato =
@@ -197,7 +197,7 @@ export const validateSammePeriodeFremTilTerminTilbakeIJobbDato =
                 },
             );
         }
-        return undefined;
+        return null;
     };
 
 export const validateBehovForTilretteleggingFom =
@@ -211,7 +211,7 @@ export const validateBehovForTilretteleggingFom =
         kanHaSvpFremTilTreUkerFørTermin: boolean,
         erFrilansTilrettelegging: boolean,
     ) =>
-    (fom: string): string | undefined => {
+    (fom: string): string | null => {
         if (dayjs(fom).isBefore(tiMånederSidenDato(termindato), 'd')) {
             return intl.formatMessage({ id: 'valideringsfeil.tilrettelagtArbeidFom.tiMndSidenTermin' });
         }
@@ -243,12 +243,12 @@ export const validateBehovForTilretteleggingFom =
                 },
             );
         }
-        return undefined;
+        return null;
     };
 
 export const validerTilretteleggingTomType =
     (intl: IntlShape, tilretteleggingType: Tilretteleggingstype, kanHaSVPFremTilTreUkerFørTermin: boolean) =>
-    (value: TilOgMedDatoType | undefined): string | undefined => {
+    (value: TilOgMedDatoType | undefined): string | null => {
         const erDelvis = tilretteleggingType === 'delvis';
         if (!hasValue(value)) {
             if (erDelvis) {
@@ -262,7 +262,7 @@ export const validerTilretteleggingTomType =
             }
         }
 
-        return undefined;
+        return null;
     };
 
 const finnFeilmeldingForPåkrevd = (intl: IntlShape, type: Arbeidsforholdstype) => {

--- a/packages/form-hooks/src/form-wrappers/formUtils.ts
+++ b/packages/form-hooks/src/form-wrappers/formUtils.ts
@@ -1,7 +1,6 @@
 import { FieldErrors, FieldValues, Path } from 'react-hook-form';
 
-//TODO (TOR) Trur ein bør fjerna undefined her
-export type ValidationReturnType = string | null | undefined;
+export type ValidationReturnType = string | null;
 
 export const getValidationRules = <T>(validate: Array<(value: T) => ValidationReturnType>) =>
     validate.reduce(

--- a/packages/steg-egen-næring/src/components/OrgnummerEllerLand.tsx
+++ b/packages/steg-egen-næring/src/components/OrgnummerEllerLand.tsx
@@ -9,7 +9,7 @@ import { NæringFormValues } from '../types/NæringFormValues';
 
 const validateEgenNæringOrgnr =
     (intl: IntlShape, erValgfri: boolean) =>
-    (orgnrValue = ''): string | undefined => {
+    (orgnrValue = ''): string | null => {
         if (!erValgfri && !orgnrValue) {
             return intl.formatMessage({ id: 'valideringsfeil.egenNæringOrgnr.påkrevd' });
         }
@@ -22,7 +22,7 @@ const validateEgenNæringOrgnr =
             return intl.formatMessage({ id: 'valideringsfeil.egenNæringOrgnr.ugyldigFormat' });
         }
 
-        return undefined;
+        return null;
     };
 
 interface Props {

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
@@ -53,9 +53,9 @@ describe('prosentValideringGradering', () => {
         expect(validator('50')).toBe('Stillingsprosent og samtidig uttak kan ikke utgjøre mer enn 100 % sammenlagt');
     });
 
-    it('skal returnere undefined når verdi er gyldig', () => {
+    it('skal returnere null når verdi er gyldig', () => {
         const validator = prosentValideringGradering(intlMock, '20');
-        expect(validator('30')).toBeUndefined();
+        expect(validator('30')).toBeNull();
     });
 });
 
@@ -85,9 +85,9 @@ describe('valideringSamtidigUttak', () => {
         expect(validator('40')).toBe('Stillingsprosent og samtidig uttak kan ikke utgjøre mer enn 100 % sammenlagt');
     });
 
-    it('skal returnere undefined når verdi er gyldig', () => {
+    it('skal returnere null når verdi er gyldig', () => {
         const validator = valideringSamtidigUttak(intlMock, '30');
-        expect(validator('40')).toBeUndefined();
+        expect(validator('40')).toBeNull();
     });
 });
 

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
@@ -53,7 +53,7 @@ export const prosentValideringGradering =
             });
         }
 
-        return undefined;
+        return null;
     };
 
 export const valideringSamtidigUttak =
@@ -89,7 +89,7 @@ export const valideringSamtidigUttak =
             });
         }
 
-        return undefined;
+        return null;
     };
 
 export const kanMisteDagerVedEndringTilFerie = (

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -48,7 +48,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                         (value) => {
                             return value === undefined
                                 ? intl.formatMessage({ id: 'VelgPeriodePanelStep.VelgPeriode' })
-                                : undefined;
+                                : null;
                         },
                     ]}
                 >


### PR DESCRIPTION
Align with FormValidationResult (string | null) frå generalFormValidation.ts. Undefined og null er funksjonelt ekvivalente i getValidationRules (begge falsy), men null er meir eksplisitt for 'ingen feil'.