### PR TITLE
TFP-6562 - Fjern sperre mot å gradere mors periode i seksvekersperioden etter fø…

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
@@ -7,12 +7,10 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
+import { getAntallUttaksdagerIVinduRundtFødsel } from '@navikt/fp-uttaksplan';
+import { Uttaksperioden } from '@navikt/fp-utils';
 
 type Periode = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
-
-const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
-const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
 
 interface ForeldersBrukteDager {
     førTermin: KontoDto[];
@@ -83,27 +81,6 @@ const finnAntallDagerÅTrekke = (periode: Periode, erFødsel: boolean, familiehe
         return dager * (samtidigUttak / 100);
     }
     return dager;
-};
-
-const getAntallUttaksdagerIVinduRundtFødsel = (
-    periodeFom: string,
-    periodeTom: string,
-    familiehendelsedato: string,
-): number => {
-    const familiehendelseSomUttaksdag = Uttaksdagen.denneEllerNeste(familiehendelsedato);
-    const førsteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TRE_UKER);
-    const sisteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerSenere(
-        ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
-    );
-
-    const overlappFom = dayjs(periodeFom).isAfter(førsteDagIVindu, 'day') ? periodeFom : førsteDagIVindu;
-    const overlappTom = dayjs(periodeTom).isBefore(sisteDagIVindu, 'day') ? periodeTom : sisteDagIVindu;
-
-    if (dayjs(overlappFom).isAfter(overlappTom, 'day')) {
-        return 0;
-    }
-
-    return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
 };
 
 const beregnBrukteUttaksdager = (

--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
@@ -96,10 +96,10 @@ const getAntallUttaksdagerIVinduRundtFødsel = (
         ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
     );
 
-    const overlappFom = periodeFom > førsteDagIVindu ? periodeFom : førsteDagIVindu;
-    const overlappTom = periodeTom < sisteDagIVindu ? periodeTom : sisteDagIVindu;
+    const overlappFom = dayjs(periodeFom).isAfter(førsteDagIVindu, 'day') ? periodeFom : førsteDagIVindu;
+    const overlappTom = dayjs(periodeTom).isBefore(sisteDagIVindu, 'day') ? periodeTom : sisteDagIVindu;
 
-    if (overlappFom > overlappTom) {
+    if (dayjs(overlappFom).isAfter(overlappTom, 'day')) {
         return 0;
     }
 

--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
@@ -7,9 +7,12 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksperioden } from '@navikt/fp-utils';
+import { Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
 
 type Periode = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
+
+const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
+const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
 
 interface ForeldersBrukteDager {
     førTermin: KontoDto[];
@@ -58,7 +61,7 @@ const filtrerAvslåttePerioderMenBeholdPleiepenger = (periode: Periode): boolean
     return periode.resultat?.trekkerDager ?? true;
 };
 
-const finnAntallDagerÅTrekke = (periode: Periode): number => {
+const finnAntallDagerÅTrekke = (periode: Periode, erFødsel: boolean, familiehendelsesdato: string): number => {
     if (Uttaksperioden.erEøsPeriode(periode)) {
         return periode.trekkdager;
     }
@@ -66,7 +69,15 @@ const finnAntallDagerÅTrekke = (periode: Periode): number => {
     const samtidigUttak = periode.samtidigUttak;
     const dager = Uttaksperioden.getAntallUttaksdager(periode);
     if (arbeidstidprosent) {
-        return dager * ((100 - arbeidstidprosent) / 100);
+        const graderingsProsent = (100 - arbeidstidprosent) / 100;
+        // Mor sin gradering i tidsrommet 3 uker før / 6 uker etter familiehendelsesdato
+        // gir ikkje forlenging av stønadsperioden – dagane skal trekkjast som heile.
+        if (erFødsel && periode.forelder === 'MOR') {
+            const dagerIVindu = getAntallUttaksdagerIVinduRundtFødsel(periode.fom, periode.tom, familiehendelsesdato);
+            const dagerUtenforVindu = dager - dagerIVindu;
+            return dagerIVindu + dagerUtenforVindu * graderingsProsent;
+        }
+        return dager * graderingsProsent;
     }
     if (samtidigUttak) {
         return dager * (samtidigUttak / 100);
@@ -74,11 +85,42 @@ const finnAntallDagerÅTrekke = (periode: Periode): number => {
     return dager;
 };
 
-const beregnBrukteUttaksdager = (tilgjengeligeStønadskontoer: KontoBeregningDto, perioder: Periode[]): KontoDto[] => {
+const getAntallUttaksdagerIVinduRundtFødsel = (
+    periodeFom: string,
+    periodeTom: string,
+    familiehendelsedato: string,
+): number => {
+    const familiehendelseSomUttaksdag = Uttaksdagen.denneEllerNeste(familiehendelsedato);
+    const førsteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TRE_UKER);
+    const sisteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerSenere(
+        ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
+    );
+
+    const overlappFom = periodeFom > førsteDagIVindu ? periodeFom : førsteDagIVindu;
+    const overlappTom = periodeTom < sisteDagIVindu ? periodeTom : sisteDagIVindu;
+
+    if (overlappFom > overlappTom) {
+        return 0;
+    }
+
+    return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
+};
+
+const beregnBrukteUttaksdager = (
+    tilgjengeligeStønadskontoer: KontoBeregningDto,
+    perioder: Periode[],
+    erFødsel: boolean,
+    familiehendelsesdato: string,
+): KontoDto[] => {
     return tilgjengeligeStønadskontoer.kontoer
         .map((konto) => {
             const perioderForKonto = perioder.filter((p) => p.kontoType === konto.konto);
-            const dager = Math.floor(perioderForKonto.reduce((sum, p) => sum + finnAntallDagerÅTrekke(p), 0));
+            const dager = Math.floor(
+                perioderForKonto.reduce(
+                    (sum, p) => sum + finnAntallDagerÅTrekke(p, erFødsel, familiehendelsesdato),
+                    0,
+                ),
+            );
             return { konto: konto.konto, dager };
         })
         .filter((k) => k.dager > 0);
@@ -101,12 +143,23 @@ const getBrukteDagerForForelder = (
     perioder: Periode[],
     familiehendelsesdato: string,
     forelder: BrukerRolleSak_fpoversikt,
+    erFødsel: boolean,
 ): ForeldersBrukteDager => {
     const perioderFørTermin = getPerioderFørFamiliehendelse(perioder, familiehendelsesdato);
     const perioderEtterTermin = getPerioderEtterFamiliehendelse(perioder, familiehendelsesdato);
-    const førTermin = beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioderFørTermin);
-    const etterTermin = beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioderEtterTermin);
-    const alle = beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioder);
+    const førTermin = beregnBrukteUttaksdager(
+        tilgjengeligeStønadskontoer,
+        perioderFørTermin,
+        erFødsel,
+        familiehendelsesdato,
+    );
+    const etterTermin = beregnBrukteUttaksdager(
+        tilgjengeligeStønadskontoer,
+        perioderEtterTermin,
+        erFødsel,
+        familiehendelsesdato,
+    );
+    const alle = beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioder, erFødsel, familiehendelsesdato);
     const dagerTotalt = summerBrukteUttaksdager(alle);
 
     const isMor = forelder === 'MOR';
@@ -129,6 +182,7 @@ export const getBrukteDager = (
     tilgjengeligeStønadskontoer: KontoBeregningDto,
     perioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined,
     familiehendelsesdato: string,
+    erFødsel: boolean,
 ): BrukteDager => {
     const perioderMedUttak = (perioder ?? []).filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
     return {
@@ -137,13 +191,15 @@ export const getBrukteDager = (
             perioderMedUttak.filter(isMorsPeriode),
             familiehendelsesdato,
             'MOR',
+            erFødsel,
         ),
         farMedmor: getBrukteDagerForForelder(
             tilgjengeligeStønadskontoer,
             perioderMedUttak.filter(isFarsPeriode),
             familiehendelsesdato,
             'FAR_MEDMOR',
+            erFødsel,
         ),
-        alle: beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioderMedUttak),
+        alle: beregnBrukteUttaksdager(tilgjengeligeStønadskontoer, perioderMedUttak, erFødsel, familiehendelsesdato),
     };
 };

--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/fordelingOversiktUtils.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/fordelingOversiktUtils.tsx
@@ -269,14 +269,15 @@ const getAntallDagerSøkerensKvoteBruktAvAnnenPart = (
     kontoer: KontoBeregningDto,
     erFarEllerMedmor: boolean,
     familiehendelsesdato: string,
+    erFødsel: boolean,
 ): number => {
     if (uttaksplanAnnenPart === undefined || uttaksplanAnnenPart.length === 0) {
         return 0;
     }
     if (erFarEllerMedmor) {
-        return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato).farMedmor.dagerEgneKvoter;
+        return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato, erFødsel).farMedmor.dagerEgneKvoter;
     } else {
-        return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato).mor.dagerEgneKvoter;
+        return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato, erFødsel).mor.dagerEgneKvoter;
     }
 };
 
@@ -284,11 +285,12 @@ const getAntallDagerFellesperiodeBruktAvAnnenPart = (
     uttaksplanAnnenPart: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined,
     kontoer: KontoBeregningDto,
     familiehendelsesdato: string,
+    erFødsel: boolean,
 ): number => {
     if (uttaksplanAnnenPart === undefined || uttaksplanAnnenPart.length === 0) {
         return 0;
     }
-    return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato).mor.dagerFellesperiode;
+    return getBrukteDager(kontoer, uttaksplanAnnenPart, familiehendelsesdato, erFødsel).mor.dagerFellesperiode;
 };
 
 const getFordelingFelles = (
@@ -785,6 +787,7 @@ export const getFordelingFraKontoer = (
     const erAleneomsorg = getErAleneOmOmsorg(annenForelder);
     const familiehendelsesdato = getFamiliehendelsedato(barn);
     const erFarEllerMedmor = isFarEllerMedmor(søkersituasjon.rolle);
+    const erFødsel = søkersituasjon.situasjon === 'fødsel';
     const fordelingsinformasjon = [];
     const dagerMødrekvote = getAntallUkerMødrekvote(kontoer) * 5;
     const dagerFedrekvote = getAntallUkerFedrekvote(kontoer) * 5;
@@ -794,6 +797,7 @@ export const getFordelingFraKontoer = (
         uttaksplanAnnenPart,
         kontoer,
         familiehendelsesdato,
+        erFødsel,
     );
     const erMor = !erFarEllerMedmor;
     const erMorOgFarHarIkkeKunRettIEØS = erMor && !annenPartHarKunRettIEØS;
@@ -814,6 +818,7 @@ export const getFordelingFraKontoer = (
                   kontoer,
                   erFarEllerMedmor,
                   familiehendelsesdato,
+                  erFødsel,
               );
         const fordelingMor = getFordelingMor(
             kontoer,
@@ -850,6 +855,7 @@ export const getFordelingFraKontoer = (
                   kontoer,
                   erFarEllerMedmor,
                   familiehendelsesdato,
+                  erFødsel,
               )
             : undefined;
         const fordelingFar = getFordelingFedrekvote(

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -22,6 +22,6 @@ export { FjernAltIUttaksplanModal } from './src/FjernAltIUttaksplanModal';
 export { useErAntallDagerOvertrukketIUttaksplan } from './src/utils/kvoteOppsummeringUtils';
 export { UttaksperiodeValidatorer } from './src/utils/UttaksperiodeValidatorer';
 export { skalBesvareFlerbarnsdager } from './src/felles/LeggTilEllerEndrePeriodeFellesForm';
-export { sorterUttakPerioder, harPeriodeDerMorsAktivitetIkkeErValgt } from './src/utils/periodeUtils';
+export { sorterUttakPerioder, harPeriodeDerMorsAktivitetIkkeErValgt, getAntallUttaksdagerIVinduRundtFødsel } from './src/utils/periodeUtils';
 export { deltUttak } from './src/utils/forslag/deltUttak';
 export { ikkeDeltUttak } from './src/utils/forslag/ikkeDeltUttak';

--- a/packages/uttaksplan/src/KvoteOppsummering.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.tsx
@@ -81,7 +81,7 @@ const KvoteTittelKunEnHarForeldrepenger = ({
     erInnsyn: boolean;
 }) => {
     const intl = useIntl();
-    const { uttakPerioder, familiesituasjon, valgtStønadskonto } = useUttaksplanData();
+    const { uttakPerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato } = useUttaksplanData();
 
     const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
 
@@ -89,6 +89,7 @@ const KvoteTittelKunEnHarForeldrepenger = ({
         filtrertePerioder,
         familiesituasjon,
         valgtStønadskonto,
+        familiehendelsedato,
     );
 
     if (antallOvertrukketDager > 0) {
@@ -156,7 +157,8 @@ const KvoteTittel = ({
     erInnsyn: boolean;
 }) => {
     const intl = useIntl();
-    const { foreldreInfo, uttakPerioder, familiesituasjon, valgtStønadskonto } = useUttaksplanData();
+    const { foreldreInfo, uttakPerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato } =
+        useUttaksplanData();
 
     const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
 
@@ -169,7 +171,7 @@ const KvoteTittel = ({
         dagerBruktAvFar,
         dagerBruktAvMor,
         dagerFellesBrukt,
-    } = tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskonto);
+    } = tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato);
 
     if (antallOvertrukketDager > 0) {
         const beggeHarBruktMorsKvote = filtrertePerioder
@@ -482,7 +484,8 @@ const MødreKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
 
 const FellesKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
     const intl = useIntl();
-    const { uttakPerioder, valgtStønadskonto, foreldreInfo } = useUttaksplanData();
+    const { uttakPerioder, valgtStønadskonto, foreldreInfo, familiesituasjon, familiehendelsedato } =
+        useUttaksplanData();
 
     const forelder = foreldreInfo.søker;
     const fellesKonto = valgtStønadskonto.kontoer.find((k) => k.konto === 'FELLESPERIODE');
@@ -496,6 +499,8 @@ const FellesKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
             (p) => getUttaksKontoType(p) === 'FELLESPERIODE' && erVanligUttakPeriode(p) && p.forelder === forelder,
         ),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
     const dagerBruktAvAnnenPart = summerDagerIPerioder(
         filtrertePerioder.filter(
@@ -505,6 +510,8 @@ const FellesKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
                 p.forelder !== forelder,
         ),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
     const samletBrukteDager = dagerBruktAvDeg + dagerBruktAvAnnenPart;
     const ubrukteDager = fellesKonto.dager - samletBrukteDager;
@@ -611,6 +618,7 @@ const StandardVisning = ({
     const intl = useIntl();
     const {
         familiesituasjon,
+        familiehendelsedato,
         foreldreInfo: { erMedmorDelAvSøknaden },
     } = useUttaksplanData();
 
@@ -621,7 +629,7 @@ const StandardVisning = ({
     // Dersom barnet er født vil ubrukte dager på mor sin "3 uker før fødsel" konto utløpe og ikke kunne brukes.
     const ubrukteDagerErUtløpt = konto.konto === 'FORELDREPENGER_FØR_FØDSEL' && familiesituasjon === 'fødsel';
 
-    const dagerBrukt = summerDagerIPerioder(perioder, [konto]);
+    const dagerBrukt = summerDagerIPerioder(perioder, [konto], familiesituasjon, familiehendelsedato);
     const ubrukteDager = konto.dager - dagerBrukt;
     const overtrukketDager = ubrukteDager * -1;
     const prosentBruktAvkvote = Math.floor((dagerBrukt / konto.dager) * 100);

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
@@ -168,7 +168,7 @@ const getWrapper =
     );
 
 describe('useFormSubmitValidator', () => {
-    it('skal returnere feilmelding dersom mor kombinerer arbeid og foreldrepenger de første 6 ukene', () => {
+    it('skal ikke returnere feilmelding dersom mor kombinerer arbeid og foreldrepenger de første 6 ukene', () => {
         const { result } = renderHook(() => useFormSubmitValidator(), {
             wrapper: getWrapper(),
         });
@@ -190,7 +190,7 @@ describe('useFormSubmitValidator', () => {
         const valider = result.current;
         const feilmelding = valider(nyePerioder, formValues);
 
-        expect(feilmelding).toBe('Mor kan ikke kombinere foreldrepenger med arbeid de første seks ukene');
+        expect(feilmelding).toBeNull();
     });
 
     it('skal returnere feilmelding dersom far kombinerer arbeid og mødrekvote de første 6 ukene', () => {

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
@@ -401,19 +401,6 @@ const erKombinasjonAvArbeidOgForeldrepengerDe6FørsteUkene = <T extends LeggTilE
     }
 
     if (
-        formValues.skalDuKombinereArbeidOgUttakMor &&
-        (formValues.kontoTypeMor === 'MØDREKVOTE' ||
-            formValues.kontoTypeMor === 'FELLESPERIODE' ||
-            formValues.kontoTypeMor === 'FORELDREPENGER') &&
-        UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletFamDatoOgSeksUkerEtterFamDato(
-            perioder,
-            familiehendelsedato,
-        )
-    ) {
-        return intl.formatMessage({ id: 'endreTidsPeriodeModal.kanIkkeKombinere' });
-    }
-
-    if (
         formValues.skalDuKombinereArbeidOgUttakFarMedmor &&
         formValues.kontoTypeFarMedmor === 'MØDREKVOTE' &&
         UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletFamDatoOgSeksUkerEtterFamDato(

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.test.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { KontoBeregningDto, UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { summerDagerIPerioder } from './kvoteOppsummeringUtils';
+
+const FAMILIEHENDELSESDATO = '2024-04-01'; // Mandag
+
+const KONTOER: KontoBeregningDto = {
+    kontoer: [
+        { konto: 'MØDREKVOTE', dager: 75 },
+        { konto: 'FEDREKVOTE', dager: 75 },
+        { konto: 'FELLESPERIODE', dager: 80 },
+        { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+    ],
+    minsteretter: { farRundtFødsel: 0, toTette: 0 },
+    tillegg: { flerbarn: 0, prematur: 0 },
+};
+
+const lagMorsMødrekvotePeriode = (
+    fom: string,
+    tom: string,
+    arbeidstidprosent?: number,
+): UttakPeriode_fpoversikt => ({
+    fom,
+    tom,
+    forelder: 'MOR',
+    kontoType: 'MØDREKVOTE',
+    flerbarnsdager: false,
+    gradering: arbeidstidprosent ? { arbeidstidprosent, aktivitet: { type: 'ORDINÆRT_ARBEID' } } : undefined,
+});
+
+describe('summerDagerIPerioder – mors gradering i 3v før / 6v etter familiehendelse', () => {
+    it('skal trekke 30 fulle dager (6 uker) når mor jobbar 50 % heile seksvekersperioden etter fødsel', () => {
+        const seksUkerEtterFødsel = lagMorsMødrekvotePeriode('2024-04-01', '2024-05-10', 50);
+
+        const dager = summerDagerIPerioder([seksUkerEtterFødsel], KONTOER.kontoer, 'fødsel', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(30);
+    });
+
+    it('skal trekke 15 fulle dager (3 uker) når mor jobbar 50 % heile treukersperioden før fødsel på FORELDREPENGER_FØR_FØDSEL', () => {
+        const treUkerFørFødsel: UttakPeriode_fpoversikt = {
+            fom: '2024-03-11',
+            tom: '2024-03-29',
+            forelder: 'MOR',
+            kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+            flerbarnsdager: false,
+            gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ORDINÆRT_ARBEID' } },
+        };
+
+        const dager = summerDagerIPerioder([treUkerFørFødsel], KONTOER.kontoer, 'fødsel', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(15);
+    });
+
+    it('skal trekke gradert (halvparten av dagane) når mor jobbar 50 % utanfor vinduet', () => {
+        // 4 uker (20 uttaksdager) startar etter 6 vekers-vinduet sluttar
+        const utanforVindu = lagMorsMødrekvotePeriode('2024-05-13', '2024-06-07', 50);
+
+        const dager = summerDagerIPerioder([utanforVindu], KONTOER.kontoer, 'fødsel', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(10);
+    });
+
+    it('skal splitte korrekt når perioden delvis overlappar vinduet', () => {
+        // Periode startar 5 uker etter fødsel, varer i 4 uker (20 uttaksdager).
+        // 5 uttaksdager fell innanfor 6v-vindauget, 15 utanfor.
+        // Forventa: 5 fulle + 15 * 0.5 = 5 + 7.5 = 12.5 → floor = 12
+        const delvisOverlapp = lagMorsMødrekvotePeriode('2024-05-06', '2024-05-31', 50);
+
+        const dager = summerDagerIPerioder([delvisOverlapp], KONTOER.kontoer, 'fødsel', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(12);
+    });
+
+    it('skal IKKJE bruka spesialregel for adopsjon', () => {
+        const seksUker = lagMorsMødrekvotePeriode('2024-04-01', '2024-05-10', 50);
+
+        const dager = summerDagerIPerioder([seksUker], KONTOER.kontoer, 'adopsjon', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(15);
+    });
+
+    it('skal IKKJE bruka spesialregel for far/medmor sin gradering', () => {
+        const farsPeriode: UttakPeriode_fpoversikt = {
+            fom: '2024-04-01',
+            tom: '2024-05-10',
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'MØDREKVOTE',
+            flerbarnsdager: false,
+            gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ORDINÆRT_ARBEID' } },
+        };
+
+        const dager = summerDagerIPerioder([farsPeriode], KONTOER.kontoer, 'fødsel', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(15);
+    });
+});

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -9,10 +9,13 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksperioden } from '@navikt/fp-utils';
+import { Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../context/UttaksplanDataContext';
 import { erEøsUttakPeriode, erVanligUttakPeriode } from '../types/UttaksplanPeriode';
+
+const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
+const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
 
 export const useErAntallDagerOvertrukketIUttaksplan = () => {
     const {
@@ -20,22 +23,31 @@ export const useErAntallDagerOvertrukketIUttaksplan = () => {
         uttakPerioder,
         familiesituasjon,
         valgtStønadskonto,
+        familiehendelsedato,
     } = useUttaksplanData();
 
     if (rettighetType === 'ALENEOMSORG' || rettighetType === 'BARE_SØKER_RETT') {
         return (
-            finnAntallDagerDerKunEnHarForeldrepenger(uttakPerioder, familiesituasjon, valgtStønadskonto)
-                .antallOvertrukketDager > 0
+            finnAntallDagerDerKunEnHarForeldrepenger(
+                uttakPerioder,
+                familiesituasjon,
+                valgtStønadskonto,
+                familiehendelsedato,
+            ).antallOvertrukketDager > 0
         );
     }
 
-    return tellDagerIUttaksPeriodene(uttakPerioder, familiesituasjon, valgtStønadskonto).antallOvertrukketDager > 0;
+    return (
+        tellDagerIUttaksPeriodene(uttakPerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato)
+            .antallOvertrukketDager > 0
+    );
 };
 
 export const finnAntallDagerDerKunEnHarForeldrepenger = (
     uttakPerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     familiesituasjon: Familiesituasjon,
     valgtStønadskonto: KontoBeregningDto,
+    familiehendelsedato: string,
 ) => {
     const kvoter = ['FORELDREPENGER_FØR_FØDSEL', 'FORELDREPENGER', 'AKTIVITETSFRI_KVOTE'].map((kontoType) => {
         const aktuellKonto = valgtStønadskonto.kontoer.find((k) => k.konto === kontoType);
@@ -67,6 +79,8 @@ export const finnAntallDagerDerKunEnHarForeldrepenger = (
                 return kontoType === getUttaksKontoType(p);
             }),
             valgtStønadskonto.kontoer,
+            familiesituasjon,
+            familiehendelsedato,
         );
         const ubrukteDager = aktuellKonto.dager - brukteDager;
         const overtrukketDager = ubrukteDager * -1;
@@ -110,21 +124,24 @@ export const filtrerAvslåttePerioderMenBeholdPleiepenger = (
 };
 
 export const useTellDagerIUttaksPeriodene = () => {
-    const { uttakPerioder, familiesituasjon, valgtStønadskonto } = useUttaksplanData();
+    const { uttakPerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato } = useUttaksplanData();
 
     const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
 
-    return tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskonto);
+    return tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskonto, familiehendelsedato);
 };
 
 export const tellDagerIUttaksPeriodene = (
     uttakPerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     familiesituasjon: Familiesituasjon,
     valgtStønadskonto: KontoBeregningDto,
+    familiehendelsedato: string,
 ) => {
     const dagerBruktAvMorFørFødsel = summerDagerIPerioder(
         uttakPerioder.filter((p) => getUttaksKontoType(p) === 'FORELDREPENGER_FØR_FØDSEL'),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
     const dagerBruktAvMor = summerDagerIPerioder(
         uttakPerioder.filter(
@@ -134,6 +151,8 @@ export const tellDagerIUttaksPeriodene = (
                 (erVanligUttakPeriode(p) && p.oppholdÅrsak === 'MØDREKVOTE_ANNEN_FORELDER'),
         ),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
     const dagerBruktAvFar = summerDagerIPerioder(
         uttakPerioder.filter(
@@ -142,6 +161,8 @@ export const tellDagerIUttaksPeriodene = (
                 (erVanligUttakPeriode(p) && p.oppholdÅrsak === 'FEDREKVOTE_ANNEN_FORELDER'),
         ),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
     const dagerFellesBrukt = summerDagerIPerioder(
         uttakPerioder.filter(
@@ -150,6 +171,8 @@ export const tellDagerIUttaksPeriodene = (
                 (erVanligUttakPeriode(p) && p.oppholdÅrsak === 'FELLESPERIODE_ANNEN_FORELDER'),
         ),
         valgtStønadskonto.kontoer,
+        familiesituasjon,
+        familiehendelsedato,
     );
 
     const barnetErFødt = familiesituasjon === 'fødsel';
@@ -186,6 +209,8 @@ export const tellDagerIUttaksPeriodene = (
 export const summerDagerIPerioder = (
     perioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     konto: KontoDto[],
+    familiesituasjon: Familiesituasjon,
+    familiehendelsedato: string,
 ) => {
     const aktuelleKontotyper = new Set(
         perioder.map((p) => {
@@ -214,7 +239,7 @@ export const summerDagerIPerioder = (
             sum(
                 perioder
                     .filter((p) => 'trekkdager' in p && getUttaksKontoType(p) === aktuellKontoType)
-                    .map(finnAntallDagerÅTrekke),
+                    .map((p) => finnAntallDagerÅTrekke(p, familiesituasjon, familiehendelsedato)),
             ),
             gjeldendeKonto.dager,
         );
@@ -225,7 +250,7 @@ export const summerDagerIPerioder = (
                         (!('trekkdager' in p) && getUttaksKontoType(p) === aktuellKontoType) ||
                         harOppholdÅrsakLikKontoType(aktuellKontoType, p),
                 )
-                .map(finnAntallDagerÅTrekke),
+                .map((p) => finnAntallDagerÅTrekke(p, familiesituasjon, familiehendelsedato)),
         );
         dagerTotalt += dagerEøs + dagerNorge;
     }
@@ -270,7 +295,11 @@ const getStønadskontoTypeFromOppholdÅrsakType = (årsak: UttakOppholdÅrsak_fp
     }
 };
 
-const finnAntallDagerÅTrekke = (periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt) => {
+const finnAntallDagerÅTrekke = (
+    periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt,
+    familiesituasjon: Familiesituasjon,
+    familiehendelsedato: string,
+) => {
     if (erEøsUttakPeriode(periode)) {
         return periode.trekkdager;
     }
@@ -281,10 +310,46 @@ const finnAntallDagerÅTrekke = (periode: UttakPeriode_fpoversikt | UttakPeriode
 
     if (arbeidstidprosent) {
         const graderingsProsent = (100 - arbeidstidprosent) / 100;
+        // Mor sin gradering i tidsrommet 3 uker før / 6 uker etter familiehendelsesdato
+        // gir ikkje forlenging av stønadsperioden – dagane skal trekkjast som heile.
+        if (familiesituasjon === 'fødsel' && periode.forelder === 'MOR') {
+            const dagerIVindu = getAntallUttaksdagerIVinduRundtFødsel(
+                periode.fom,
+                periode.tom,
+                familiehendelsedato,
+            );
+            const dagerUtenforVindu = dager - dagerIVindu;
+            return dagerIVindu + dagerUtenforVindu * graderingsProsent;
+        }
         return dager * graderingsProsent;
     }
     if (samtidigUttak) {
         return dager * (samtidigUttak / 100);
     }
     return dager;
+};
+
+// Vinduet er [familiehendelsesdato - 15 uttaksdager, familiehendelsesdato + 30 uttaksdager] –
+// dvs. 3 veker før og 6 veker etter (matchar UI-validatoren).
+const getAntallUttaksdagerIVinduRundtFødsel = (
+    periodeFom: string,
+    periodeTom: string,
+    familiehendelsedato: string,
+): number => {
+    const familiehendelseSomUttaksdag = Uttaksdagen.denneEllerNeste(familiehendelsedato);
+    const førsteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TRE_UKER);
+    // getDatoAntallUttaksdagerSenere(N) returnerer den (N+1)-te uttaksdagen frå familiehendelse,
+    // så vi brukar (30 - 1) for å treffe den 30. (siste) uttaksdagen i seksvekersvinduet.
+    const sisteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerSenere(
+        ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
+    );
+
+    const overlappFom = periodeFom > førsteDagIVindu ? periodeFom : førsteDagIVindu;
+    const overlappTom = periodeTom < sisteDagIVindu ? periodeTom : sisteDagIVindu;
+
+    if (overlappFom > overlappTom) {
+        return 0;
+    }
+
+    return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
 };

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { sum, sumBy } from 'lodash';
 
 import {
@@ -10,13 +9,11 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
+import { Uttaksperioden } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../context/UttaksplanDataContext';
 import { erEøsUttakPeriode, erVanligUttakPeriode } from '../types/UttaksplanPeriode';
-
-const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
-const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
+import { getAntallUttaksdagerIVinduRundtFødsel } from './periodeUtils';
 
 export const useErAntallDagerOvertrukketIUttaksplan = () => {
     const {
@@ -328,29 +325,4 @@ const finnAntallDagerÅTrekke = (
         return dager * (samtidigUttak / 100);
     }
     return dager;
-};
-
-// Vinduet er [familiehendelsesdato - 15 uttaksdager, familiehendelsesdato + 30 uttaksdager] –
-// dvs. 3 veker før og 6 veker etter (matchar UI-validatoren).
-const getAntallUttaksdagerIVinduRundtFødsel = (
-    periodeFom: string,
-    periodeTom: string,
-    familiehendelsedato: string,
-): number => {
-    const familiehendelseSomUttaksdag = Uttaksdagen.denneEllerNeste(familiehendelsedato);
-    const førsteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TRE_UKER);
-    // getDatoAntallUttaksdagerSenere(N) returnerer den (N+1)-te uttaksdagen frå familiehendelse,
-    // så vi brukar (30 - 1) for å treffe den 30. (siste) uttaksdagen i seksvekersvinduet.
-    const sisteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerSenere(
-        ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
-    );
-
-    const overlappFom = dayjs(periodeFom).isAfter(førsteDagIVindu, 'day') ? periodeFom : førsteDagIVindu;
-    const overlappTom = dayjs(periodeTom).isBefore(sisteDagIVindu, 'day') ? periodeTom : sisteDagIVindu;
-
-    if (dayjs(overlappFom).isAfter(overlappTom, 'day')) {
-        return 0;
-    }
-
-    return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
 };

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { sum, sumBy } from 'lodash';
 
 import {
@@ -344,10 +345,10 @@ const getAntallUttaksdagerIVinduRundtFødsel = (
         ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
     );
 
-    const overlappFom = periodeFom > førsteDagIVindu ? periodeFom : førsteDagIVindu;
-    const overlappTom = periodeTom < sisteDagIVindu ? periodeTom : sisteDagIVindu;
+    const overlappFom = dayjs(periodeFom).isAfter(førsteDagIVindu, 'day') ? periodeFom : førsteDagIVindu;
+    const overlappTom = dayjs(periodeTom).isBefore(sisteDagIVindu, 'day') ? periodeTom : sisteDagIVindu;
 
-    if (overlappFom > overlappTom) {
+    if (dayjs(overlappFom).isAfter(overlappTom, 'day')) {
         return 0;
     }
 

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -11,7 +11,7 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Tidsperioden } from '@navikt/fp-utils';
+import { Tidsperioden, Uttaksdagen } from '@navikt/fp-utils';
 
 import {
     Uttaksplanperiode,
@@ -23,6 +23,34 @@ import {
 dayjs.extend(isSameOrAfter);
 dayjs.extend(minMax);
 dayjs.extend(isoWeekday);
+
+export const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
+export const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
+
+// Vinduet er [familiehendelsesdato - 15 uttaksdager, familiehendelsesdato + 30 uttaksdager] –
+// dvs. 3 veker før og 6 veker etter (matchar UI-validatoren).
+export const getAntallUttaksdagerIVinduRundtFødsel = (
+    periodeFom: string,
+    periodeTom: string,
+    familiehendelsedato: string,
+): number => {
+    const familiehendelseSomUttaksdag = Uttaksdagen.denneEllerNeste(familiehendelsedato);
+    const førsteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TRE_UKER);
+    // getDatoAntallUttaksdagerSenere(N) returnerer den (N+1)-te uttaksdagen frå familiehendelse,
+    // så vi brukar (30 - 1) for å treffe den 30. (siste) uttaksdagen i seksvekersvinduet.
+    const sisteDagIVindu = familiehendelseSomUttaksdag.getDatoAntallUttaksdagerSenere(
+        ANTALL_UTTAKSDAGER_SEKS_UKER - 1,
+    );
+
+    const overlappFom = dayjs(periodeFom).isAfter(førsteDagIVindu, 'day') ? periodeFom : førsteDagIVindu;
+    const overlappTom = dayjs(periodeTom).isBefore(sisteDagIVindu, 'day') ? periodeTom : sisteDagIVindu;
+
+    if (dayjs(overlappFom).isAfter(overlappTom, 'day')) {
+        return 0;
+    }
+
+    return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
+};
 
 export const erUttaksperiode = (periode: Uttaksplanperiode) => {
     return erVanligUttakPeriode(periode) && periode.utsettelseÅrsak === undefined;


### PR DESCRIPTION
…dsel

Mor kan kombinere foreldrepenger med delvis arbeid i tidsrommet 3 uker før termin og 6 uker etter fødsel. Det gir ikkje forlenging av stønadsperioden – foreldrepengane reduserast tilsvarande. Sperra som hindra mor i å leggja til ein gradert periode i seksvekersperioden etter fødsel er no fjerna. Brukaren får framleis ein advarsel om at dagane ikkje kan brukast seinare. Sperra for far/medmor på MØDREKVOTE er behaldt.

https://jira.adeo.no/browse/TFP-6562