### PR TITLE
vis error lokalt istedenfor å kaste videre til errorboundary

### DIFF
--- a/apps/foreldrepengeoversikt/src/Foreldrepengeoversikt.tsx
+++ b/apps/foreldrepengeoversikt/src/Foreldrepengeoversikt.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { FormattedMessage } from 'react-intl';
 
-import { Alert, Loader } from '@navikt/ds-react';
+import { Loader } from '@navikt/ds-react';
 
 import { hentSakerOptions, minidialogOptions, søkerInfoOptions } from './api/queries.ts';
+import { ErrorAlert } from './components/error-boundary/ErrorAlert';
 import { ScrollToTop } from './components/scroll-to-top/ScrollToTop';
 import { useGetBackgroundColor } from './hooks/useBackgroundColor';
 import { ForeldrepengeoversiktRoutes } from './routes/ForeldrepengeoversiktRoutes';
@@ -25,9 +26,9 @@ export const Foreldrepengeoversikt = () => {
 
     if (søkerInfoQuery.isError || sakerQuery.isError) {
         return (
-            <Alert variant="info" className="m-8 mr-auto ml-auto w-[704px]">
+            <ErrorAlert>
                 <FormattedMessage id="error.hentingInformasjon" />
-            </Alert>
+            </ErrorAlert>
         );
     }
 

--- a/apps/foreldrepengeoversikt/src/Foreldrepengeoversikt.tsx
+++ b/apps/foreldrepengeoversikt/src/Foreldrepengeoversikt.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { Loader } from '@navikt/ds-react';
+import { Alert, Loader } from '@navikt/ds-react';
 
 import { hentSakerOptions, minidialogOptions, søkerInfoOptions } from './api/queries.ts';
 import { ScrollToTop } from './components/scroll-to-top/ScrollToTop';
@@ -11,7 +11,6 @@ import { SakOppslag } from './types/SakOppslag';
 import { mapSakerDTOToSaker } from './utils/sakerUtils';
 
 export const Foreldrepengeoversikt = () => {
-    const intl = useIntl();
     const backgroundColor = useGetBackgroundColor();
 
     // Denne trenger vi ikke før senere. Men vi putter den i cache så tidlig som mulig.
@@ -25,8 +24,11 @@ export const Foreldrepengeoversikt = () => {
     });
 
     if (søkerInfoQuery.isError || sakerQuery.isError) {
-        const error = new Error(intl.formatMessage({ id: 'error.hentingInformasjon' }));
-        throw error;
+        return (
+            <Alert variant="info" className="m-8 mr-auto ml-auto w-[704px]">
+                <FormattedMessage id="error.hentingInformasjon" />
+            </Alert>
+        );
     }
 
     if (!søkerInfoQuery.data || sakerQuery.isPending) {

--- a/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorAlert.tsx
+++ b/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorAlert.tsx
@@ -1,0 +1,13 @@
+import { Alert } from '@navikt/ds-react';
+
+interface Props {
+    children: React.ReactNode;
+}
+
+export const ErrorAlert = ({ children }: Props) => {
+    return (
+        <Alert variant="error" className="m-8 mr-auto ml-auto w-[704px]">
+            {children}
+        </Alert>
+    );
+};

--- a/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorAlert.tsx
+++ b/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorAlert.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const ErrorAlert = ({ children }: Props) => {
     return (
-        <Alert variant="error" className="m-8 mr-auto ml-auto w-[704px]">
+        <Alert variant="info" className="m-8 mr-auto ml-auto w-[704px]">
             {children}
         </Alert>
     );

--- a/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorBoundary.tsx
+++ b/apps/foreldrepengeoversikt/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,8 +1,8 @@
 import { Component } from 'react';
 
-import { Alert } from '@navikt/ds-react';
-
 import { captureException } from '@navikt/fp-observability';
+
+import { ErrorAlert } from './ErrorAlert';
 
 type Props = {
     children: React.ReactNode;
@@ -28,11 +28,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
     render() {
         if (this.state.hasError) {
-            return (
-                <Alert variant="info" className="m-8 mr-auto ml-auto w-[704px]">
-                    {this.state.error?.message}
-                </Alert>
-            );
+            return <ErrorAlert>{this.state.error?.message}</ErrorAlert>;
         }
 
         return this.props.children;


### PR DESCRIPTION
Håndteringen av denne feilen slik er en oddball, og skaper sentry støy som er vanskelig å luke bort