### PR TITLE
Logg ugyldige overlappende perioder i uttaksplan til Sentry

### DIFF
--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -22,6 +22,7 @@
         "@navikt/ds-react": "8.9.1",
         "@navikt/fp-constants": "workspace:*",
         "@navikt/fp-form-hooks": "workspace:*",
+        "@navikt/fp-observability": "workspace:*",
         "@navikt/fp-types": "workspace:*",
         "@navikt/fp-ui": "workspace:*",
         "@navikt/fp-utils": "workspace:*",

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
@@ -506,6 +506,7 @@ const harFarMedmorValgtMerEnnToUkerTotaltIIntervallet2UkerFørOg6UkerEtterFamili
             });
             const uttaksperioderUtenomBortsettFraEndredePerioder = new UttakPeriodeBuilder(
                 uttakPerioderUtenOverførtMødrekvote,
+                'validator',
             )
                 .fjernUttakPerioder(nyePerioder, false)
                 .getUttakPerioder();

--- a/packages/uttaksplan/src/kalender/redigering/context/KalenderRedigeringContext.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/context/KalenderRedigeringContext.tsx
@@ -38,7 +38,7 @@ export const KalenderRedigeringProvider = ({
 
     const leggTilUttaksplanPerioder = useCallback(
         (perioder: UttakPeriode_fpoversikt[], skalForskyvePeriode: boolean) => {
-            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder)
+            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder, 'kalender')
                 .leggTilUttakPerioder(perioder, skalForskyvePeriode)
                 .getUttakPerioder();
 
@@ -49,7 +49,7 @@ export const KalenderRedigeringProvider = ({
 
     const slettUttaksplanPerioder = useCallback(
         (perioder: Array<{ fom: string; tom: string }>, skalForskyveBakover: boolean) => {
-            const uttakPeriodeBuilder = new UttakPeriodeBuilder(uttakPerioder);
+            const uttakPeriodeBuilder = new UttakPeriodeBuilder(uttakPerioder, 'kalender');
             uttakPeriodeBuilder.fjernUttakPerioder(perioder, skalForskyveBakover);
             notEmpty(uttaksplanRedigering).oppdaterUttaksplan(uttakPeriodeBuilder.getUttakPerioder());
         },

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -114,7 +114,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     );
 
     const handleAddPeriode = (nyPeriode: UttakPeriode_fpoversikt[], skalForskyve: boolean) => {
-        const builder = new UttakPeriodeBuilder(uttakPerioder);
+        const builder = new UttakPeriodeBuilder(uttakPerioder, 'liste');
         if (uttaksplanperiode) {
             builder.fjernUttakPerioder([uttaksplanperiode], false);
         }
@@ -220,7 +220,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                 skalForskyve,
             );
         } else if (hvaVilDuGjøre === 'LEGG_TIL_OPPHOLD') {
-            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder)
+            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder, 'liste')
                 .fjernUttakPerioder(
                     [
                         {

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
@@ -15,6 +15,7 @@ import {
     erTapteDagerHull,
     erVanligUttakPeriode,
 } from '../../../types/UttaksplanPeriode';
+import { UttakPeriodeBuilder } from '../../../utils/UttakPeriodeBuilder';
 import {
     erDetEksisterendePerioderEtterValgtePerioder,
     erOppholdsperiode,
@@ -23,7 +24,6 @@ import {
     erUtsettelsesperiode,
     erUttaksperiode,
 } from '../../../utils/periodeUtils';
-import { UttakPeriodeBuilder } from '../../../utils/UttakPeriodeBuilder';
 import { genererPeriodeKey } from '../../utils/uttaksplanListeUtils';
 import {
     erUttaksplanperiodeEøs,
@@ -79,7 +79,7 @@ export const PeriodeListeContent = ({ isReadOnly, uttaksplanperioder }: Props) =
         );
 
         if (!erEksisterendePerioderEtterValgteDager && uttaksplanperioder.length === 1) {
-            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder)
+            const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder, 'liste')
                 .fjernUttakPerioder(uttaksplanperioder, false)
                 .getUttakPerioder();
             uttaksplanRedigering?.oppdaterUttaksplan?.(nyeUttakPerioder);
@@ -263,13 +263,7 @@ const EndreOgSlettKnapper = ({
             >
                 <FormattedMessage id="uttaksplan.endre" />
             </Button>
-            <Button
-                type="button"
-                size="small"
-                variant="secondary"
-                icon={<TrashIcon />}
-                onClick={onSlettPeriodeClick}
-            >
+            <Button type="button" size="small" variant="secondary" icon={<TrashIcon />} onClick={onSlettPeriodeClick}>
                 <FormattedMessage id="uttaksplan.slett" />
             </Button>
         </HStack>

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/slett-periode-panel/SlettPeriodePanel.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/slett-periode-panel/SlettPeriodePanel.tsx
@@ -68,7 +68,7 @@ export const SlettPeriodePanel = ({ closePanel, uttaksplanperioder, navnPåForel
     };
 
     const slettPerioder = (perioderSomSkalSlettes: Uttaksplanperiode[], skalForskyveBakover: boolean) => {
-        const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder)
+        const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder, 'liste')
             .fjernUttakPerioder(perioderSomSkalSlettes, skalForskyveBakover)
             .getUttakPerioder();
         uttaksplanRedigering?.oppdaterUttaksplan?.(nyeUttakPerioder);

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { BrukerRolleSak_fpoversikt } from '@navikt/fp-types';
 
 import { UttakPeriodeBuilder } from './UttakPeriodeBuilder';
+
+const captureMessageMock = vi.hoisted(() => vi.fn());
+vi.mock('@navikt/fp-observability', () => ({
+    captureMessage: captureMessageMock,
+    withScope: (cb: (scope: { setLevel: () => void; setTag: () => void; setExtra: () => void }) => void) =>
+        cb({ setLevel: vi.fn(), setTag: vi.fn(), setExtra: vi.fn() }),
+}));
 
 // Bruker forelder for å skille på eksisterende og nye perioder.
 const lagPeriode = (fom: string, tom: string) => ({
@@ -363,5 +370,45 @@ describe('UttakPeriodeBuilder.fjernUttakPerioder (Forskyv)', () => {
         builder.fjernUttakPerioder([lagNyPeriode('2024-01-04', '2024-01-05')], SKAL_FORSKYVE);
 
         expect(builder.getUttakPerioder()).toEqual([lagPeriode('2024-01-01', '2024-01-08')]);
+    });
+});
+
+describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp', () => {
+    it('loggar ikkje når planen er gyldig', () => {
+        captureMessageMock.mockClear();
+        const builder = new UttakPeriodeBuilder([lagPeriode('2024-01-01', '2024-01-05')]);
+        builder.leggTilUttakPerioder([lagNyPeriode('2024-01-10', '2024-01-12')], false);
+
+        builder.getUttakPerioder();
+
+        expect(captureMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('loggar ikkje for gyldig samtidig uttak (ulik forelder, samtidigUttak satt)', () => {
+        captureMessageMock.mockClear();
+        const builder = new UttakPeriodeBuilder([
+            { ...lagPeriode('2024-01-01', '2024-01-05'), kontoType: 'MØDREKVOTE', samtidigUttak: 100 },
+            { ...lagNyPeriode('2024-01-01', '2024-01-05'), kontoType: 'FEDREKVOTE', samtidigUttak: 100 },
+        ]);
+
+        builder.getUttakPerioder();
+
+        expect(captureMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('loggar når planen inneheld ein FERIE og ein FELLES på same dag', () => {
+        captureMessageMock.mockClear();
+        const builder = new UttakPeriodeBuilder([
+            { ...lagPeriode('2026-12-30', '2026-12-30'), kontoType: 'FELLESPERIODE' },
+            { ...lagPeriode('2026-12-30', '2026-12-30'), utsettelseÅrsak: 'LOVBESTEMT_FERIE' },
+        ]);
+
+        builder.getUttakPerioder();
+
+        expect(captureMessageMock).toHaveBeenCalledTimes(1);
+        expect(captureMessageMock).toHaveBeenCalledWith(
+            'UttakPeriodeBuilder produserte ugyldig overlappende perioder',
+            'warning',
+        );
     });
 });

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
@@ -5,11 +5,24 @@ import { BrukerRolleSak_fpoversikt } from '@navikt/fp-types';
 import { UttakPeriodeBuilder } from './UttakPeriodeBuilder';
 
 const captureMessageMock = vi.hoisted(() => vi.fn());
+const setExtraMock = vi.hoisted(() => vi.fn());
+const setTagMock = vi.hoisted(() => vi.fn());
+const setLevelMock = vi.hoisted(() => vi.fn());
 vi.mock('@navikt/fp-observability', () => ({
     captureMessage: captureMessageMock,
-    withScope: (cb: (scope: { setLevel: () => void; setTag: () => void; setExtra: () => void }) => void) =>
-        cb({ setLevel: vi.fn(), setTag: vi.fn(), setExtra: vi.fn() }),
+    withScope: (
+        cb: (scope: {
+            setLevel: typeof setLevelMock;
+            setTag: typeof setTagMock;
+            setExtra: typeof setExtraMock;
+        }) => void,
+    ) => cb({ setLevel: setLevelMock, setTag: setTagMock, setExtra: setExtraMock }),
 }));
+
+const getExtra = (key: string) => {
+    const call = setExtraMock.mock.calls.find(([k]) => k === key);
+    return call?.[1];
+};
 
 // Bruker forelder for å skille på eksisterende og nye perioder.
 const lagPeriode = (fom: string, tom: string) => ({
@@ -376,6 +389,7 @@ describe('UttakPeriodeBuilder.fjernUttakPerioder (Forskyv)', () => {
 describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp', () => {
     it('loggar ikkje når planen er gyldig', () => {
         captureMessageMock.mockClear();
+        setExtraMock.mockClear();
         const builder = new UttakPeriodeBuilder([lagPeriode('2024-01-01', '2024-01-05')]);
         builder.leggTilUttakPerioder([lagNyPeriode('2024-01-10', '2024-01-12')], false);
 
@@ -386,6 +400,7 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
 
     it('loggar ikkje for gyldig samtidig uttak (ulik forelder, samtidigUttak satt)', () => {
         captureMessageMock.mockClear();
+        setExtraMock.mockClear();
         const builder = new UttakPeriodeBuilder([
             { ...lagPeriode('2024-01-01', '2024-01-05'), kontoType: 'MØDREKVOTE', samtidigUttak: 100 },
             { ...lagNyPeriode('2024-01-01', '2024-01-05'), kontoType: 'FEDREKVOTE', samtidigUttak: 100 },
@@ -396,12 +411,19 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
         expect(captureMessageMock).not.toHaveBeenCalled();
     });
 
-    it('loggar når planen inneheld ein FERIE og ein FELLES på same dag', () => {
+    it('loggar når planen inneheld ein FERIE og ein FELLES på same dag, med full diagnostikk', () => {
         captureMessageMock.mockClear();
-        const builder = new UttakPeriodeBuilder([
-            { ...lagPeriode('2026-12-30', '2026-12-30'), kontoType: 'FELLESPERIODE' },
-            { ...lagPeriode('2026-12-30', '2026-12-30'), utsettelseÅrsak: 'LOVBESTEMT_FERIE' },
-        ]);
+        setExtraMock.mockClear();
+        setTagMock.mockClear();
+        setLevelMock.mockClear();
+
+        const opprinnelig = [
+            { ...lagPeriode('2026-12-30', '2026-12-30'), kontoType: 'FELLESPERIODE' as const },
+            { ...lagPeriode('2026-12-30', '2026-12-30'), utsettelseÅrsak: 'LOVBESTEMT_FERIE' as const },
+        ];
+        const builder = new UttakPeriodeBuilder(opprinnelig);
+        const nyPeriode = { ...lagNyPeriode('2026-12-31', '2026-12-31'), kontoType: 'FELLESPERIODE' as const };
+        builder.leggTilUttakPerioder([nyPeriode], false);
 
         builder.getUttakPerioder();
 
@@ -410,5 +432,34 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
             'UttakPeriodeBuilder produserte ugyldig overlappende perioder',
             'warning',
         );
+
+        expect(setLevelMock).toHaveBeenCalledWith('warning');
+        expect(setTagMock).toHaveBeenCalledWith('feiltype', 'uttaksplan-builder-overlapp');
+
+        expect(getExtra('antallUgyldigeOverlapp')).toBe(1);
+
+        const par = getExtra('ugyldigeOverlappPar');
+        expect(par).toHaveLength(1);
+        expect(par[0]).toMatchObject({
+            a: { fom: '2026-12-30', tom: '2026-12-30' },
+            b: { fom: '2026-12-30', tom: '2026-12-30' },
+        });
+
+        const opp = getExtra('opprinneligPerioder');
+        expect(opp).toHaveLength(2);
+        expect(opp[0]).toMatchObject({ fom: '2026-12-30', tom: '2026-12-30', kontoType: 'FELLESPERIODE' });
+        expect(opp[1]).toMatchObject({ fom: '2026-12-30', tom: '2026-12-30', utsettelseÅrsak: 'LOVBESTEMT_FERIE' });
+
+        const resultat = getExtra('resultatPerioder');
+        expect(resultat.length).toBeGreaterThanOrEqual(2);
+
+        const operasjonsLogg = getExtra('operasjonsLogg');
+        expect(operasjonsLogg).toHaveLength(1);
+        expect(operasjonsLogg[0]).toMatchObject({
+            operasjon: 'leggTilUttakPerioder',
+            forskyvPerioder: false,
+        });
+        expect(operasjonsLogg[0].nyePerioder).toHaveLength(1);
+        expect(operasjonsLogg[0].nyePerioder[0]).toMatchObject({ fom: '2026-12-31', tom: '2026-12-31' });
     });
 });

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
@@ -421,7 +421,7 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
             { ...lagPeriode('2026-12-30', '2026-12-30'), kontoType: 'FELLESPERIODE' as const },
             { ...lagPeriode('2026-12-30', '2026-12-30'), utsettelseÅrsak: 'LOVBESTEMT_FERIE' as const },
         ];
-        const builder = new UttakPeriodeBuilder(opprinnelig);
+        const builder = new UttakPeriodeBuilder(opprinnelig, 'liste');
         const nyPeriode = { ...lagNyPeriode('2026-12-31', '2026-12-31'), kontoType: 'FELLESPERIODE' as const };
         builder.leggTilUttakPerioder([nyPeriode], false);
 
@@ -435,7 +435,9 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
 
         expect(setLevelMock).toHaveBeenCalledWith('warning');
         expect(setTagMock).toHaveBeenCalledWith('feiltype', 'uttaksplan-builder-overlapp');
+        expect(setTagMock).toHaveBeenCalledWith('builderKilde', 'liste');
 
+        expect(getExtra('builderKilde')).toBe('liste');
         expect(getExtra('antallUgyldigeOverlapp')).toBe(1);
 
         const par = getExtra('ugyldigeOverlappPar');

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -11,9 +11,12 @@ dayjs.extend(utc);
 
 type AlleUttakPerioder = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
 
+type Builderkilde = 'liste' | 'kalender' | 'validator' | 'ukjent';
+
 export class UttakPeriodeBuilder {
     private alleUttakPerioder: AlleUttakPerioder[];
     private readonly opprinneligPerioder: AlleUttakPerioder[];
+    private readonly kilde: Builderkilde;
     private readonly operasjonsLogg: Array<{
         operasjon: string;
         nyePerioder?: AlleUttakPerioder[];
@@ -21,9 +24,10 @@ export class UttakPeriodeBuilder {
         forskyvPerioder: boolean;
     }> = [];
 
-    constructor(alleUttakPerioder: AlleUttakPerioder[]) {
+    constructor(alleUttakPerioder: AlleUttakPerioder[], kilde: Builderkilde = 'ukjent') {
         this.alleUttakPerioder = [...alleUttakPerioder].sort(sorterUttakPerioder);
         this.opprinneligPerioder = [...this.alleUttakPerioder];
+        this.kilde = kilde;
     }
 
     leggTilUttakPerioder(nyeUttakPerioder: AlleUttakPerioder[], forskyvPerioder: boolean): this {
@@ -120,7 +124,7 @@ export class UttakPeriodeBuilder {
 
     getUttakPerioder(): AlleUttakPerioder[] {
         const resultat = slåSammenLikeTilstøtendePerioder(this.alleUttakPerioder);
-        validerOgLoggOverlapp(resultat, this.opprinneligPerioder, this.operasjonsLogg);
+        validerOgLoggOverlapp(resultat, this.opprinneligPerioder, this.operasjonsLogg, this.kilde);
         return resultat;
     }
 }
@@ -171,6 +175,7 @@ const validerOgLoggOverlapp = (
         perioderSomSkalFjernes?: Array<{ fom: string; tom: string }>;
         forskyvPerioder: boolean;
     }>,
+    kilde: Builderkilde,
 ): void => {
     const ugyldigeOverlapp: Array<[AlleUttakPerioder, AlleUttakPerioder]> = [];
 
@@ -191,6 +196,8 @@ const validerOgLoggOverlapp = (
     withScope((scope) => {
         scope.setLevel('warning');
         scope.setTag('feiltype', 'uttaksplan-builder-overlapp');
+        scope.setTag('builderKilde', kilde);
+        scope.setExtra('builderKilde', kilde);
         scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
         scope.setExtra(
             'ugyldigeOverlappPar',

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -13,8 +13,8 @@ type AlleUttakPerioder = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpo
 
 export class UttakPeriodeBuilder {
     private alleUttakPerioder: AlleUttakPerioder[];
-    private opprinneligPerioder: AlleUttakPerioder[];
-    private operasjonsLogg: Array<{
+    private readonly opprinneligPerioder: AlleUttakPerioder[];
+    private readonly operasjonsLogg: Array<{
         operasjon: string;
         nyePerioder?: AlleUttakPerioder[];
         perioderSomSkalFjernes?: Array<{ fom: string; tom: string }>;

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -1,6 +1,7 @@
 import dayjs, { Dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
+import { captureMessage, withScope } from '@navikt/fp-observability';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils';
 
@@ -12,12 +13,21 @@ type AlleUttakPerioder = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpo
 
 export class UttakPeriodeBuilder {
     private alleUttakPerioder: AlleUttakPerioder[];
+    private opprinneligPerioder: AlleUttakPerioder[];
+    private operasjonsLogg: Array<{
+        operasjon: string;
+        nyePerioder?: AlleUttakPerioder[];
+        perioderSomSkalFjernes?: Array<{ fom: string; tom: string }>;
+        forskyvPerioder: boolean;
+    }> = [];
 
     constructor(alleUttakPerioder: AlleUttakPerioder[]) {
         this.alleUttakPerioder = [...alleUttakPerioder].sort(sorterUttakPerioder);
+        this.opprinneligPerioder = [...this.alleUttakPerioder];
     }
 
     leggTilUttakPerioder(nyeUttakPerioder: AlleUttakPerioder[], forskyvPerioder: boolean): this {
+        this.operasjonsLogg.push({ operasjon: 'leggTilUttakPerioder', nyePerioder: nyeUttakPerioder, forskyvPerioder });
         // Grupper for å håndtera at ein legg til to periodar når ein har samtidig uttak.
         // Bruk ein av dei nye periodane for å justera andre periodar, og legg så til den andre på slutten
         const grupperPerFomTom = new Map<string, AlleUttakPerioder[]>();
@@ -56,6 +66,7 @@ export class UttakPeriodeBuilder {
     }
 
     fjernUttakPerioder(perioderSomSkalFjernes: Array<{ fom: string; tom: string }>, forskyvPerioder: boolean): this {
+        this.operasjonsLogg.push({ operasjon: 'fjernUttakPerioder', perioderSomSkalFjernes, forskyvPerioder });
         if (forskyvPerioder) {
             for (const periodeSomSkalFjernes of perioderSomSkalFjernes) {
                 this.alleUttakPerioder = fjernOgForskyvUttakPerioderBakover(
@@ -108,9 +119,100 @@ export class UttakPeriodeBuilder {
     }
 
     getUttakPerioder(): AlleUttakPerioder[] {
-        return slåSammenLikeTilstøtendePerioder(this.alleUttakPerioder);
+        const resultat = slåSammenLikeTilstøtendePerioder(this.alleUttakPerioder);
+        validerOgLoggOverlapp(resultat, this.opprinneligPerioder, this.operasjonsLogg);
+        return resultat;
     }
 }
+
+const erOverlappendeIDato = (a: { fom: string; tom: string }, b: { fom: string; tom: string }): boolean =>
+    dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+const erEøsPeriode = (p: AlleUttakPerioder): p is UttakPeriodeAnnenpartEøs_fpoversikt => 'trekkdager' in p;
+
+const erGyldigSamtidigUttak = (a: AlleUttakPerioder, b: AlleUttakPerioder): boolean => {
+    if (erEøsPeriode(a) || erEøsPeriode(b)) {
+        // EØS-periodar er annen-part og kan eksistere parallelt med søkers periodar
+        return true;
+    }
+    return (
+        a.utsettelseÅrsak === undefined &&
+        b.utsettelseÅrsak === undefined &&
+        a.oppholdÅrsak === undefined &&
+        b.oppholdÅrsak === undefined &&
+        a.samtidigUttak !== undefined &&
+        b.samtidigUttak !== undefined &&
+        a.forelder !== b.forelder
+    );
+};
+
+const periodeTilLoggObjekt = (p: AlleUttakPerioder) => {
+    if (erEøsPeriode(p)) {
+        return { fom: p.fom, tom: p.tom, eøs: true, kontoType: p.kontoType };
+    }
+    return {
+        fom: p.fom,
+        tom: p.tom,
+        forelder: p.forelder,
+        kontoType: p.kontoType,
+        utsettelseÅrsak: p.utsettelseÅrsak,
+        oppholdÅrsak: p.oppholdÅrsak,
+        overføringÅrsak: p.overføringÅrsak,
+        samtidigUttak: p.samtidigUttak,
+    };
+};
+
+const validerOgLoggOverlapp = (
+    resultat: AlleUttakPerioder[],
+    opprinneligPerioder: AlleUttakPerioder[],
+    operasjonsLogg: Array<{
+        operasjon: string;
+        nyePerioder?: AlleUttakPerioder[];
+        perioderSomSkalFjernes?: Array<{ fom: string; tom: string }>;
+        forskyvPerioder: boolean;
+    }>,
+): void => {
+    const ugyldigeOverlapp: Array<[AlleUttakPerioder, AlleUttakPerioder]> = [];
+
+    for (let i = 0; i < resultat.length; i++) {
+        for (let j = i + 1; j < resultat.length; j++) {
+            const a = resultat[i]!;
+            const b = resultat[j]!;
+            if (erOverlappendeIDato(a, b) && !erGyldigSamtidigUttak(a, b)) {
+                ugyldigeOverlapp.push([a, b]);
+            }
+        }
+    }
+
+    if (ugyldigeOverlapp.length === 0) {
+        return;
+    }
+
+    withScope((scope) => {
+        scope.setLevel('warning');
+        scope.setTag('feiltype', 'uttaksplan-builder-overlapp');
+        scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
+        scope.setExtra(
+            'ugyldigeOverlappPar',
+            ugyldigeOverlapp.slice(0, 20).map(([a, b]) => ({
+                a: periodeTilLoggObjekt(a),
+                b: periodeTilLoggObjekt(b),
+            })),
+        );
+        scope.setExtra('opprinneligPerioder', opprinneligPerioder.map(periodeTilLoggObjekt));
+        scope.setExtra('resultatPerioder', resultat.map(periodeTilLoggObjekt));
+        scope.setExtra(
+            'operasjonsLogg',
+            operasjonsLogg.map((op) => ({
+                operasjon: op.operasjon,
+                forskyvPerioder: op.forskyvPerioder,
+                nyePerioder: op.nyePerioder?.map(periodeTilLoggObjekt),
+                perioderSomSkalFjernes: op.perioderSomSkalFjernes,
+            })),
+        );
+        captureMessage('UttakPeriodeBuilder produserte ugyldig overlappende perioder', 'warning');
+    });
+};
 
 const fjernOgForskyvUttakPerioderBakover = (
     alleUttakPerioder: AlleUttakPerioder[],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2491,6 +2491,9 @@ importers:
       '@navikt/fp-form-hooks':
         specifier: workspace:*
         version: link:../form-hooks
+      '@navikt/fp-observability':
+        specifier: workspace:*
+        version: link:../observability
       '@navikt/fp-types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
Legg til defensiv validering som loggar overlappande periodar med full kontekst når uttaksplanen vert sendt til backend. Eit overlapp er gyldig dersom begge er vanlege uttaksperiodar med samtidigUttak sett og ulik forelder; alle andre overlapp er teikn på korrupt tilstand.

Bakgrunn: produksjonsbug der ein dag fekk fem overlappande periodar (FELLES/FERIE/FELLES/FERIE/FELLES) på same dato. Utan repro-data klarer vi ikkje å identifisere kjelda i frontend, og denne loggen gir oss det nødvendige diagnoseunderlaget neste gong det skjer.