### PR TITLE
fix: forskyv eksisterande periode som ligg heilt inni ny periode

### DIFF
--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
@@ -220,6 +220,30 @@ describe('UttakPeriodeBuilder.leggTilUttakPerioder (Forskyv)', () => {
             lagPeriode('2025-05-23', '2025-06-25'), // Eksisterende periode 1 og 2 slått sammen og forskyvd
         ]);
     });
+    it('Skal forskyve eksisterende periode som ligg heilt inni ny periode utan å produsere overlapp', () => {
+        // Sett opp nærmare produksjonscaset: ein FELLESPERIODE som startar samstundes som den nye,
+        // og ein LOVBESTEMT_FERIE heilt inni den nye. Ulik kontoType/utsettelseÅrsak hindrar
+        // at periodane vert slått saman, slik at eit eventuelt overlapp ville vere synleg.
+        const fellesperiode = { ...lagPeriode('2024-01-01', '2024-01-05'), kontoType: 'FELLESPERIODE' as const };
+        const feriePeriode = {
+            ...lagPeriode('2024-01-08', '2024-01-09'),
+            utsettelseÅrsak: 'LOVBESTEMT_FERIE' as const,
+        };
+
+        const builder = new UttakPeriodeBuilder([fellesperiode, feriePeriode]);
+
+        // Ny periode er 10 verkedagar (2024-01-01 → 2024-01-12)
+        builder.leggTilUttakPerioder([{ ...lagNyPeriode('2024-01-01', '2024-01-12') }], SKAL_FORSKYVE);
+
+        expect(builder.getUttakPerioder()).toEqual([
+            { ...lagNyPeriode('2024-01-01', '2024-01-12') },
+            // FELLESPERIODE: nFom == eFom, nTom > eTom → shift +10 verkedagar
+            { ...fellesperiode, fom: '2024-01-15', tom: '2024-01-19' },
+            // LOVBESTEMT_FERIE: heilt inni → shift +10 verkedagar (ikkje hamne på same fom som over)
+            { ...feriePeriode, fom: '2024-01-22', tom: '2024-01-23' },
+        ]);
+    });
+
     it('Skal forskyve korrekt når en legger til to like perioder', () => {
         const builder = new UttakPeriodeBuilder([
             lagPeriode('2024-07-01', '2024-07-02'),

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -347,7 +347,14 @@ const forskyvEksisterendePerioder = (
 
         const nyPeriodeStarterFørOgSlutterFørEksisterende = eFom.isAfter(nFom) && nTom.isBefore(eTom);
         const nyPeriodeStarterSamtidigOgSlutterEtterEksisterende = nFom.isSame(eFom) && nTom.isAfter(eTom);
-        if (nyPeriodeStarterFørOgSlutterFørEksisterende || nyPeriodeStarterSamtidigOgSlutterEtterEksisterende) {
+        // Eksisterande periode ligg heilt inni den nye => flytt heile perioden framover
+        const eksisterendeErHeltInniNy =
+            (eFom.isAfter(nFom) || eFom.isSame(nFom)) && (eTom.isBefore(nTom) || eTom.isSame(nTom));
+        if (
+            nyPeriodeStarterFørOgSlutterFørEksisterende ||
+            nyPeriodeStarterSamtidigOgSlutterEtterEksisterende ||
+            eksisterendeErHeltInniNy
+        ) {
             nyeUttakPerioder.push({
                 ...eksisterendePeriode,
                 fom: Uttaksdagen.denne(eksisterendePeriode.fom).getDatoAntallUttaksdagerSenere(antallUkedager),


### PR DESCRIPTION
Når ein eksisterande periode låg fullstendig inni den nye perioden (eFom >= nFom og eTom <= nTom) fall koden gjennom til fall-through-grenen i forskyvEksisterendePerioder, som sette fom til Uttaksdagen.neste(nyUttakPeriode.tom) for alle gjenverande periodar. Dette gav overlappande periodar i resultatet.

Fiksen legg til ein eksplisitt eksisterendeErHeltInniNy-sjekk som sikrar at slike periodar vert flytta +N verkedagar framover, konsistent med dei andre branchane.