### PR TITLE
fix(form-hooks): fjern TODO og ts-expect-error i RhfRadioGroup

### DIFF
--- a/packages/form-hooks/src/form-wrappers/RhfRadioGroup.tsx
+++ b/packages/form-hooks/src/form-wrappers/RhfRadioGroup.tsx
@@ -63,11 +63,12 @@ export const RhfRadioGroup = <TFieldValues extends FieldValues, TName extends Fi
             className={className}
         >
             {children.map((child, index) => {
-                //TODO Vurder å heller lage ein wrapper til children
-                //Denne map'en legg til ref for å kunna setta fokus ved feil
+                // Legg til ref på første child for å kunna setta fokus ved feil
                 if (index === 0) {
-                    // @ts-expect-error fiks
-                    return React.cloneElement(child, { key: child.key, ref: field.ref });
+                    return React.cloneElement(child as React.ReactElement<React.RefAttributes<HTMLElement>>, {
+                        key: child.key,
+                        ref: field.ref,
+                    });
                 }
                 return child;
             })}


### PR DESCRIPTION
Brukar React.RefAttributes<HTMLElement> for å typsa cloneElement riktig i staden for @ts-expect-error. Semantikken er uendra – ref ligg framleis på første Radio-child for fokusstyring ved valideringsfeil.