### PR TITLE
Logg ugyldig overlapp i periodar frå backend-vedtak

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
@@ -1,0 +1,126 @@
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { useEffect, useRef } from 'react';
+
+import { captureMessage, withScope } from '@navikt/fp-observability';
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+dayjs.extend(isSameOrBefore);
+
+export const useLoggOverlappIVedtak = (
+    perioderSøker: UttakPeriode_fpoversikt[] | undefined,
+    perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
+    justeringSøkerPerioder: UttakPeriode_fpoversikt[] | undefined,
+): void => {
+    const harLogget = useRef(false);
+    useEffect(() => {
+        if (harLogget.current || !perioderSøker) {
+            return;
+        }
+        harLogget.current = true;
+
+        const ugyldigeOverlappSøker = finnUgyldigeOverlapp(perioderSøker);
+        if (ugyldigeOverlappSøker.length > 0) {
+            withScope((scope) => {
+                scope.setLevel('warning');
+                scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
+                scope.setExtra('kilde', 'søker');
+                scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappSøker.length);
+                scope.setExtra(
+                    'ugyldigeOverlappPar',
+                    ugyldigeOverlappSøker.slice(0, 20).map(([a, b]) => ({
+                        a: periodeTilLoggObjekt(a),
+                        b: periodeTilLoggObjekt(b),
+                    })),
+                );
+                scope.setExtra('perioderFraBackend', perioderSøker.map(periodeTilLoggObjekt));
+                captureMessage('Eksisterande vedtak (søker) har ugyldig overlappande periodar', 'warning');
+            });
+        }
+
+        if (perioderAnnenPart && perioderAnnenPart.length > 0) {
+            const ugyldigeOverlappAnnenPart = finnUgyldigeOverlapp(perioderAnnenPart);
+            if (ugyldigeOverlappAnnenPart.length > 0) {
+                withScope((scope) => {
+                    scope.setLevel('warning');
+                    scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
+                    scope.setExtra('kilde', 'annenPart');
+                    scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappAnnenPart.length);
+                    scope.setExtra(
+                        'ugyldigeOverlappPar',
+                        ugyldigeOverlappAnnenPart.slice(0, 20).map(([a, b]) => ({
+                            a: periodeTilLoggObjekt(a),
+                            b: periodeTilLoggObjekt(b),
+                        })),
+                    );
+                    scope.setExtra('perioderFraBackend', perioderAnnenPart.map(periodeTilLoggObjekt));
+                    captureMessage('Eksisterande vedtak (annen part) har ugyldig overlappande periodar', 'warning');
+                });
+            }
+
+            if (justeringSøkerPerioder) {
+                const ugyldigeOverlappEtterJustering = finnUgyldigeOverlapp(justeringSøkerPerioder);
+                if (ugyldigeOverlappEtterJustering.length > ugyldigeOverlappSøker.length) {
+                    withScope((scope) => {
+                        scope.setLevel('warning');
+                        scope.setTag('feiltype', 'uttaksplan-midlertidig-justering-overlapp');
+                        scope.setExtra('antallFørJustering', ugyldigeOverlappSøker.length);
+                        scope.setExtra('antallEtterJustering', ugyldigeOverlappEtterJustering.length);
+                        scope.setExtra(
+                            'ugyldigeOverlappPar',
+                            ugyldigeOverlappEtterJustering.slice(0, 20).map(([a, b]) => ({
+                                a: periodeTilLoggObjekt(a),
+                                b: periodeTilLoggObjekt(b),
+                            })),
+                        );
+                        scope.setExtra('søkerPeriodeFørJustering', perioderSøker.map(periodeTilLoggObjekt));
+                        scope.setExtra('søkerPeriodeEtterJustering', justeringSøkerPerioder.map(periodeTilLoggObjekt));
+                        scope.setExtra('annenPartPerioder', perioderAnnenPart.map(periodeTilLoggObjekt));
+                        captureMessage('midlertidigJusteringAvSamtidigUttak introduserte nye overlapp', 'warning');
+                    });
+                }
+            }
+        }
+    }, [perioderSøker, perioderAnnenPart, justeringSøkerPerioder]);
+};
+
+const erOverlappande = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>
+    dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+const finnUgyldigeOverlapp = (
+    perioder: UttakPeriode_fpoversikt[],
+): Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> => {
+    const ugyldigeOverlapp: Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> = [];
+    for (let i = 0; i < perioder.length; i++) {
+        for (let j = i + 1; j < perioder.length; j++) {
+            const a = perioder[i]!;
+            const b = perioder[j]!;
+            if (
+                erOverlappande(a, b) &&
+                !(
+                    a.utsettelseÅrsak === undefined &&
+                    b.utsettelseÅrsak === undefined &&
+                    a.oppholdÅrsak === undefined &&
+                    b.oppholdÅrsak === undefined &&
+                    a.samtidigUttak !== undefined &&
+                    b.samtidigUttak !== undefined &&
+                    a.forelder !== b.forelder
+                )
+            ) {
+                ugyldigeOverlapp.push([a, b]);
+            }
+        }
+    }
+    return ugyldigeOverlapp;
+};
+
+const periodeTilLoggObjekt = (p: UttakPeriode_fpoversikt) => ({
+    fom: p.fom,
+    tom: p.tom,
+    forelder: p.forelder,
+    kontoType: p.kontoType,
+    utsettelseÅrsak: p.utsettelseÅrsak,
+    oppholdÅrsak: p.oppholdÅrsak,
+    overføringÅrsak: p.overføringÅrsak,
+    samtidigUttak: p.samtidigUttak,
+});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -4,8 +4,10 @@ import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import minMax from 'dayjs/plugin/minMax';
+import { useEffect, useRef } from 'react';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { captureMessage, withScope } from '@navikt/fp-observability';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
 import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
@@ -19,6 +21,41 @@ export const useUttaksplanForEksisterendeSak = (
     const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
 
     const sakerQuery = useQuery({ ...sakerOptions(), enabled: !!valgtEksisterendeSaksnr });
+
+    const harLoggetOverlapp = useRef(false);
+    useEffect(() => {
+        if (harLoggetOverlapp.current || !sakerQuery.data || !valgtEksisterendeSaksnr) {
+            return;
+        }
+        harLoggetOverlapp.current = true;
+
+        const valgtSak = sakerQuery.data.foreldrepenger.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
+        const perioderFraBackend = valgtSak?.gjeldendeVedtak?.perioder;
+
+        if (!perioderFraBackend) {
+            return;
+        }
+
+        const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderFraBackend);
+        if (ugyldigeOverlapp.length === 0) {
+            return;
+        }
+
+        withScope((scope) => {
+            scope.setLevel('warning');
+            scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
+            scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
+            scope.setExtra(
+                'ugyldigeOverlappPar',
+                ugyldigeOverlapp.slice(0, 20).map(([a, b]) => ({
+                    a: periodeTilLoggObjekt(a),
+                    b: periodeTilLoggObjekt(b),
+                })),
+            );
+            scope.setExtra('perioderFraBackend', perioderFraBackend.map(periodeTilLoggObjekt));
+            captureMessage('Eksisterande vedtak har ugyldig overlappande periodar', 'warning');
+        });
+    }, [sakerQuery.data, valgtEksisterendeSaksnr]);
 
     if (!sakerQuery?.data || !valgtEksisterendeSaksnr) {
         return undefined;
@@ -125,3 +162,41 @@ const midlertidigJusteringAvSamtidigUttak = (
 
 const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
     dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+const finnUgyldigeOverlapp = (
+    perioder: UttakPeriode_fpoversikt[],
+): Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> => {
+    const ugyldigeOverlapp: Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> = [];
+    for (let i = 0; i < perioder.length; i++) {
+        for (let j = i + 1; j < perioder.length; j++) {
+            const a = perioder[i]!;
+            const b = perioder[j]!;
+            if (
+                harOverlapp(a, b) &&
+                !(
+                    a.utsettelseÅrsak === undefined &&
+                    b.utsettelseÅrsak === undefined &&
+                    a.oppholdÅrsak === undefined &&
+                    b.oppholdÅrsak === undefined &&
+                    a.samtidigUttak !== undefined &&
+                    b.samtidigUttak !== undefined &&
+                    a.forelder !== b.forelder
+                )
+            ) {
+                ugyldigeOverlapp.push([a, b]);
+            }
+        }
+    }
+    return ugyldigeOverlapp;
+};
+
+const periodeTilLoggObjekt = (p: UttakPeriode_fpoversikt) => ({
+    fom: p.fom,
+    tom: p.tom,
+    forelder: p.forelder,
+    kontoType: p.kontoType,
+    utsettelseÅrsak: p.utsettelseÅrsak,
+    oppholdÅrsak: p.oppholdÅrsak,
+    overføringÅrsak: p.overføringÅrsak,
+    samtidigUttak: p.samtidigUttak,
+});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -4,13 +4,13 @@ import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import minMax from 'dayjs/plugin/minMax';
-import { useEffect, useRef } from 'react';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import { captureMessage, withScope } from '@navikt/fp-observability';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
 import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
+
+import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
 
 dayjs.extend(isSameOrBefore);
 dayjs.extend(minMax);
@@ -22,96 +22,20 @@ export const useUttaksplanForEksisterendeSak = (
 
     const sakerQuery = useQuery({ ...sakerOptions(), enabled: !!valgtEksisterendeSaksnr });
 
-    const harLoggetOverlapp = useRef(false);
-    useEffect(() => {
-        if (harLoggetOverlapp.current || !sakerQuery.data || !valgtEksisterendeSaksnr) {
-            return;
-        }
-        harLoggetOverlapp.current = true;
+    const valgtSak = sakerQuery.data?.foreldrepenger.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
+    const perioderFraBackend = valgtSak?.gjeldendeVedtak?.perioder;
+    const justeringSøkerPerioder =
+        perioderFraBackend && perioderAnnenPart
+            ? midlertidigJusteringAvSamtidigUttak(perioderFraBackend, perioderAnnenPart)
+            : undefined;
 
-        const valgtSak = sakerQuery.data.foreldrepenger.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
-        const perioderFraBackend = valgtSak?.gjeldendeVedtak?.perioder;
+    useLoggOverlappIVedtak(perioderFraBackend, perioderAnnenPart, justeringSøkerPerioder);
 
-        if (!perioderFraBackend) {
-            return;
-        }
-
-        const ugyldigeOverlappSøker = finnUgyldigeOverlapp(perioderFraBackend);
-        if (ugyldigeOverlappSøker.length > 0) {
-            withScope((scope) => {
-                scope.setLevel('warning');
-                scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
-                scope.setExtra('kilde', 'søker');
-                scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappSøker.length);
-                scope.setExtra(
-                    'ugyldigeOverlappPar',
-                    ugyldigeOverlappSøker.slice(0, 20).map(([a, b]) => ({
-                        a: periodeTilLoggObjekt(a),
-                        b: periodeTilLoggObjekt(b),
-                    })),
-                );
-                scope.setExtra('perioderFraBackend', perioderFraBackend.map(periodeTilLoggObjekt));
-                captureMessage('Eksisterande vedtak (søker) har ugyldig overlappande periodar', 'warning');
-            });
-        }
-
-        if (perioderAnnenPart && perioderAnnenPart.length > 0) {
-            const ugyldigeOverlappAnnenPart = finnUgyldigeOverlapp(perioderAnnenPart);
-            if (ugyldigeOverlappAnnenPart.length > 0) {
-                withScope((scope) => {
-                    scope.setLevel('warning');
-                    scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
-                    scope.setExtra('kilde', 'annenPart');
-                    scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappAnnenPart.length);
-                    scope.setExtra(
-                        'ugyldigeOverlappPar',
-                        ugyldigeOverlappAnnenPart.slice(0, 20).map(([a, b]) => ({
-                            a: periodeTilLoggObjekt(a),
-                            b: periodeTilLoggObjekt(b),
-                        })),
-                    );
-                    scope.setExtra('perioderFraBackend', perioderAnnenPart.map(periodeTilLoggObjekt));
-                    captureMessage('Eksisterande vedtak (annen part) har ugyldig overlappande periodar', 'warning');
-                });
-            }
-
-            const justert = midlertidigJusteringAvSamtidigUttak(perioderFraBackend, perioderAnnenPart);
-            const ugyldigeOverlappEtterJustering = finnUgyldigeOverlapp(justert);
-            if (ugyldigeOverlappEtterJustering.length > ugyldigeOverlappSøker.length) {
-                withScope((scope) => {
-                    scope.setLevel('warning');
-                    scope.setTag('feiltype', 'uttaksplan-midlertidig-justering-overlapp');
-                    scope.setExtra('antallFørJustering', ugyldigeOverlappSøker.length);
-                    scope.setExtra('antallEtterJustering', ugyldigeOverlappEtterJustering.length);
-                    scope.setExtra(
-                        'ugyldigeOverlappPar',
-                        ugyldigeOverlappEtterJustering.slice(0, 20).map(([a, b]) => ({
-                            a: periodeTilLoggObjekt(a),
-                            b: periodeTilLoggObjekt(b),
-                        })),
-                    );
-                    scope.setExtra('søkerPeriodeFørJustering', perioderFraBackend.map(periodeTilLoggObjekt));
-                    scope.setExtra('søkerPeriodeEtterJustering', justert.map(periodeTilLoggObjekt));
-                    scope.setExtra('annenPartPerioder', perioderAnnenPart.map(periodeTilLoggObjekt));
-                    captureMessage('midlertidigJusteringAvSamtidigUttak introduserte nye overlapp', 'warning');
-                });
-            }
-        }
-    }, [sakerQuery.data, valgtEksisterendeSaksnr, perioderAnnenPart]);
-
-    if (!sakerQuery?.data || !valgtEksisterendeSaksnr) {
+    if (!sakerQuery?.data || !valgtEksisterendeSaksnr || !valgtSak?.gjeldendeVedtak) {
         return undefined;
     }
 
-    const valgtSak = sakerQuery.data.foreldrepenger.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
-
-    if (!valgtSak?.gjeldendeVedtak) {
-        return undefined;
-    }
-
-    const søkerPerioder = perioderAnnenPart
-        ? midlertidigJusteringAvSamtidigUttak(valgtSak.gjeldendeVedtak.perioder, perioderAnnenPart)
-        : valgtSak.gjeldendeVedtak.perioder;
+    const søkerPerioder = justeringSøkerPerioder ?? valgtSak.gjeldendeVedtak.perioder;
 
     const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> =
         fjernFrieUtsettelser(søkerPerioder);
@@ -204,41 +128,3 @@ const midlertidigJusteringAvSamtidigUttak = (
 
 const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
     dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
-
-const finnUgyldigeOverlapp = (
-    perioder: UttakPeriode_fpoversikt[],
-): Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> => {
-    const ugyldigeOverlapp: Array<[UttakPeriode_fpoversikt, UttakPeriode_fpoversikt]> = [];
-    for (let i = 0; i < perioder.length; i++) {
-        for (let j = i + 1; j < perioder.length; j++) {
-            const a = perioder[i]!;
-            const b = perioder[j]!;
-            if (
-                harOverlapp(a, b) &&
-                !(
-                    a.utsettelseÅrsak === undefined &&
-                    b.utsettelseÅrsak === undefined &&
-                    a.oppholdÅrsak === undefined &&
-                    b.oppholdÅrsak === undefined &&
-                    a.samtidigUttak !== undefined &&
-                    b.samtidigUttak !== undefined &&
-                    a.forelder !== b.forelder
-                )
-            ) {
-                ugyldigeOverlapp.push([a, b]);
-            }
-        }
-    }
-    return ugyldigeOverlapp;
-};
-
-const periodeTilLoggObjekt = (p: UttakPeriode_fpoversikt) => ({
-    fom: p.fom,
-    tom: p.tom,
-    forelder: p.forelder,
-    kontoType: p.kontoType,
-    utsettelseÅrsak: p.utsettelseÅrsak,
-    oppholdÅrsak: p.oppholdÅrsak,
-    overføringÅrsak: p.overføringÅrsak,
-    samtidigUttak: p.samtidigUttak,
-});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -36,26 +36,68 @@ export const useUttaksplanForEksisterendeSak = (
             return;
         }
 
-        const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderFraBackend);
-        if (ugyldigeOverlapp.length === 0) {
-            return;
+        const ugyldigeOverlappSøker = finnUgyldigeOverlapp(perioderFraBackend);
+        if (ugyldigeOverlappSøker.length > 0) {
+            withScope((scope) => {
+                scope.setLevel('warning');
+                scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
+                scope.setExtra('kilde', 'søker');
+                scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappSøker.length);
+                scope.setExtra(
+                    'ugyldigeOverlappPar',
+                    ugyldigeOverlappSøker.slice(0, 20).map(([a, b]) => ({
+                        a: periodeTilLoggObjekt(a),
+                        b: periodeTilLoggObjekt(b),
+                    })),
+                );
+                scope.setExtra('perioderFraBackend', perioderFraBackend.map(periodeTilLoggObjekt));
+                captureMessage('Eksisterande vedtak (søker) har ugyldig overlappande periodar', 'warning');
+            });
         }
 
-        withScope((scope) => {
-            scope.setLevel('warning');
-            scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
-            scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
-            scope.setExtra(
-                'ugyldigeOverlappPar',
-                ugyldigeOverlapp.slice(0, 20).map(([a, b]) => ({
-                    a: periodeTilLoggObjekt(a),
-                    b: periodeTilLoggObjekt(b),
-                })),
-            );
-            scope.setExtra('perioderFraBackend', perioderFraBackend.map(periodeTilLoggObjekt));
-            captureMessage('Eksisterande vedtak har ugyldig overlappande periodar', 'warning');
-        });
-    }, [sakerQuery.data, valgtEksisterendeSaksnr]);
+        if (perioderAnnenPart && perioderAnnenPart.length > 0) {
+            const ugyldigeOverlappAnnenPart = finnUgyldigeOverlapp(perioderAnnenPart);
+            if (ugyldigeOverlappAnnenPart.length > 0) {
+                withScope((scope) => {
+                    scope.setLevel('warning');
+                    scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
+                    scope.setExtra('kilde', 'annenPart');
+                    scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlappAnnenPart.length);
+                    scope.setExtra(
+                        'ugyldigeOverlappPar',
+                        ugyldigeOverlappAnnenPart.slice(0, 20).map(([a, b]) => ({
+                            a: periodeTilLoggObjekt(a),
+                            b: periodeTilLoggObjekt(b),
+                        })),
+                    );
+                    scope.setExtra('perioderFraBackend', perioderAnnenPart.map(periodeTilLoggObjekt));
+                    captureMessage('Eksisterande vedtak (annen part) har ugyldig overlappande periodar', 'warning');
+                });
+            }
+
+            const justert = midlertidigJusteringAvSamtidigUttak(perioderFraBackend, perioderAnnenPart);
+            const ugyldigeOverlappEtterJustering = finnUgyldigeOverlapp(justert);
+            if (ugyldigeOverlappEtterJustering.length > ugyldigeOverlappSøker.length) {
+                withScope((scope) => {
+                    scope.setLevel('warning');
+                    scope.setTag('feiltype', 'uttaksplan-midlertidig-justering-overlapp');
+                    scope.setExtra('antallFørJustering', ugyldigeOverlappSøker.length);
+                    scope.setExtra('antallEtterJustering', ugyldigeOverlappEtterJustering.length);
+                    scope.setExtra(
+                        'ugyldigeOverlappPar',
+                        ugyldigeOverlappEtterJustering.slice(0, 20).map(([a, b]) => ({
+                            a: periodeTilLoggObjekt(a),
+                            b: periodeTilLoggObjekt(b),
+                        })),
+                    );
+                    scope.setExtra('søkerPeriodeFørJustering', perioderFraBackend.map(periodeTilLoggObjekt));
+                    scope.setExtra('søkerPeriodeEtterJustering', justert.map(periodeTilLoggObjekt));
+                    scope.setExtra('annenPartPerioder', perioderAnnenPart.map(periodeTilLoggObjekt));
+                    captureMessage('midlertidigJusteringAvSamtidigUttak introduserte nye overlapp', 'warning');
+                });
+            }
+        }
+    }, [sakerQuery.data, valgtEksisterendeSaksnr, perioderAnnenPart]);
 
     if (!sakerQuery?.data || !valgtEksisterendeSaksnr) {
         return undefined;

--- a/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
+++ b/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
@@ -32,7 +32,7 @@ export const UttaksplanRedigeringProvider = (props: Props) => {
     const { oppdaterUttaksplan: oppdater, harEndretPlan, children } = props;
     const [visFjernAltModal, setVisFjernAltModal] = useState(false);
 
-    const { uttakPerioder } = useUttaksplanData();
+    const { uttakPerioder, erEndringssøknad } = useUttaksplanData();
 
     const harLoggetInitielleOverlapp = useRef(false);
     useEffect(() => {
@@ -49,6 +49,7 @@ export const UttaksplanRedigeringProvider = (props: Props) => {
         withScope((scope) => {
             scope.setLevel('warning');
             scope.setTag('feiltype', 'uttaksplan-initielle-overlapp');
+            scope.setExtra('erEndringssøknad', erEndringssøknad);
             scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
             scope.setExtra(
                 'ugyldigeOverlappPar',


### PR DESCRIPTION
Legg til Sentry-logging i useUttaksplanForEksisterendeSak for å oppdaga overlappande periodar i gjeldendeVedtak.perioder slik dei kjem frå backend, før frontend-manipulering (fjernFrieUtsettelser, midlertidigJusteringAvSamtidigUttak).