### PR TITLE
Fix: handter tom gjeldendeUttaksplan array i endringssøknad

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -156,7 +156,7 @@ export const UttaksplanForm = ({
                 visAutomatiskJustering ? formValues.ønskerJustertUttakVedFødsel : undefined,
             );
 
-            if (!gjeldendeUttaksplan) {
+            if (!gjeldendeUttaksplan || gjeldendeUttaksplan.length === 0) {
                 oppdaterUttaksplan(defaultUttaksperioder);
             }
 


### PR DESCRIPTION
For endringssøknad der uttaksplan er undefined i context, blir gjeldendeUttaksplan sett til ein tom array (truthy), slik at aldri vart kalla. Dette førte til at UTTAKSPLAN forblei undefined i context, og UttaksplanOppsummeringsliste kasta 'Data er ikke oppgitt' ved navigasjon til oppsummering.

Løysing: utvid sjekken til å også inkludere tom array.