### PR TITLE
Logg uttaksplan-perioder med ugyldig overlapp før redigering startar

### DIFF
--- a/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
+++ b/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
@@ -1,8 +1,10 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
+import { captureMessage, withScope } from '@navikt/fp-observability';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 
 import { erEøsUttakPeriode } from '../types/UttaksplanPeriode';
+import { finnUgyldigeOverlapp, periodeTilLoggObjekt } from '../utils/UttakPeriodeBuilder';
 import { useUttaksplanData } from './UttaksplanDataContext';
 
 type AlleUttakPerioder = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
@@ -31,6 +33,34 @@ export const UttaksplanRedigeringProvider = (props: Props) => {
     const [visFjernAltModal, setVisFjernAltModal] = useState(false);
 
     const { uttakPerioder } = useUttaksplanData();
+
+    const harLoggetInitielleOverlapp = useRef(false);
+    useEffect(() => {
+        if (harLoggetInitielleOverlapp.current) {
+            return;
+        }
+        harLoggetInitielleOverlapp.current = true;
+
+        const ugyldigeOverlapp = finnUgyldigeOverlapp(uttakPerioder);
+        if (ugyldigeOverlapp.length === 0) {
+            return;
+        }
+
+        withScope((scope) => {
+            scope.setLevel('warning');
+            scope.setTag('feiltype', 'uttaksplan-initielle-overlapp');
+            scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
+            scope.setExtra(
+                'ugyldigeOverlappPar',
+                ugyldigeOverlapp.slice(0, 20).map(([a, b]) => ({
+                    a: periodeTilLoggObjekt(a),
+                    b: periodeTilLoggObjekt(b),
+                })),
+            );
+            scope.setExtra('opprinneligPerioder', uttakPerioder.map(periodeTilLoggObjekt));
+            captureMessage('Uttaksplan har ugyldig overlappende perioder før redigering startet', 'warning');
+        });
+    }, [uttakPerioder]);
 
     const [uttaksplanVersjoner, setUttaksplanVersjoner] = useState<AlleUttakPerioder[][]>([]);
 

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -134,6 +134,36 @@ const erOverlappendeIDato = (a: { fom: string; tom: string }, b: { fom: string; 
 
 const erEøsPeriode = (p: AlleUttakPerioder): p is UttakPeriodeAnnenpartEøs_fpoversikt => 'trekkdager' in p;
 
+export const finnUgyldigeOverlapp = (perioder: AlleUttakPerioder[]): Array<[AlleUttakPerioder, AlleUttakPerioder]> => {
+    const ugyldigeOverlapp: Array<[AlleUttakPerioder, AlleUttakPerioder]> = [];
+    for (let i = 0; i < perioder.length; i++) {
+        for (let j = i + 1; j < perioder.length; j++) {
+            const a = perioder[i]!;
+            const b = perioder[j]!;
+            if (erOverlappendeIDato(a, b) && !erGyldigSamtidigUttak(a, b)) {
+                ugyldigeOverlapp.push([a, b]);
+            }
+        }
+    }
+    return ugyldigeOverlapp;
+};
+
+export const periodeTilLoggObjekt = (p: AlleUttakPerioder) => {
+    if (erEøsPeriode(p)) {
+        return { fom: p.fom, tom: p.tom, eøs: true, kontoType: p.kontoType };
+    }
+    return {
+        fom: p.fom,
+        tom: p.tom,
+        forelder: p.forelder,
+        kontoType: p.kontoType,
+        utsettelseÅrsak: p.utsettelseÅrsak,
+        oppholdÅrsak: p.oppholdÅrsak,
+        overføringÅrsak: p.overføringÅrsak,
+        samtidigUttak: p.samtidigUttak,
+    };
+};
+
 const erGyldigSamtidigUttak = (a: AlleUttakPerioder, b: AlleUttakPerioder): boolean => {
     if (erEøsPeriode(a) || erEøsPeriode(b)) {
         // EØS-periodar er annen-part og kan eksistere parallelt med søkers periodar
@@ -150,22 +180,6 @@ const erGyldigSamtidigUttak = (a: AlleUttakPerioder, b: AlleUttakPerioder): bool
     );
 };
 
-const periodeTilLoggObjekt = (p: AlleUttakPerioder) => {
-    if (erEøsPeriode(p)) {
-        return { fom: p.fom, tom: p.tom, eøs: true, kontoType: p.kontoType };
-    }
-    return {
-        fom: p.fom,
-        tom: p.tom,
-        forelder: p.forelder,
-        kontoType: p.kontoType,
-        utsettelseÅrsak: p.utsettelseÅrsak,
-        oppholdÅrsak: p.oppholdÅrsak,
-        overføringÅrsak: p.overføringÅrsak,
-        samtidigUttak: p.samtidigUttak,
-    };
-};
-
 const validerOgLoggOverlapp = (
     resultat: AlleUttakPerioder[],
     opprinneligPerioder: AlleUttakPerioder[],
@@ -177,17 +191,7 @@ const validerOgLoggOverlapp = (
     }>,
     kilde: Builderkilde,
 ): void => {
-    const ugyldigeOverlapp: Array<[AlleUttakPerioder, AlleUttakPerioder]> = [];
-
-    for (let i = 0; i < resultat.length; i++) {
-        for (let j = i + 1; j < resultat.length; j++) {
-            const a = resultat[i]!;
-            const b = resultat[j]!;
-            if (erOverlappendeIDato(a, b) && !erGyldigSamtidigUttak(a, b)) {
-                ugyldigeOverlapp.push([a, b]);
-            }
-        }
-    }
+    const ugyldigeOverlapp = finnUgyldigeOverlapp(resultat);
 
     if (ugyldigeOverlapp.length === 0) {
         return;


### PR DESCRIPTION
Eksponerer overlapp-deteksjon frå UttakPeriodeBuilder slik at UttaksplanRedigeringProvider kan gjera ein éin-gongs sjekk av dei opphavlege periodane når redigeringssesjonen startar. Loggar til Sentry berre dersom det finst ulovleg overlappande datoar.