### PR TITLE
Rydd opp overlappande periodar i eksisterande sak

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
@@ -3,33 +3,27 @@ import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { useEffect, useRef } from 'react';
 
 import { captureMessage, withScope } from '@navikt/fp-observability';
-import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 
 dayjs.extend(isSameOrBefore);
 
 export const useLoggOverlappIVedtak = (
-    perioderSøker: UttakPeriode_fpoversikt[] | undefined,
-    perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
-    justeringSøkerPerioder: UttakPeriode_fpoversikt[] | undefined,
+    uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined,
 ): void => {
-    // Kvar sjekk har eigen ref sidan søker og annen part kjem frå separate queries
-    // og kan bli tilgjengelege på ulike tidspunkt
-    const harLoggetSøker = useRef(false);
-    const harLoggetAnnenPart = useRef(false);
-    const harLoggetKrysspart = useRef(false);
+    const harLoggetUttaksplan = useRef(false);
 
     useEffect(() => {
-        if (harLoggetSøker.current || !perioderSøker) {
+        if (harLoggetUttaksplan.current || !uttaksplan || uttaksplan.length === 0) {
             return;
         }
-        harLoggetSøker.current = true;
+        harLoggetUttaksplan.current = true;
 
-        const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderSøker);
+        const perioderUttaksplan = uttaksplan.filter((p): p is UttakPeriode_fpoversikt => 'forelder' in p);
+        const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderUttaksplan);
         if (ugyldigeOverlapp.length > 0) {
             withScope((scope) => {
                 scope.setLevel('warning');
-                scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
-                scope.setExtra('kilde', 'søker');
+                scope.setTag('feiltype', 'uttaksplan-overlapp-etter-transformasjon');
                 scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
                 scope.setExtra(
                     'ugyldigeOverlappPar',
@@ -38,90 +32,11 @@ export const useLoggOverlappIVedtak = (
                         b: periodeTilLoggObjekt(b),
                     })),
                 );
-                scope.setExtra('perioderFraBackend', perioderSøker.map(periodeTilLoggObjekt));
-                captureMessage('Eksisterande vedtak (søker) har ugyldig overlappande periodar', 'warning');
+                scope.setExtra('uttaksplan', perioderUttaksplan.map(periodeTilLoggObjekt));
+                captureMessage('Uttaksplan har ugyldig overlappande periodar etter transformasjon', 'warning');
             });
         }
-    }, [perioderSøker]);
-
-    useEffect(() => {
-        if (harLoggetAnnenPart.current || !perioderAnnenPart || perioderAnnenPart.length === 0) {
-            return;
-        }
-        harLoggetAnnenPart.current = true;
-
-        const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderAnnenPart);
-        if (ugyldigeOverlapp.length > 0) {
-            withScope((scope) => {
-                scope.setLevel('warning');
-                scope.setTag('feiltype', 'uttaksplan-backend-overlapp');
-                scope.setExtra('kilde', 'annenPart');
-                scope.setExtra('antallUgyldigeOverlapp', ugyldigeOverlapp.length);
-                scope.setExtra(
-                    'ugyldigeOverlappPar',
-                    ugyldigeOverlapp.slice(0, 20).map(([a, b]) => ({
-                        a: periodeTilLoggObjekt(a),
-                        b: periodeTilLoggObjekt(b),
-                    })),
-                );
-                scope.setExtra('perioderFraBackend', perioderAnnenPart.map(periodeTilLoggObjekt));
-                captureMessage('Eksisterande vedtak (annen part) har ugyldig overlappande periodar', 'warning');
-            });
-        }
-    }, [perioderAnnenPart]);
-
-    useEffect(() => {
-        if (harLoggetKrysspart.current || !perioderSøker || !perioderAnnenPart) {
-            return;
-        }
-        harLoggetKrysspart.current = true;
-
-        // Sjekk overlapp på tvers av søker og annen part med rådata direkte fra backend (ingen transformasjonar)
-        const ugyldigeKrysspartOverlapp = finnUgyldigeOverlapp([...perioderSøker, ...perioderAnnenPart]).filter(
-            ([a, b]) => a.forelder !== b.forelder,
-        );
-        if (ugyldigeKrysspartOverlapp.length > 0) {
-            withScope((scope) => {
-                scope.setLevel('warning');
-                scope.setTag('feiltype', 'uttaksplan-krysspart-overlapp');
-                scope.setExtra('antallUgyldigeOverlapp', ugyldigeKrysspartOverlapp.length);
-                scope.setExtra(
-                    'ugyldigeOverlappPar',
-                    ugyldigeKrysspartOverlapp.slice(0, 20).map(([a, b]) => ({
-                        a: periodeTilLoggObjekt(a),
-                        b: periodeTilLoggObjekt(b),
-                    })),
-                );
-                scope.setExtra('perioderSøker', perioderSøker.map(periodeTilLoggObjekt));
-                scope.setExtra('perioderAnnenPart', perioderAnnenPart.map(periodeTilLoggObjekt));
-                captureMessage('Eksisterande vedtak har ugyldig overlappande periodar på tvers av foreldre', 'warning');
-            });
-        }
-
-        if (justeringSøkerPerioder) {
-            const ugyldigeOverlappSøker = finnUgyldigeOverlapp(perioderSøker);
-            const ugyldigeOverlappEtterJustering = finnUgyldigeOverlapp(justeringSøkerPerioder);
-            if (ugyldigeOverlappEtterJustering.length > ugyldigeOverlappSøker.length) {
-                withScope((scope) => {
-                    scope.setLevel('warning');
-                    scope.setTag('feiltype', 'uttaksplan-midlertidig-justering-overlapp');
-                    scope.setExtra('antallFørJustering', ugyldigeOverlappSøker.length);
-                    scope.setExtra('antallEtterJustering', ugyldigeOverlappEtterJustering.length);
-                    scope.setExtra(
-                        'ugyldigeOverlappPar',
-                        ugyldigeOverlappEtterJustering.slice(0, 20).map(([a, b]) => ({
-                            a: periodeTilLoggObjekt(a),
-                            b: periodeTilLoggObjekt(b),
-                        })),
-                    );
-                    scope.setExtra('søkerPeriodeFørJustering', perioderSøker.map(periodeTilLoggObjekt));
-                    scope.setExtra('søkerPeriodeEtterJustering', justeringSøkerPerioder.map(periodeTilLoggObjekt));
-                    scope.setExtra('annenPartPerioder', perioderAnnenPart.map(periodeTilLoggObjekt));
-                    captureMessage('midlertidigJusteringAvSamtidigUttak introduserte nye overlapp', 'warning');
-                });
-            }
-        }
-    }, [perioderSøker, perioderAnnenPart, justeringSøkerPerioder]);
+    }, [uttaksplan]);
 };
 
 const erOverlappande = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
@@ -10,13 +10,18 @@ dayjs.extend(isSameOrBefore);
 export const useLoggOverlappIVedtak = (
     uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined,
 ): void => {
-    const harLoggetUttaksplan = useRef(false);
+    const lastCheckedFingerprint = useRef<string | null>(null);
 
     useEffect(() => {
-        if (harLoggetUttaksplan.current || !uttaksplan || uttaksplan.length === 0) {
+        if (!uttaksplan || uttaksplan.length === 0) {
             return;
         }
-        harLoggetUttaksplan.current = true;
+
+        const fingerprint = uttaksplan.map((p) => `${p.fom}:${p.tom}`).join(',');
+        if (lastCheckedFingerprint.current === fingerprint) {
+            return;
+        }
+        lastCheckedFingerprint.current = fingerprint;
 
         const perioderUttaksplan = uttaksplan.filter((p): p is UttakPeriode_fpoversikt => 'forelder' in p);
         const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderUttaksplan);

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -132,14 +132,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 samtidigUttak: 100,
             },
             {
-                fom: '2025-12-11',
-                tom: '2026-01-13',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'FEDREKVOTE',
-                flerbarnsdager: false,
-                samtidigUttak: 100,
-            },
-            {
                 fom: '2026-01-14',
                 tom: '2026-01-30',
                 forelder: 'MOR',
@@ -148,7 +140,7 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 samtidigUttak: 100,
             },
             {
-                fom: '2026-01-14',
+                fom: '2025-12-11',
                 tom: '2026-01-30',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
@@ -271,7 +263,7 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
             {
                 fom: '2025-02-17',
-                tom: '2025-02-17',
+                tom: '2025-02-28',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
                 flerbarnsdager: false,
@@ -282,14 +274,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 tom: '2025-02-17',
                 forelder: 'MOR',
                 kontoType: 'FORELDREPENGER_FØR_FØDSEL',
-                flerbarnsdager: false,
-                samtidigUttak: 100,
-            },
-            {
-                fom: '2025-02-18',
-                tom: '2025-02-28',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'FEDREKVOTE',
                 flerbarnsdager: false,
                 samtidigUttak: 100,
             },
@@ -420,13 +404,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
             {
                 fom: '2026-02-10',
-                tom: '2026-02-17',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'FEDREKVOTE',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-02-18',
                 tom: '2026-06-22',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
@@ -534,22 +511,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
         const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
             {
                 fom: '2026-02-27',
-                tom: '2026-03-27',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'MØDREKVOTE',
-                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-03-30',
-                tom: '2026-04-01',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'MØDREKVOTE',
-                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-04-02',
                 tom: '2026-04-24',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'MØDREKVOTE',
@@ -626,22 +587,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
             { fom: '2026-02-19', tom: '2026-02-26', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
             {
                 fom: '2026-02-27',
-                tom: '2026-03-27',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'MØDREKVOTE',
-                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-03-30',
-                tom: '2026-04-01',
-                forelder: 'FAR_MEDMOR',
-                kontoType: 'MØDREKVOTE',
-                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-04-02',
                 tom: '2026-04-24',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'MØDREKVOTE',

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -602,4 +602,286 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
         ]);
     });
+    it('testcase 5 - regel 1: søkar sin ARBEID-utsettelse vert trimma der den overlappar annenPart, resten vert beholdt', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-03-15',
+                tom: '2026-04-15',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-03-01',
+                tom: '2026-03-31',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                utsettelseÅrsak: 'ARBEID',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2026-01-01' },
+                    forelder: 'FAR_MEDMOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: false,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        // Søkar sin ARBEID-utsettelse [03-01 til 03-14] overlappar ikkje annenPart og skal overleve.
+        // Den overlappande delen [03-15 til 03-31] vert kasta av regel 1.
+        // ARBEID er ikkje FRI, så fjernFrieUtsettelser fjernar den ikkje.
+        expect(result.current).toEqual([
+            {
+                fom: '2026-03-01',
+                tom: '2026-03-13',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                utsettelseÅrsak: 'ARBEID',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-15',
+                tom: '2026-04-15',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('testcase 6 - regel 2: kun annenPart har samtidigattak, søkar vert markert for den overlappande delen', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-15',
+                tom: '2026-06-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2026-01-01' },
+                    forelder: 'MOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: true,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        // Søkar [05-01 til 05-14] overlappar ikkje annenPart, inga endring.
+        // Søkar [05-15 til 05-31] overlappar annenPart med samtidigattak → markert med samtidigattak: 100.
+        // AnnenPart [05-15 til 06-20] vert slått saman frå to split-segment sidan dei er tilstøytande og like.
+        expect(result.current).toEqual([
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-14',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-05-15',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2026-05-15',
+                tom: '2026-06-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ]);
+    });
+
+    it('testcase 7 - regel 1 har prioritet over regel 2: utsettelse+samtidigattak markerer ikkje søkar med samtidigattak', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-07-01',
+                tom: '2026-07-31',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                utsettelseÅrsak: 'LOVBESTEMT_FERIE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-07-10',
+                tom: '2026-07-20',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2026-01-01' },
+                    forelder: 'MOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: true,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        // Annen part sin utsettelse [07-10 til 07-20] overlappar søkar → vert kasta av regel 1.
+        // Utan regel 1 ville søkar vorte markert med samtidigattak av regel 2.
+        // Søkar [07-10 til 07-20] skal IKKJE ha samtidigattak.
+        // Annen part sin ikke-overlappande del [07-01 til 07-09] og [07-21 til 07-31] overlever.
+        expect(result.current).toEqual([
+            {
+                fom: '2026-07-01',
+                tom: '2026-07-09',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                utsettelseÅrsak: 'LOVBESTEMT_FERIE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2026-07-10',
+                tom: '2026-07-20',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-07-21',
+                tom: '2026-07-31',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                utsettelseÅrsak: 'LOVBESTEMT_FERIE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ]);
+    });
+
+    it('testcase 8 - regel 4: annenPart heilt omslutta av søkar sin periode, heile annenPart-perioden fjernast', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-09-10',
+                tom: '2026-09-20',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-09-01',
+                tom: '2026-09-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2026-01-01' },
+                    forelder: 'FAR_MEDMOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: false,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        // AnnenPart [09-10 til 09-20] er heilt omslutta av søkar [09-01 til 09-30].
+        // Regel 4 fjernar heile annenPart-perioden.
+        // Søkar sine tre split-segment vert slått saman att til éin periode.
+        expect(result.current).toEqual([
+            {
+                fom: '2026-09-01',
+                tom: '2026-09-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
 });

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -1,0 +1,612 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { sakerOptions } from 'api/queries';
+import { ContextDataType, FpDataContext } from 'appData/FpDataContext';
+import { ReactNode } from 'react';
+
+import { Saker_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { useUttaksplanForEksisterendeSak } from './useUttaksplanForEksisterendeSak';
+
+vi.mock('./useLoggOverlappIVedtak', () => ({
+    useLoggOverlappIVedtak: vi.fn(),
+}));
+
+const SAKSNUMMER = '123456789';
+
+const getWrapper = (saker: Saker_fpoversikt) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(sakerOptions().queryKey, saker);
+
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            <FpDataContext initialState={{ [ContextDataType.VALGT_EKSISTERENDE_SAKSNR]: SAKSNUMMER }}>
+                {children}
+            </FpDataContext>
+        </QueryClientProvider>
+    );
+};
+
+describe('useUttaksplanForEksisterendeSak', () => {
+    it('testcase 0 - mor har samtidigattak, søkar (far) sine periodar skal justerast', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-10-01',
+                tom: '2025-10-14',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-12-11',
+                tom: '2026-01-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-09-22',
+                tom: '2025-09-30',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-10-01', tom: '2025-12-10', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            { fom: '2025-12-11', tom: '2026-01-13', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2026-01-14',
+                tom: '2026-01-30',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-02',
+                tom: '2026-05-05',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2025-10-01' },
+                    forelder: 'MOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: true,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        expect(result.current).toEqual([
+            {
+                fom: '2025-09-22',
+                tom: '2025-09-30',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-10-01',
+                tom: '2025-10-14',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-10-01',
+                tom: '2025-10-14',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            { fom: '2025-10-15', tom: '2025-12-10', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-12-11',
+                tom: '2026-01-13',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2026-01-14',
+                tom: '2026-01-30',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-12-11',
+                tom: '2026-01-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2026-02-02',
+                tom: '2026-05-05',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('testcase 1 - far har samtidigattak, annenpart (mor) sine periodar skal justerast', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-01-23',
+                tom: '2025-01-27',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-01-28',
+                tom: '2025-02-17',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-02-18', tom: '2025-06-02', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-06-03',
+                tom: '2025-08-01',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-02-17',
+                tom: '2025-02-28',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-08-04',
+                tom: '2025-09-17',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-09-18',
+                tom: '2025-10-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-30',
+                tom: '2026-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-04-07',
+                tom: '2026-04-07',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2025-02-18' },
+                    forelder: 'FAR_MEDMOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: false,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        expect(result.current).toEqual([
+            {
+                fom: '2025-01-23',
+                tom: '2025-01-27',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-01-28',
+                tom: '2025-02-14',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-02-17',
+                tom: '2025-02-28',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-02-17',
+                tom: '2025-02-17',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-02-18',
+                tom: '2025-02-28',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            { fom: '2025-03-03', tom: '2025-06-02', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-06-03',
+                tom: '2025-08-01',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-08-04',
+                tom: '2025-09-17',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2025-09-18',
+                tom: '2025-10-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-30',
+                tom: '2026-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-04-07',
+                tom: '2026-04-07',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('testcase 2 - annenpart har overlappande periode utan samtidigattak som skal kastast', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-03-24',
+                tom: '2025-04-03',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-04-04', tom: '2025-05-29', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            { fom: '2025-07-07', tom: '2025-09-19', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-09-22',
+                tom: '2026-02-09',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-10',
+                tom: '2026-02-17',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-02-10',
+                tom: '2026-06-22',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2025-04-04' },
+                    forelder: 'FAR_MEDMOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: false,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        expect(result.current).toEqual([
+            {
+                fom: '2025-03-24',
+                tom: '2025-04-03',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-04-04', tom: '2025-05-29', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            { fom: '2025-07-07', tom: '2025-09-19', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-09-22',
+                tom: '2026-02-09',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-10',
+                tom: '2026-06-22',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('testcase 3 - same som testcase 2, men søker er mor', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-02-10',
+                tom: '2026-06-22',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-03-24',
+                tom: '2025-04-03',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-04-04', tom: '2025-05-29', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            { fom: '2025-07-07', tom: '2025-09-19', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-09-22',
+                tom: '2026-02-09',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-10',
+                tom: '2026-02-17',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2025-04-04' },
+                    forelder: 'MOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: true,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        expect(result.current).toEqual([
+            {
+                fom: '2025-03-24',
+                tom: '2025-04-03',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2025-04-04', tom: '2025-05-29', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            { fom: '2025-07-07', tom: '2025-09-19', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2025-09-22',
+                tom: '2026-02-09',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-10',
+                tom: '2026-02-17',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-18',
+                tom: '2026-06-22',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('testcase 4 - søker sin periode med utsettelseÅrsak skal ikkje kaste annenpart sin periode', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-02-27',
+                tom: '2026-04-24',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-11-20',
+                tom: '2027-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-02-09',
+                tom: '2026-02-18',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2026-02-19', tom: '2026-02-26', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2026-03-30',
+                tom: '2026-04-01',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                utsettelseÅrsak: 'FRI',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-07-02',
+                tom: '2026-11-19',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2026-02-27' },
+                    forelder: 'MOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: true,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        expect(result.current).toEqual([
+            {
+                fom: '2026-02-09',
+                tom: '2026-02-18',
+                forelder: 'MOR',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+            },
+            { fom: '2026-02-19', tom: '2026-02-26', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
+            {
+                fom: '2026-02-27',
+                tom: '2026-04-24',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-07-02',
+                tom: '2026-11-19',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-11-20',
+                tom: '2027-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -132,6 +132,14 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 samtidigUttak: 100,
             },
             {
+                fom: '2025-12-11',
+                tom: '2026-01-13',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
                 fom: '2026-01-14',
                 tom: '2026-01-30',
                 forelder: 'MOR',
@@ -140,7 +148,7 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 samtidigUttak: 100,
             },
             {
-                fom: '2025-12-11',
+                fom: '2026-01-14',
                 tom: '2026-01-30',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
@@ -263,7 +271,7 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
             {
                 fom: '2025-02-17',
-                tom: '2025-02-28',
+                tom: '2025-02-17',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
                 flerbarnsdager: false,
@@ -274,6 +282,14 @@ describe('useUttaksplanForEksisterendeSak', () => {
                 tom: '2025-02-17',
                 forelder: 'MOR',
                 kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2025-02-18',
+                tom: '2025-02-28',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
                 flerbarnsdager: false,
                 samtidigUttak: 100,
             },
@@ -404,6 +420,13 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
             {
                 fom: '2026-02-10',
+                tom: '2026-02-17',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-02-18',
                 tom: '2026-06-22',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FEDREKVOTE',
@@ -511,6 +534,22 @@ describe('useUttaksplanForEksisterendeSak', () => {
         const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
             {
                 fom: '2026-02-27',
+                tom: '2026-03-27',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-30',
+                tom: '2026-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-04-02',
                 tom: '2026-04-24',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'MØDREKVOTE',
@@ -587,6 +626,22 @@ describe('useUttaksplanForEksisterendeSak', () => {
             { fom: '2026-02-19', tom: '2026-02-26', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
             {
                 fom: '2026-02-27',
+                tom: '2026-03-27',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-30',
+                tom: '2026-04-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-04-02',
                 tom: '2026-04-24',
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'MØDREKVOTE',

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -485,13 +485,6 @@ describe('useUttaksplanForEksisterendeSak', () => {
             { fom: '2025-07-07', tom: '2025-09-19', forelder: 'MOR', kontoType: 'MØDREKVOTE', flerbarnsdager: false },
             {
                 fom: '2025-09-22',
-                tom: '2026-02-09',
-                forelder: 'MOR',
-                kontoType: 'FELLESPERIODE',
-                flerbarnsdager: false,
-            },
-            {
-                fom: '2026-02-10',
                 tom: '2026-02-17',
                 forelder: 'MOR',
                 kontoType: 'FELLESPERIODE',

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -23,32 +23,45 @@ export const useUttaksplanForEksisterendeSak = (
     const sakerQuery = useQuery({ ...sakerOptions(), enabled: !!valgtEksisterendeSaksnr });
 
     const valgtSak = sakerQuery.data?.foreldrepenger.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
-    const perioderFraBackend = valgtSak?.gjeldendeVedtak?.perioder;
-    const justeringSøkerPerioder =
+    const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
+    const perioderFraBackend = gjeldendeVedtak?.perioder;
+
+    const trimmedSøker =
         perioderFraBackend && perioderAnnenPart
-            ? midlertidigJusteringAvSamtidigUttak(perioderFraBackend, perioderAnnenPart)
+            ? fjernUtsettelseOverlapp(perioderFraBackend, perioderAnnenPart)
+            : perioderFraBackend;
+    const trimmedAnnenPart =
+        perioderFraBackend && perioderAnnenPart
+            ? fjernUtsettelseOverlapp(perioderAnnenPart, perioderFraBackend)
+            : perioderAnnenPart;
+
+    const justeringSøkerPerioder =
+        trimmedSøker && trimmedAnnenPart
+            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
             : undefined;
 
-    useLoggOverlappIVedtak(perioderFraBackend, perioderAnnenPart, justeringSøkerPerioder);
+    const søkerRef = trimmedSøker ?? perioderFraBackend ?? [];
+    const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined = gjeldendeVedtak
+        ? [
+              ...fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak.perioder),
+              ...(gjeldendeVedtak.perioderAnnenpartEøs ?? []),
+              ...(trimmedAnnenPart
+                  ? fjernOverlappUtenSamtidigUttak(
+                        midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef),
+                        søkerRef,
+                    )
+                  : []),
+          ].sort(sorterUttakPerioder)
+        : undefined;
 
-    if (!sakerQuery?.data || !valgtEksisterendeSaksnr || !valgtSak?.gjeldendeVedtak) {
+    useLoggOverlappIVedtak(uttaksplan);
+
+    if (!sakerQuery?.data || !valgtEksisterendeSaksnr || !gjeldendeVedtak) {
         return undefined;
     }
 
-    const søkerPerioder = justeringSøkerPerioder ?? valgtSak.gjeldendeVedtak.perioder;
-
-    const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> =
-        fjernFrieUtsettelser(søkerPerioder);
-
-    if (valgtSak.gjeldendeVedtak?.perioderAnnenpartEøs) {
-        uttaksplan.push(...valgtSak.gjeldendeVedtak.perioderAnnenpartEøs);
-    }
-
-    if (perioderAnnenPart) {
-        uttaksplan.push(...midlertidigJusteringAvSamtidigUttak(perioderAnnenPart, valgtSak.gjeldendeVedtak.perioder));
-    }
-
-    return uttaksplan.sort(sorterUttakPerioder);
+    // uttaksplan er alltid definert når gjeldendeVedtak er definert
+    return uttaksplan!;
 };
 
 const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
@@ -128,3 +141,90 @@ const midlertidigJusteringAvSamtidigUttak = (
 
 const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
     dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
+// Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
+// Den overlappande delen vert kasta. Denne algoritmen har prioritet over dei to andre og skal køyrast først.
+const fjernUtsettelseOverlapp = (
+    perioder: UttakPeriode_fpoversikt[],
+    motpartPerioder: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    return perioder.flatMap((periode) => {
+        if (periode.utsettelseÅrsak === undefined) {
+            return [periode];
+        }
+
+        const overlappende = motpartPerioder.find((motpart) => harOverlapp(periode, motpart));
+        if (!overlappende) {
+            return [periode];
+        }
+
+        const periodeFom = dayjs(periode.fom);
+        const periodeTom = dayjs(periode.tom);
+        const motpartFom = dayjs(overlappende.fom);
+        const motpartTom = dayjs(overlappende.tom);
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+
+        if (periodeFom.isBefore(motpartFom, 'day')) {
+            resultat.push({
+                ...periode,
+                tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        if (periodeTom.isAfter(motpartTom, 'day')) {
+            resultat.push({
+                ...periode,
+                fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        return resultat;
+    });
+};
+
+// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
+// Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
+// er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
+const fjernOverlappUtenSamtidigUttak = (
+    perioderAnnenPart: UttakPeriode_fpoversikt[],
+    perioderSøker: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    return perioderAnnenPart.flatMap((periodeAnnenPart) => {
+        if (periodeAnnenPart.samtidigUttak !== undefined) {
+            return [periodeAnnenPart];
+        }
+
+        const overlappendeSøkerPeriode = perioderSøker.find(
+            (søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker),
+        );
+
+        if (!overlappendeSøkerPeriode) {
+            return [periodeAnnenPart];
+        }
+
+        const annenFom = dayjs(periodeAnnenPart.fom);
+        const annenTom = dayjs(periodeAnnenPart.tom);
+        const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
+        const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+
+        if (annenFom.isBefore(søkerFom, 'day')) {
+            resultat.push({
+                ...periodeAnnenPart,
+                tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        if (annenTom.isAfter(søkerTom, 'day')) {
+            resultat.push({
+                ...periodeAnnenPart,
+                fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        return resultat;
+    });
+};

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -3,7 +3,9 @@ import { sakerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import minMax from 'dayjs/plugin/minMax';
 
+import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
 import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
@@ -11,6 +13,7 @@ import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
 import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
 
 dayjs.extend(isSameOrBefore);
+dayjs.extend(minMax);
 
 export const useUttaksplanForEksisterendeSak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
@@ -23,26 +26,21 @@ export const useUttaksplanForEksisterendeSak = (
     const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
     const perioderFraBackend = gjeldendeVedtak?.perioder;
 
-    // Pre-split both parties' periods at each other's boundaries so each segment
-    // either fully overlaps or does not overlap at all when comparing the two parties
-    const splitSøker =
+    const trimmedSøker =
         perioderFraBackend && perioderAnnenPart
-            ? splitPerioder(perioderFraBackend, perioderAnnenPart)
+            ? fjernUtsettelseOverlapp(perioderFraBackend, perioderAnnenPart)
             : perioderFraBackend;
-    const splitAnnenPart =
+    const trimmedAnnenPart =
         perioderFraBackend && perioderAnnenPart
-            ? splitPerioder(perioderAnnenPart, perioderFraBackend)
+            ? fjernUtsettelseOverlapp(perioderAnnenPart, perioderFraBackend)
             : perioderAnnenPart;
 
-    const trimmedAnnenPart =
-        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitAnnenPart, splitSøker) : splitAnnenPart;
-
-    const søkerRef = splitSøker ?? [];
     const justeringSøkerPerioder =
-        perioderFraBackend && trimmedAnnenPart
-            ? midlertidigJusteringAvSamtidigUttak(søkerRef, trimmedAnnenPart)
+        trimmedSøker && trimmedAnnenPart
+            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
             : undefined;
 
+    const søkerRef = trimmedSøker ?? perioderFraBackend ?? [];
     const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined = gjeldendeVedtak
         ? [
               ...fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak.perioder),
@@ -66,34 +64,6 @@ export const useUttaksplanForEksisterendeSak = (
     return uttaksplan!;
 };
 
-// Split periods at the boundaries of another party's periods so each resulting segment
-// can only fully overlap or not overlap at all with the other party's periods
-const splitPerioder = (
-    perioderToSplit: UttakPeriode_fpoversikt[],
-    splittBasertPå: UttakPeriode_fpoversikt[],
-): UttakPeriode_fpoversikt[] => {
-    const splitDatoer = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort();
-
-    return perioderToSplit.flatMap((periode) => {
-        const relevanteDelDatoer = splitDatoer.filter(
-            (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
-        );
-
-        if (relevanteDelDatoer.length === 0) return [periode];
-
-        const resultat: UttakPeriode_fpoversikt[] = [];
-        let gjeldendeFom = periode.fom;
-
-        for (const dato of relevanteDelDatoer) {
-            resultat.push({ ...periode, fom: gjeldendeFom, tom: Uttaksdagen.forrige(dato).getDato() });
-            gjeldendeFom = dato;
-        }
-
-        resultat.push({ ...periode, fom: gjeldendeFom });
-        return resultat;
-    });
-};
-
 const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
     // Dersom perioden har et aktivitetskrav så er det en periode lagt inn for kun far har rett
     // og det skal derfor ikke fjernes selv om det er en utsettelse med årsak fri
@@ -113,21 +83,59 @@ const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om annen part har søkt først og har lagt til ein periode som overlappar med søkar sin samtidig uttaksperiode (er muligens kun
 // synleg om søkar har har lagt til samtidig uttak og så seinare ser på ein endringssøknad), så må en endra
-// annen part sin periode til samtidig uttak for å få rett visning i kalender.
-// Periodane er pre-splitta, så overlapp er alltid fullstendig (aldri delvis).
+// annen part sin periode til samtidig uttak for å få rett visning i kalender
 const midlertidigJusteringAvSamtidigUttak = (
     perioderSøker1: UttakPeriode_fpoversikt[],
     perioderSøker2: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderSøker1.map((periodeSøker1) => {
+    return perioderSøker1.flatMap((periodeSøker1) => {
         const overlappendeSøker2Periode = perioderSøker2.find((søker) => harOverlapp(periodeSøker1, søker));
 
-        if (!overlappendeSøker2Periode) return periodeSøker1;
-
+        if (!overlappendeSøker2Periode) {
+            return [periodeSøker1];
+        }
         const skalEndreTilSamtidigUttak =
             overlappendeSøker2Periode.samtidigUttak !== undefined && periodeSøker1.samtidigUttak === undefined;
 
-        return skalEndreTilSamtidigUttak ? { ...periodeSøker1, samtidigUttak: 100 } : periodeSøker1;
+        if (!skalEndreTilSamtidigUttak) {
+            return [periodeSøker1];
+        }
+
+        const annenFom = dayjs(periodeSøker1.fom);
+        const annenTom = dayjs(periodeSøker1.tom);
+        const søkerFom = dayjs(overlappendeSøker2Periode.fom);
+        const søkerTom = dayjs(overlappendeSøker2Periode.tom);
+
+        const overlappFom = dayjs.max(annenFom, søkerFom);
+        const overlappTom = dayjs.min(annenTom, søkerTom);
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+
+        // Før overlapp
+        if (annenFom.isBefore(overlappFom, 'day')) {
+            resultat.push({
+                ...periodeSøker1,
+                tom: Uttaksdagen.forrige(overlappFom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        // Overlapp-del
+        resultat.push({
+            ...periodeSøker1,
+            fom: overlappFom.format(ISO_DATE_FORMAT),
+            tom: overlappTom.format(ISO_DATE_FORMAT),
+            samtidigUttak: 100,
+        });
+
+        // Etter overlapp
+        if (annenTom.isAfter(overlappTom, 'day')) {
+            resultat.push({
+                ...periodeSøker1,
+                fom: Uttaksdagen.neste(overlappTom.format(ISO_DATE_FORMAT)).getDato(),
+            });
+        }
+
+        return resultat;
     });
 };
 
@@ -137,32 +145,113 @@ const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
 // Den overlappande delen vert kasta. Denne algoritmen har prioritet over dei to andre og skal køyrast først.
-// Periodane er pre-splitta, så overlappande segment kan berre kastast direkte (aldri delvis).
 const fjernUtsettelseOverlapp = (
     perioder: UttakPeriode_fpoversikt[],
     motpartPerioder: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioder.filter(
-        (periode) => periode.utsettelseÅrsak === undefined || !motpartPerioder.some((m) => harOverlapp(periode, m)),
-    );
+    return perioder.flatMap((periode) => {
+        if (periode.utsettelseÅrsak === undefined) {
+            return [periode];
+        }
+
+        const overlappendePerioder = motpartPerioder
+            .filter((motpart) => harOverlapp(periode, motpart))
+            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
+
+        if (overlappendePerioder.length === 0) {
+            return [periode];
+        }
+
+        let resterendeSegmenter: UttakPeriode_fpoversikt[] = [periode];
+
+        overlappendePerioder.forEach((motpart) => {
+            const motpartFom = dayjs(motpart.fom);
+            const motpartTom = dayjs(motpart.tom);
+
+            resterendeSegmenter = resterendeSegmenter.flatMap((segment) => {
+                if (!harOverlapp(segment, motpart)) {
+                    return [segment];
+                }
+
+                const segmentFom = dayjs(segment.fom);
+                const segmentTom = dayjs(segment.tom);
+                const resultat: UttakPeriode_fpoversikt[] = [];
+
+                if (segmentFom.isBefore(motpartFom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                if (segmentTom.isAfter(motpartTom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                return resultat;
+            });
+        });
+
+        return resterendeSegmenter;
+    });
 };
 
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
 // er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
-// Periodane er pre-splitta, så overlappande segment kan berre kastast direkte (aldri delvis).
 const fjernOverlappUtenSamtidigUttak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[],
     perioderSøker: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderAnnenPart.filter(
-        (periodeAnnenPart) =>
-            periodeAnnenPart.samtidigUttak !== undefined ||
-            !perioderSøker.some(
-                (søker) =>
-                    søker.samtidigUttak === undefined &&
-                    søker.utsettelseÅrsak === undefined &&
-                    harOverlapp(periodeAnnenPart, søker),
-            ),
-    );
+    return perioderAnnenPart.flatMap((periodeAnnenPart) => {
+        if (periodeAnnenPart.samtidigUttak !== undefined) {
+            return [periodeAnnenPart];
+        }
+
+        const overlappendeSøkerPerioder = perioderSøker
+            .filter((søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker))
+            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
+
+        if (overlappendeSøkerPerioder.length === 0) {
+            return [periodeAnnenPart];
+        }
+
+        let segmenter: UttakPeriode_fpoversikt[] = [periodeAnnenPart];
+
+        overlappendeSøkerPerioder.forEach((overlappendeSøkerPeriode) => {
+            const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
+            const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
+
+            segmenter = segmenter.flatMap((segment) => {
+                if (!harOverlapp(segment, overlappendeSøkerPeriode)) {
+                    return [segment];
+                }
+
+                const segmentFom = dayjs(segment.fom);
+                const segmentTom = dayjs(segment.tom);
+                const resultat: UttakPeriode_fpoversikt[] = [];
+
+                if (segmentFom.isBefore(søkerFom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                if (segmentTom.isAfter(søkerTom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                return resultat;
+            });
+        });
+
+        return segmenter;
+    });
 };

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -83,7 +83,9 @@ const splitPerioder = (
             (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
         );
 
-        if (relevante.length === 0) return [periode];
+        if (relevante.length === 0) {
+            return [periode];
+        }
 
         const resultat: UttakPeriode_fpoversikt[] = [];
         let gjeldandeFom = periode.fom;
@@ -103,7 +105,9 @@ const splitPerioder = (
 // som vart delt av splitPerioder.
 const slåSammenTilstøtande = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
     return perioder.reduce<UttakPeriode_fpoversikt[]>((acc, periode) => {
-        if (acc.length === 0) return [periode];
+        if (acc.length === 0) {
+            return [periode];
+        }
         const forrige = acc.at(-1)!;
         const erTilstøtande = Uttaksdagen.neste(forrige.tom).getDato() === periode.fom;
         if (erTilstøtande && erLikeUtenDatoar(forrige, periode)) {
@@ -150,7 +154,9 @@ const midlertidigJusteringAvSamtidigUttak = (
 ): UttakPeriode_fpoversikt[] => {
     return perioderSøker1.map((p) => {
         const overlappande = perioderSøker2.find((s) => harOverlapp(p, s));
-        if (!overlappande) return p;
+        if (!overlappande) {
+            return p;
+        }
         return overlappande.samtidigUttak !== undefined && p.samtidigUttak === undefined
             ? { ...p, samtidigUttak: 100 }
             : p;

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -3,9 +3,7 @@ import { sakerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import minMax from 'dayjs/plugin/minMax';
 
-import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
 import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
@@ -13,7 +11,6 @@ import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
 import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
 
 dayjs.extend(isSameOrBefore);
-dayjs.extend(minMax);
 
 export const useUttaksplanForEksisterendeSak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
@@ -26,32 +23,41 @@ export const useUttaksplanForEksisterendeSak = (
     const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
     const perioderFraBackend = gjeldendeVedtak?.perioder;
 
-    const trimmedSøker =
+    // Pre-split both parties at each other's boundaries so every segment either
+    // fully overlaps or does not overlap at all. The algorithms then become simple
+    // filter/map operations. Adjacent equal segments are re-merged at the end.
+    const splitSøker =
         perioderFraBackend && perioderAnnenPart
-            ? fjernUtsettelseOverlapp(perioderFraBackend, perioderAnnenPart)
+            ? splitPerioder(perioderFraBackend, perioderAnnenPart)
             : perioderFraBackend;
-    const trimmedAnnenPart =
+    const splitAnnenPart =
         perioderFraBackend && perioderAnnenPart
-            ? fjernUtsettelseOverlapp(perioderAnnenPart, perioderFraBackend)
+            ? splitPerioder(perioderAnnenPart, perioderFraBackend)
             : perioderAnnenPart;
 
-    const justeringSøkerPerioder =
-        trimmedSøker && trimmedAnnenPart
-            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
-            : undefined;
+    // fjernUtsettelseOverlapp berre på annenPart – søkar sine periodar skal ikkje endrast
+    const trimmedAnnenPart =
+        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitAnnenPart, splitSøker) : splitAnnenPart;
 
-    const søkerRef = trimmedSøker ?? perioderFraBackend ?? [];
+    const søkerRef = splitSøker ?? [];
+    const justeringSøkerPerioder =
+        splitSøker && trimmedAnnenPart ? midlertidigJusteringAvSamtidigUttak(splitSøker, trimmedAnnenPart) : undefined;
+
+    // Merge each party separately before combining so that adjacent split-segments
+    // with identical properties are restored to single periods in the output.
+    const mergedSøker = slåSammenTilstøtande(
+        fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak?.perioder ?? []),
+    );
+    const processedAnnenPart = trimmedAnnenPart
+        ? slåSammenTilstøtande(
+              fjernOverlappUtenSamtidigUttak(midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef), søkerRef),
+          )
+        : [];
+
     const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined = gjeldendeVedtak
-        ? [
-              ...fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak.perioder),
-              ...(gjeldendeVedtak.perioderAnnenpartEøs ?? []),
-              ...(trimmedAnnenPart
-                  ? fjernOverlappUtenSamtidigUttak(
-                        midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef),
-                        søkerRef,
-                    )
-                  : []),
-          ].sort(sorterUttakPerioder)
+        ? [...mergedSøker, ...(gjeldendeVedtak.perioderAnnenpartEøs ?? []), ...processedAnnenPart].sort(
+              sorterUttakPerioder,
+          )
         : undefined;
 
     useLoggOverlappIVedtak(uttaksplan);
@@ -64,78 +70,90 @@ export const useUttaksplanForEksisterendeSak = (
     return uttaksplan!;
 };
 
+// Deler opp periodar ved grensene til motparten slik at kvart segment
+// anten heilt overlappar eller ikkje overlappar med motparten sine periodar.
+const splitPerioder = (
+    perioderToSplit: UttakPeriode_fpoversikt[],
+    splittBasertPå: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    const splitDatoar = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort();
+
+    return perioderToSplit.flatMap((periode) => {
+        const relevante = splitDatoar.filter(
+            (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
+        );
+
+        if (relevante.length === 0) return [periode];
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+        let gjeldandeFom = periode.fom;
+
+        for (const dato of relevante) {
+            resultat.push({ ...periode, fom: gjeldandeFom, tom: Uttaksdagen.forrige(dato).getDato() });
+            gjeldandeFom = dato;
+        }
+
+        resultat.push({ ...periode, fom: gjeldandeFom });
+        return resultat;
+    });
+};
+
+// Slår saman tilstøytande periodar med identiske eigenskapar.
+// Vert kalla separat for søkar og annenPart for å gjenopprette periodar
+// som vart delt av splitPerioder.
+const slåSammenTilstøtande = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
+    return perioder.reduce<UttakPeriode_fpoversikt[]>((acc, periode) => {
+        if (acc.length === 0) return [periode];
+        const forrige = acc.at(-1)!;
+        const erTilstøtande = Uttaksdagen.neste(forrige.tom).getDato() === periode.fom;
+        if (erTilstøtande && erLikeUtenDatoar(forrige, periode)) {
+            return [...acc.slice(0, -1), { ...forrige, tom: periode.tom }];
+        }
+        return [...acc, periode];
+    }, []);
+};
+
+const erLikeUtenDatoar = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>
+    a.forelder === b.forelder &&
+    a.kontoType === b.kontoType &&
+    a.flerbarnsdager === b.flerbarnsdager &&
+    a.gradering?.arbeidstidprosent === b.gradering?.arbeidstidprosent &&
+    a.gradering?.aktivitet === b.gradering?.aktivitet &&
+    a.morsAktivitet === b.morsAktivitet &&
+    a.oppholdÅrsak === b.oppholdÅrsak &&
+    a.utsettelseÅrsak === b.utsettelseÅrsak &&
+    a.overføringÅrsak === b.overføringÅrsak &&
+    a.resultat?.innvilget === b.resultat?.innvilget &&
+    a.resultat?.trekkerDager === b.resultat?.trekkerDager &&
+    a.resultat?.trekkerMinsterett === b.resultat?.trekkerMinsterett &&
+    a.resultat?.årsak === b.resultat?.årsak &&
+    a.samtidigUttak === b.samtidigUttak;
+
 const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
     // Dersom perioden har et aktivitetskrav så er det en periode lagt inn for kun far har rett
     // og det skal derfor ikke fjernes selv om det er en utsettelse med årsak fri
-    const erEnPeriodeMedFriUtsettelseSomSkalBeholdes = (periode: UttakPeriode_fpoversikt) => {
-        if (periode.utsettelseÅrsak === 'FRI' && periode.morsAktivitet !== undefined) {
-            return true;
-        }
-
-        return false;
-    };
-
     return perioder.filter(
-        (periode) => erEnPeriodeMedFriUtsettelseSomSkalBeholdes(periode) || periode.utsettelseÅrsak !== 'FRI',
+        (periode) =>
+            (periode.utsettelseÅrsak === 'FRI' && periode.morsAktivitet !== undefined) ||
+            periode.utsettelseÅrsak !== 'FRI',
     );
 };
 
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om annen part har søkt først og har lagt til ein periode som overlappar med søkar sin samtidig uttaksperiode (er muligens kun
 // synleg om søkar har har lagt til samtidig uttak og så seinare ser på ein endringssøknad), så må en endra
-// annen part sin periode til samtidig uttak for å få rett visning i kalender
+// annen part sin periode til samtidig uttak for å få rett visning i kalender.
+// Periodane er pre-splitta, så overlapp er alltid fullstendig.
 const midlertidigJusteringAvSamtidigUttak = (
     perioderSøker1: UttakPeriode_fpoversikt[],
     perioderSøker2: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderSøker1.flatMap((periodeSøker1) => {
-        const overlappendeSøker2Periode = perioderSøker2.find((søker) => harOverlapp(periodeSøker1, søker));
-
-        if (!overlappendeSøker2Periode) {
-            return [periodeSøker1];
-        }
-        const skalEndreTilSamtidigUttak =
-            overlappendeSøker2Periode.samtidigUttak !== undefined && periodeSøker1.samtidigUttak === undefined;
-
-        if (!skalEndreTilSamtidigUttak) {
-            return [periodeSøker1];
-        }
-
-        const annenFom = dayjs(periodeSøker1.fom);
-        const annenTom = dayjs(periodeSøker1.tom);
-        const søkerFom = dayjs(overlappendeSøker2Periode.fom);
-        const søkerTom = dayjs(overlappendeSøker2Periode.tom);
-
-        const overlappFom = dayjs.max(annenFom, søkerFom);
-        const overlappTom = dayjs.min(annenTom, søkerTom);
-
-        const resultat: UttakPeriode_fpoversikt[] = [];
-
-        // Før overlapp
-        if (annenFom.isBefore(overlappFom, 'day')) {
-            resultat.push({
-                ...periodeSøker1,
-                tom: Uttaksdagen.forrige(overlappFom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        // Overlapp-del
-        resultat.push({
-            ...periodeSøker1,
-            fom: overlappFom.format(ISO_DATE_FORMAT),
-            tom: overlappTom.format(ISO_DATE_FORMAT),
-            samtidigUttak: 100,
-        });
-
-        // Etter overlapp
-        if (annenTom.isAfter(overlappTom, 'day')) {
-            resultat.push({
-                ...periodeSøker1,
-                fom: Uttaksdagen.neste(overlappTom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        return resultat;
+    return perioderSøker1.map((p) => {
+        const overlappande = perioderSøker2.find((s) => harOverlapp(p, s));
+        if (!overlappande) return p;
+        return overlappande.samtidigUttak !== undefined && p.samtidigUttak === undefined
+            ? { ...p, samtidigUttak: 100 }
+            : p;
     });
 };
 
@@ -145,113 +163,33 @@ const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
 // Den overlappande delen vert kasta. Denne algoritmen har prioritet over dei to andre og skal køyrast først.
+// Periodane er pre-splitta, så overlappande segment kan kastast direkte.
 const fjernUtsettelseOverlapp = (
     perioder: UttakPeriode_fpoversikt[],
     motpartPerioder: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioder.flatMap((periode) => {
-        if (periode.utsettelseÅrsak === undefined) {
-            return [periode];
-        }
-
-        const overlappendePerioder = motpartPerioder
-            .filter((motpart) => harOverlapp(periode, motpart))
-            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
-
-        if (overlappendePerioder.length === 0) {
-            return [periode];
-        }
-
-        let resterendeSegmenter: UttakPeriode_fpoversikt[] = [periode];
-
-        overlappendePerioder.forEach((motpart) => {
-            const motpartFom = dayjs(motpart.fom);
-            const motpartTom = dayjs(motpart.tom);
-
-            resterendeSegmenter = resterendeSegmenter.flatMap((segment) => {
-                if (!harOverlapp(segment, motpart)) {
-                    return [segment];
-                }
-
-                const segmentFom = dayjs(segment.fom);
-                const segmentTom = dayjs(segment.tom);
-                const resultat: UttakPeriode_fpoversikt[] = [];
-
-                if (segmentFom.isBefore(motpartFom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                if (segmentTom.isAfter(motpartTom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                return resultat;
-            });
-        });
-
-        return resterendeSegmenter;
-    });
+    return perioder.filter(
+        (periode) => periode.utsettelseÅrsak === undefined || !motpartPerioder.some((m) => harOverlapp(periode, m)),
+    );
 };
 
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
 // er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
+// Periodar med utsettelseÅrsak hjå søkar tel ikkje som overlapp her.
+// Periodane er pre-splitta, så overlappande segment kan kastast direkte.
 const fjernOverlappUtenSamtidigUttak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[],
     perioderSøker: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderAnnenPart.flatMap((periodeAnnenPart) => {
-        if (periodeAnnenPart.samtidigUttak !== undefined) {
-            return [periodeAnnenPart];
-        }
-
-        const overlappendeSøkerPerioder = perioderSøker
-            .filter((søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker))
-            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
-
-        if (overlappendeSøkerPerioder.length === 0) {
-            return [periodeAnnenPart];
-        }
-
-        let segmenter: UttakPeriode_fpoversikt[] = [periodeAnnenPart];
-
-        overlappendeSøkerPerioder.forEach((overlappendeSøkerPeriode) => {
-            const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
-            const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
-
-            segmenter = segmenter.flatMap((segment) => {
-                if (!harOverlapp(segment, overlappendeSøkerPeriode)) {
-                    return [segment];
-                }
-
-                const segmentFom = dayjs(segment.fom);
-                const segmentTom = dayjs(segment.tom);
-                const resultat: UttakPeriode_fpoversikt[] = [];
-
-                if (segmentFom.isBefore(søkerFom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                if (segmentTom.isAfter(søkerTom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                return resultat;
-            });
-        });
-
-        return segmenter;
-    });
+    return perioderAnnenPart.filter(
+        (periodeAnnenPart) =>
+            periodeAnnenPart.samtidigUttak !== undefined ||
+            !perioderSøker.some(
+                (søker) =>
+                    søker.samtidigUttak === undefined &&
+                    søker.utsettelseÅrsak === undefined &&
+                    harOverlapp(periodeAnnenPart, søker),
+            ),
+    );
 };

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -23,9 +23,9 @@ export const useUttaksplanForEksisterendeSak = (
     const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
     const perioderFraBackend = gjeldendeVedtak?.perioder;
 
-    // Pre-split both parties at each other's boundaries so every segment either
-    // fully overlaps or does not overlap at all. The algorithms then become simple
-    // filter/map operations. Adjacent equal segments are re-merged at the end.
+    // Deler opp begge partar ved kvarandre sine grenser slik at kvart segment anten
+    // heilt overlappar eller ikkje overlappar i det heile. Algoritmane vert då enkle
+    // filter/map-operasjonar. Tilstøytande like segment vert slått saman att til slutt.
     const splitSøker =
         perioderFraBackend && perioderAnnenPart
             ? splitPerioder(perioderFraBackend, perioderAnnenPart)
@@ -47,8 +47,8 @@ export const useUttaksplanForEksisterendeSak = (
             ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
             : undefined;
 
-    // Merge each party separately before combining so that adjacent split-segments
-    // with identical properties are restored to single periods in the output.
+    // Slår saman kvar part for seg før kombinering, slik at tilstøytande segment
+    // med identiske eigenskapar vert gjenoppretta til enkeltperiodar i output.
     const mergedSøker = slåSammenTilstøtande(
         fjernFrieUtsettelser(justeringSøkerPerioder ?? trimmedSøker ?? gjeldendeVedtak?.perioder ?? []),
     );
@@ -138,8 +138,8 @@ const erLikeUtenDatoar = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt
     a.samtidigUttak === b.samtidigUttak;
 
 const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
-    // Dersom perioden har et aktivitetskrav så er det en periode lagt inn for kun far har rett
-    // og det skal derfor ikke fjernes selv om det er en utsettelse med årsak fri
+    // Dersom perioden har eit aktivitetskrav er det ein periode lagt inn for kun far har rett,
+    // og den skal difor ikkje fjernast sjølv om det er ei utsettelse med årsak fri.
     return perioder.filter(
         (periode) =>
             (periode.utsettelseÅrsak === 'FRI' && periode.morsAktivitet !== undefined) ||

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -154,33 +154,48 @@ const fjernUtsettelseOverlapp = (
             return [periode];
         }
 
-        const overlappende = motpartPerioder.find((motpart) => harOverlapp(periode, motpart));
-        if (!overlappende) {
+        const overlappendePerioder = motpartPerioder
+            .filter((motpart) => harOverlapp(periode, motpart))
+            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
+
+        if (overlappendePerioder.length === 0) {
             return [periode];
         }
 
-        const periodeFom = dayjs(periode.fom);
-        const periodeTom = dayjs(periode.tom);
-        const motpartFom = dayjs(overlappende.fom);
-        const motpartTom = dayjs(overlappende.tom);
+        let resterendeSegmenter: UttakPeriode_fpoversikt[] = [periode];
 
-        const resultat: UttakPeriode_fpoversikt[] = [];
+        overlappendePerioder.forEach((motpart) => {
+            const motpartFom = dayjs(motpart.fom);
+            const motpartTom = dayjs(motpart.tom);
 
-        if (periodeFom.isBefore(motpartFom, 'day')) {
-            resultat.push({
-                ...periode,
-                tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
+            resterendeSegmenter = resterendeSegmenter.flatMap((segment) => {
+                if (!harOverlapp(segment, motpart)) {
+                    return [segment];
+                }
+
+                const segmentFom = dayjs(segment.fom);
+                const segmentTom = dayjs(segment.tom);
+                const resultat: UttakPeriode_fpoversikt[] = [];
+
+                if (segmentFom.isBefore(motpartFom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                if (segmentTom.isAfter(motpartTom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                return resultat;
             });
-        }
+        });
 
-        if (periodeTom.isAfter(motpartTom, 'day')) {
-            resultat.push({
-                ...periode,
-                fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        return resultat;
+        return resterendeSegmenter;
     });
 };
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -80,7 +80,9 @@ const splitPerioder = (
     perioderToSplit: UttakPeriode_fpoversikt[],
     splittBasertPå: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    const splitDatoar = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort();
+    const splitDatoar = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort(
+        (a, b) => a.localeCompare(b),
+    );
 
     return perioderToSplit.flatMap((periode) => {
         const relevante = splitDatoar.filter(

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -211,35 +211,47 @@ const fjernOverlappUtenSamtidigUttak = (
             return [periodeAnnenPart];
         }
 
-        const overlappendeSøkerPeriode = perioderSøker.find(
+        const overlappendeSøkerPerioder = perioderSøker.filter(
             (søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker),
         );
 
-        if (!overlappendeSøkerPeriode) {
+        if (overlappendeSøkerPerioder.length === 0) {
             return [periodeAnnenPart];
         }
 
-        const annenFom = dayjs(periodeAnnenPart.fom);
-        const annenTom = dayjs(periodeAnnenPart.tom);
-        const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
-        const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
+        let segmenter: UttakPeriode_fpoversikt[] = [periodeAnnenPart];
 
-        const resultat: UttakPeriode_fpoversikt[] = [];
+        overlappendeSøkerPerioder.forEach((overlappendeSøkerPeriode) => {
+            const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
+            const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
 
-        if (annenFom.isBefore(søkerFom, 'day')) {
-            resultat.push({
-                ...periodeAnnenPart,
-                tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
+            segmenter = segmenter.flatMap((segment) => {
+                if (!harOverlapp(segment, overlappendeSøkerPeriode)) {
+                    return [segment];
+                }
+
+                const segmentFom = dayjs(segment.fom);
+                const segmentTom = dayjs(segment.tom);
+                const resultat: UttakPeriode_fpoversikt[] = [];
+
+                if (segmentFom.isBefore(søkerFom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                if (segmentTom.isAfter(søkerTom, 'day')) {
+                    resultat.push({
+                        ...segment,
+                        fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
+                    });
+                }
+
+                return resultat;
             });
-        }
+        });
 
-        if (annenTom.isAfter(søkerTom, 'day')) {
-            resultat.push({
-                ...periodeAnnenPart,
-                fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        return resultat;
+        return segmenter;
     });
 };

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -211,9 +211,9 @@ const fjernOverlappUtenSamtidigUttak = (
             return [periodeAnnenPart];
         }
 
-        const overlappendeSøkerPerioder = perioderSøker.filter(
-            (søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker),
-        );
+        const overlappendeSøkerPerioder = perioderSøker
+            .filter((søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker))
+            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
 
         if (overlappendeSøkerPerioder.length === 0) {
             return [periodeAnnenPart];

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -35,18 +35,22 @@ export const useUttaksplanForEksisterendeSak = (
             ? splitPerioder(perioderAnnenPart, perioderFraBackend)
             : perioderAnnenPart;
 
-    // fjernUtsettelseOverlapp berre på annenPart – søkar sine periodar skal ikkje endrast
+    // Periodar med utsettelseÅrsak som overlappar motparten skal fjernast, uansett kven som eig perioden
+    const trimmedSøker =
+        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitSøker, splitAnnenPart) : splitSøker;
     const trimmedAnnenPart =
         splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitAnnenPart, splitSøker) : splitAnnenPart;
 
-    const søkerRef = splitSøker ?? [];
+    const søkerRef = trimmedSøker ?? [];
     const justeringSøkerPerioder =
-        splitSøker && trimmedAnnenPart ? midlertidigJusteringAvSamtidigUttak(splitSøker, trimmedAnnenPart) : undefined;
+        trimmedSøker && trimmedAnnenPart
+            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
+            : undefined;
 
     // Merge each party separately before combining so that adjacent split-segments
     // with identical properties are restored to single periods in the output.
     const mergedSøker = slåSammenTilstøtande(
-        fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak?.perioder ?? []),
+        fjernFrieUtsettelser(justeringSøkerPerioder ?? trimmedSøker ?? gjeldendeVedtak?.perioder ?? []),
     );
     const processedAnnenPart = trimmedAnnenPart
         ? slåSammenTilstøtande(

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -3,9 +3,7 @@ import { sakerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import minMax from 'dayjs/plugin/minMax';
 
-import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
 import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
@@ -13,7 +11,6 @@ import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
 import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
 
 dayjs.extend(isSameOrBefore);
-dayjs.extend(minMax);
 
 export const useUttaksplanForEksisterendeSak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
@@ -26,21 +23,26 @@ export const useUttaksplanForEksisterendeSak = (
     const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
     const perioderFraBackend = gjeldendeVedtak?.perioder;
 
-    const trimmedSøker =
+    // Pre-split both parties' periods at each other's boundaries so each segment
+    // either fully overlaps or does not overlap at all when comparing the two parties
+    const splitSøker =
         perioderFraBackend && perioderAnnenPart
-            ? fjernUtsettelseOverlapp(perioderFraBackend, perioderAnnenPart)
+            ? splitPerioder(perioderFraBackend, perioderAnnenPart)
             : perioderFraBackend;
-    const trimmedAnnenPart =
+    const splitAnnenPart =
         perioderFraBackend && perioderAnnenPart
-            ? fjernUtsettelseOverlapp(perioderAnnenPart, perioderFraBackend)
+            ? splitPerioder(perioderAnnenPart, perioderFraBackend)
             : perioderAnnenPart;
 
+    const trimmedAnnenPart =
+        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitAnnenPart, splitSøker) : splitAnnenPart;
+
+    const søkerRef = splitSøker ?? [];
     const justeringSøkerPerioder =
-        trimmedSøker && trimmedAnnenPart
-            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
+        perioderFraBackend && trimmedAnnenPart
+            ? midlertidigJusteringAvSamtidigUttak(søkerRef, trimmedAnnenPart)
             : undefined;
 
-    const søkerRef = trimmedSøker ?? perioderFraBackend ?? [];
     const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined = gjeldendeVedtak
         ? [
               ...fjernFrieUtsettelser(justeringSøkerPerioder ?? gjeldendeVedtak.perioder),
@@ -64,6 +66,34 @@ export const useUttaksplanForEksisterendeSak = (
     return uttaksplan!;
 };
 
+// Split periods at the boundaries of another party's periods so each resulting segment
+// can only fully overlap or not overlap at all with the other party's periods
+const splitPerioder = (
+    perioderToSplit: UttakPeriode_fpoversikt[],
+    splittBasertPå: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    const splitDatoer = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort();
+
+    return perioderToSplit.flatMap((periode) => {
+        const relevanteDelDatoer = splitDatoer.filter(
+            (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
+        );
+
+        if (relevanteDelDatoer.length === 0) return [periode];
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+        let gjeldendeFom = periode.fom;
+
+        for (const dato of relevanteDelDatoer) {
+            resultat.push({ ...periode, fom: gjeldendeFom, tom: Uttaksdagen.forrige(dato).getDato() });
+            gjeldendeFom = dato;
+        }
+
+        resultat.push({ ...periode, fom: gjeldendeFom });
+        return resultat;
+    });
+};
+
 const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
     // Dersom perioden har et aktivitetskrav så er det en periode lagt inn for kun far har rett
     // og det skal derfor ikke fjernes selv om det er en utsettelse med årsak fri
@@ -83,59 +113,21 @@ const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om annen part har søkt først og har lagt til ein periode som overlappar med søkar sin samtidig uttaksperiode (er muligens kun
 // synleg om søkar har har lagt til samtidig uttak og så seinare ser på ein endringssøknad), så må en endra
-// annen part sin periode til samtidig uttak for å få rett visning i kalender
+// annen part sin periode til samtidig uttak for å få rett visning i kalender.
+// Periodane er pre-splitta, så overlapp er alltid fullstendig (aldri delvis).
 const midlertidigJusteringAvSamtidigUttak = (
     perioderSøker1: UttakPeriode_fpoversikt[],
     perioderSøker2: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderSøker1.flatMap((periodeSøker1) => {
+    return perioderSøker1.map((periodeSøker1) => {
         const overlappendeSøker2Periode = perioderSøker2.find((søker) => harOverlapp(periodeSøker1, søker));
 
-        if (!overlappendeSøker2Periode) {
-            return [periodeSøker1];
-        }
+        if (!overlappendeSøker2Periode) return periodeSøker1;
+
         const skalEndreTilSamtidigUttak =
             overlappendeSøker2Periode.samtidigUttak !== undefined && periodeSøker1.samtidigUttak === undefined;
 
-        if (!skalEndreTilSamtidigUttak) {
-            return [periodeSøker1];
-        }
-
-        const annenFom = dayjs(periodeSøker1.fom);
-        const annenTom = dayjs(periodeSøker1.tom);
-        const søkerFom = dayjs(overlappendeSøker2Periode.fom);
-        const søkerTom = dayjs(overlappendeSøker2Periode.tom);
-
-        const overlappFom = dayjs.max(annenFom, søkerFom);
-        const overlappTom = dayjs.min(annenTom, søkerTom);
-
-        const resultat: UttakPeriode_fpoversikt[] = [];
-
-        // Før overlapp
-        if (annenFom.isBefore(overlappFom, 'day')) {
-            resultat.push({
-                ...periodeSøker1,
-                tom: Uttaksdagen.forrige(overlappFom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        // Overlapp-del
-        resultat.push({
-            ...periodeSøker1,
-            fom: overlappFom.format(ISO_DATE_FORMAT),
-            tom: overlappTom.format(ISO_DATE_FORMAT),
-            samtidigUttak: 100,
-        });
-
-        // Etter overlapp
-        if (annenTom.isAfter(overlappTom, 'day')) {
-            resultat.push({
-                ...periodeSøker1,
-                fom: Uttaksdagen.neste(overlappTom.format(ISO_DATE_FORMAT)).getDato(),
-            });
-        }
-
-        return resultat;
+        return skalEndreTilSamtidigUttak ? { ...periodeSøker1, samtidigUttak: 100 } : periodeSøker1;
     });
 };
 
@@ -145,113 +137,32 @@ const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
 // Den overlappande delen vert kasta. Denne algoritmen har prioritet over dei to andre og skal køyrast først.
+// Periodane er pre-splitta, så overlappande segment kan berre kastast direkte (aldri delvis).
 const fjernUtsettelseOverlapp = (
     perioder: UttakPeriode_fpoversikt[],
     motpartPerioder: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioder.flatMap((periode) => {
-        if (periode.utsettelseÅrsak === undefined) {
-            return [periode];
-        }
-
-        const overlappendePerioder = motpartPerioder
-            .filter((motpart) => harOverlapp(periode, motpart))
-            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
-
-        if (overlappendePerioder.length === 0) {
-            return [periode];
-        }
-
-        let resterendeSegmenter: UttakPeriode_fpoversikt[] = [periode];
-
-        overlappendePerioder.forEach((motpart) => {
-            const motpartFom = dayjs(motpart.fom);
-            const motpartTom = dayjs(motpart.tom);
-
-            resterendeSegmenter = resterendeSegmenter.flatMap((segment) => {
-                if (!harOverlapp(segment, motpart)) {
-                    return [segment];
-                }
-
-                const segmentFom = dayjs(segment.fom);
-                const segmentTom = dayjs(segment.tom);
-                const resultat: UttakPeriode_fpoversikt[] = [];
-
-                if (segmentFom.isBefore(motpartFom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        tom: Uttaksdagen.forrige(motpartFom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                if (segmentTom.isAfter(motpartTom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        fom: Uttaksdagen.neste(motpartTom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                return resultat;
-            });
-        });
-
-        return resterendeSegmenter;
-    });
+    return perioder.filter(
+        (periode) => periode.utsettelseÅrsak === undefined || !motpartPerioder.some((m) => harOverlapp(periode, m)),
+    );
 };
 
 // TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
 // Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
 // er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
+// Periodane er pre-splitta, så overlappande segment kan berre kastast direkte (aldri delvis).
 const fjernOverlappUtenSamtidigUttak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[],
     perioderSøker: UttakPeriode_fpoversikt[],
 ): UttakPeriode_fpoversikt[] => {
-    return perioderAnnenPart.flatMap((periodeAnnenPart) => {
-        if (periodeAnnenPart.samtidigUttak !== undefined) {
-            return [periodeAnnenPart];
-        }
-
-        const overlappendeSøkerPerioder = perioderSøker
-            .filter((søker) => søker.samtidigUttak === undefined && harOverlapp(periodeAnnenPart, søker))
-            .sort((a, b) => dayjs(a.fom).valueOf() - dayjs(b.fom).valueOf());
-
-        if (overlappendeSøkerPerioder.length === 0) {
-            return [periodeAnnenPart];
-        }
-
-        let segmenter: UttakPeriode_fpoversikt[] = [periodeAnnenPart];
-
-        overlappendeSøkerPerioder.forEach((overlappendeSøkerPeriode) => {
-            const søkerFom = dayjs(overlappendeSøkerPeriode.fom);
-            const søkerTom = dayjs(overlappendeSøkerPeriode.tom);
-
-            segmenter = segmenter.flatMap((segment) => {
-                if (!harOverlapp(segment, overlappendeSøkerPeriode)) {
-                    return [segment];
-                }
-
-                const segmentFom = dayjs(segment.fom);
-                const segmentTom = dayjs(segment.tom);
-                const resultat: UttakPeriode_fpoversikt[] = [];
-
-                if (segmentFom.isBefore(søkerFom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        tom: Uttaksdagen.forrige(søkerFom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                if (segmentTom.isAfter(søkerTom, 'day')) {
-                    resultat.push({
-                        ...segment,
-                        fom: Uttaksdagen.neste(søkerTom.format(ISO_DATE_FORMAT)).getDato(),
-                    });
-                }
-
-                return resultat;
-            });
-        });
-
-        return segmenter;
-    });
+    return perioderAnnenPart.filter(
+        (periodeAnnenPart) =>
+            periodeAnnenPart.samtidigUttak !== undefined ||
+            !perioderSøker.some(
+                (søker) =>
+                    søker.samtidigUttak === undefined &&
+                    søker.utsettelseÅrsak === undefined &&
+                    harOverlapp(periodeAnnenPart, søker),
+            ),
+    );
 };


### PR DESCRIPTION
Legg til tre nye algoritmar i useUttaksplanForEksisterendeSak:
- fjernUtsettelseOverlapp: periodar med utsettelseÅrsak som overlappar motparten sin periode vert trimma (høgast prioritet)
- fjernOverlappUtenSamtidigUttak: overlappande annenPart-periodar utan samtidigattak vert kasta Forenklar useLoggOverlappIVedtak til kun å logge den endelege uttaksplanen.