### PR TITLE
Refaktor: sentraliser uttaksplan-dataflyt i UttaksplanSteg

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -51,24 +51,32 @@ type FormValues = {
 
 interface UttaksplanFormProps {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
-    defaultUttaksperioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
+    /** Den planen som faktisk vises (mellomlagra plan om den finst, ellers initiell). */
+    gjeldendeUttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
+    /** Initiell plan, brukt som fallback for lagring viss brukar ikkje har endra noko. */
+    initiellPlan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
+    /** Sann om brukar har ein mellomlagra plan i context. Styrer vis-tilbake-modal og lagringslogikk. */
+    harMellomlagretPlan: boolean;
     mellomlagreSøknadOgNaviger: () => Promise<void>;
     avbrytSøknad: () => void;
     setFeilmelding: (melding: ReactNode) => void;
     scrollToKvoteOppsummering: () => void;
     eksisterendeSak: FpSak_fpoversikt | undefined;
-    opprinneligPlan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined;
+    /** Plan henta frå eksisterande sak, brukt for å avgjere om brukar berre har sletta saksperiodar. */
+    planFraEksisterendeSak: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined;
 }
 
 export const UttaksplanForm = ({
     søkerInfo,
-    defaultUttaksperioder,
+    gjeldendeUttaksplan,
+    initiellPlan,
+    harMellomlagretPlan,
     mellomlagreSøknadOgNaviger,
     avbrytSøknad,
     setFeilmelding,
     scrollToKvoteOppsummering,
     eksisterendeSak,
-    opprinneligPlan,
+    planFraEksisterendeSak,
 }: UttaksplanFormProps) => {
     const intl = useIntl();
 
@@ -76,7 +84,6 @@ export const UttaksplanForm = ({
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
     const barn = notEmpty(useContextGetData(ContextDataType.OM_BARNET));
     const harJustertUttakVedFødsel = useContextGetData(ContextDataType.HAR_JUSTERT_UTTAK_VED_FØDSEL);
-    const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
     const vedlegg = useContextGetData(ContextDataType.VEDLEGG);
 
     const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
@@ -86,9 +93,12 @@ export const UttaksplanForm = ({
     const oppdaterVedlegg = useContextSaveData(ContextDataType.VEDLEGG);
 
     const erEndringssøknad = !!valgtEksisterendeSaksnr;
-    const uttaksplanMedKunNyePerioder =
-        uttaksplan?.filter((p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.resultat === undefined) ?? [];
-    const gjeldendeUttaksplan = erEndringssøknad ? uttaksplanMedKunNyePerioder : uttaksplan;
+
+    // I ein endringssøknad er det berre dei nye periodane (utan resultat frå vedtak) som skal brukast
+    // til validering og visning av automatisk justering.
+    const planForValideringOgVisning = erEndringssøknad
+        ? gjeldendeUttaksplan.filter((p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.resultat === undefined)
+        : gjeldendeUttaksplan;
 
     const navigator = useFpNavigator(
         søkerInfo.arbeidsforhold,
@@ -122,8 +132,11 @@ export const UttaksplanForm = ({
     const visAutomatiskJustering =
         erSøkerFarEllerMedmor &&
         søkersituasjon.situasjon === 'fødsel' &&
-        gjeldendeUttaksplan &&
-        finnPerioderRundtFødsel(gjeldendeUttaksplan, barn).filter(
+        // Bevarer eksisterande oppførsel: vis berre når brukar har gjort endringar (mellomlagra plan finst).
+        // For endringssøknad krev me i tillegg at det faktisk finst nye periodar etter filtreringa.
+        harMellomlagretPlan &&
+        (!erEndringssøknad || planForValideringOgVisning.length > 0) &&
+        finnPerioderRundtFødsel(planForValideringOgVisning, barn).filter(
             (p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.forelder === 'FAR_MEDMOR',
         ).length === 1 &&
         isUfødtBarn(barn) &&
@@ -131,8 +144,12 @@ export const UttaksplanForm = ({
         !bareFarHarRett;
 
     const onSubmit = (formValues: FormValues) => {
-        const planForValidering = gjeldendeUttaksplan ?? defaultUttaksperioder;
-        if (planForValidering.length === 0 && !harBrukerKunSlettetPerioder(uttaksplan, opprinneligPlan)) {
+        const planForValidering = planForValideringOgVisning;
+        const mellomlagretPlanForSletteSjekk = harMellomlagretPlan ? gjeldendeUttaksplan : undefined;
+        if (
+            planForValidering.length === 0 &&
+            !harBrukerKunSlettetPerioder(mellomlagretPlanForSletteSjekk, planFraEksisterendeSak)
+        ) {
             if (erEndringssøknad) {
                 setFeilmelding(<FormattedMessage id="UttaksplanSteg.IngenNyePerioder" />);
             } else {
@@ -156,8 +173,11 @@ export const UttaksplanForm = ({
                 visAutomatiskJustering ? formValues.ønskerJustertUttakVedFødsel : undefined,
             );
 
-            if (!gjeldendeUttaksplan) {
-                oppdaterUttaksplan(defaultUttaksperioder);
+            // Bevarer eksisterande oppførsel: lagre initiell plan berre om brukar ikkje har mellomlagra noko.
+            // For endringssøknad vart dette aldri trigga før (sidan filtrert plan var [] ikkje undefined),
+            // så vi held same oppførsel her.
+            if (!harMellomlagretPlan && !erEndringssøknad) {
+                oppdaterUttaksplan(initiellPlan);
             }
 
             return navigator.goToNextDefaultStep();
@@ -189,7 +209,7 @@ export const UttaksplanForm = ({
                     <VStack gap="space-16">
                         <AutomatiskJusteringInfotekst
                             harSvartJaPåAutoJustering={harSvartJaPåAutoJustering}
-                            uttaksplan={gjeldendeUttaksplan}
+                            uttaksplan={planForValideringOgVisning}
                         />
                         <RhfRadioGroup
                             name="ønskerJustertUttakVedFødsel"
@@ -217,7 +237,7 @@ export const UttaksplanForm = ({
                 )}
                 <StepButtonsHookForm
                     goToPreviousStep={
-                        uttaksplan
+                        harMellomlagretPlan
                             ? () => {
                                   setGåTilbakeIsOpen(true);
                               }

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -7,7 +7,6 @@ import { ReactNode, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
 import { getAktiveArbeidsforhold } from 'utils/arbeidsforholdUtils';
-import { erPeriodeIOpprinneligPlan } from 'utils/eksisterendeSakUtils';
 import { isFarEllerMedmor } from 'utils/isFarEllerMedmor';
 import { getErSøkerFarEllerMedmor, getKjønnFromFnr, getNavnPåForeldre } from 'utils/personUtils';
 
@@ -16,7 +15,7 @@ import { Alert, BodyLong, Tabs } from '@navikt/ds-react';
 import { loggUmamiEvent } from '@navikt/fp-observability';
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt, RettighetType_fpoversikt } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
-import { Uttaksperioden, barnehagestartDato, getFamiliehendelsedato } from '@navikt/fp-utils';
+import { barnehagestartDato, getFamiliehendelsedato } from '@navikt/fp-utils';
 import {
     FjernAltIUttaksplanModal,
     HvaErMulig,
@@ -30,8 +29,7 @@ import {
 import { notEmpty } from '@navikt/fp-validation';
 
 import { UttaksplanForm } from './UttaksplanForm';
-import { useUttaksplanForEksisterendeSak } from './hooks/useUttaksplanForEksisterendeSak';
-import { useUttaksplanForslag } from './hooks/useUttaksplanForslag';
+import { useGjeldendeUttaksplan } from './hooks/useGjeldendeUttaksplan';
 
 interface Props {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
@@ -48,11 +46,9 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
     const dekningsgrad = notEmpty(useContextGetData(ContextDataType.PERIODE_MED_FORELDREPENGER));
     const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
-    const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
-    const eksisterendeSaksnummer = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
     const oppdaterUttaksplan = useContextSaveData(ContextDataType.UTTAKSPLAN);
 
-    const eksisterendeSak = foreldrepengerSaker?.find((sak) => sak.saksnummer === eksisterendeSaksnummer);
+    const eksisterendeSak = foreldrepengerSaker?.find((sak) => sak.saksnummer === valgtEksisterendeSaksnr);
 
     const [feilmelding, setFeilmelding] = useState<ReactNode | undefined>();
 
@@ -94,35 +90,24 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
         ...annenPartVedtakOptionsWrapped,
     });
 
-    const uttaksplanForEksisterendeSak = useUttaksplanForEksisterendeSak(annenPartVedtakQuery.data?.perioder);
-
     const valgteStønadskontoer = tilgjengeligeStønadskontoerQuery.data;
 
-    // Filtrerer ut periodane til annen part midlertidig fram til me får på plass lagring av desse periodane
-    const nyttUttaksplanForslag = useUttaksplanForslag(
+    const {
+        planFraEksisterendeSak,
+        initiellPlan,
+        gjeldendeUttaksplan,
+        harMellomlagretPlan,
+        erPeriodeneTilAnnenPartLåst,
+        erPlanenEndret,
+    } = useGjeldendeUttaksplan({
         valgteStønadskontoer,
-        annenPartVedtakQuery.data?.perioder,
-    ).filter(
-        (periode) =>
-            Uttaksperioden.erIkkeEøsPeriode(periode) &&
-            periode.forelder === (erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
-    );
+        annenPartPerioder: annenPartVedtakQuery.data?.perioder,
+        erSøkerFarEllerMedmor,
+    });
 
     if (!valgteStønadskontoer || annenPartVedtakQuery.isLoading) {
         return null;
     }
-
-    const annenPartsPerioderEllerUndefined =
-        annenPartVedtakQuery.data?.perioder && annenPartVedtakQuery.data?.perioder?.length > 0
-            ? annenPartVedtakQuery.data.perioder
-            : undefined;
-    const tidligereUttaksperioder = uttaksplanForEksisterendeSak ?? annenPartsPerioderEllerUndefined;
-    const defaultUttaksperioder = tidligereUttaksperioder ?? nyttUttaksplanForslag;
-
-    const erPlanenEndret =
-        uttaksplan !== undefined &&
-        (uttaksplan.length !== defaultUttaksperioder.length ||
-            defaultUttaksperioder.some((defaultPeriode) => !erPeriodeIOpprinneligPlan(uttaksplan, defaultPeriode)));
 
     const aktiveArbeidsforhold = getAktiveArbeidsforhold(
         søkerInfo.arbeidsforhold,
@@ -152,8 +137,8 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
                     }}
                     valgtStønadskonto={valgteStønadskontoer}
                     harAktivitetskravIPeriodeUtenUttak={false}
-                    uttakPerioder={uttaksplan || defaultUttaksperioder}
-                    erPeriodeneTilAnnenPartLåst={!!tidligereUttaksperioder}
+                    uttakPerioder={gjeldendeUttaksplan}
+                    erPeriodeneTilAnnenPartLåst={erPeriodeneTilAnnenPartLåst}
                     aktiveArbeidsforhold={aktiveArbeidsforhold}
                     erEndringssøknad={erEndringssøknad}
                 >
@@ -215,9 +200,11 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
                         avbrytSøknad={avbrytSøknad}
                         setFeilmelding={setFeilmelding}
                         scrollToKvoteOppsummering={scrollToKvoteOppsummering}
-                        defaultUttaksperioder={defaultUttaksperioder}
+                        gjeldendeUttaksplan={gjeldendeUttaksplan}
+                        initiellPlan={initiellPlan}
+                        harMellomlagretPlan={harMellomlagretPlan}
                         eksisterendeSak={eksisterendeSak}
-                        opprinneligPlan={uttaksplanForEksisterendeSak}
+                        planFraEksisterendeSak={planFraEksisterendeSak}
                     />
                 </UttaksplanDataProvider>
             </Step>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useGjeldendeUttaksplan.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useGjeldendeUttaksplan.ts
@@ -1,0 +1,75 @@
+import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
+import { erPeriodeIOpprinneligPlan } from 'utils/eksisterendeSakUtils';
+
+import { KontoBeregningDto, UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { Uttaksperioden } from '@navikt/fp-utils';
+
+import { useUttaksplanForEksisterendeSak } from './useUttaksplanForEksisterendeSak';
+import { useUttaksplanForslag } from './useUttaksplanForslag';
+
+type AlleUttakPerioder = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
+
+type Args = {
+    valgteStønadskontoer: KontoBeregningDto | undefined;
+    annenPartPerioder: UttakPeriode_fpoversikt[] | undefined;
+    erSøkerFarEllerMedmor: boolean;
+};
+
+export type GjeldendeUttaksplan = {
+    /** Plan henta frå backend for ein eksisterande sak (gjeldende vedtak + annen part). undefined for ny søknad. */
+    planFraEksisterendeSak: AlleUttakPerioder[] | undefined;
+    /** Initiell plan som vert vist når brukar ikkje har gjort endringar. */
+    initiellPlan: AlleUttakPerioder[];
+    /** Den planen som faktisk skal visast: mellomlagra plan om den finst, ellers initiell. */
+    gjeldendeUttaksplan: AlleUttakPerioder[];
+    /** Indikerer om brukar har ein mellomlagra plan i context. */
+    harMellomlagretPlan: boolean;
+    /** Annen parts periodar er låste når dei kjem frå eksisterande sak eller annenPartVedtak. */
+    erPeriodeneTilAnnenPartLåst: boolean;
+    /** Sann om brukar sin mellomlagra plan skil seg frå initiellPlan. */
+    erPlanenEndret: boolean;
+};
+
+/**
+ * Samlar all logikk for å avgjere kva uttaksplan som skal visast og redigerast i UttaksplanSteg.
+ * Sentraliserer dei ulike plan-kjeldene (mellomlagring, eksisterande sak, annen part, forslag)
+ * slik at andre komponentar slepp å rekonstruere dette sjølv.
+ */
+export const useGjeldendeUttaksplan = ({
+    valgteStønadskontoer,
+    annenPartPerioder,
+    erSøkerFarEllerMedmor,
+}: Args): GjeldendeUttaksplan => {
+    const mellomlagretPlan = useContextGetData(ContextDataType.UTTAKSPLAN);
+
+    const planFraEksisterendeSak = useUttaksplanForEksisterendeSak(annenPartPerioder);
+
+    // Filtrerer ut periodane til annen part midlertidig fram til me får på plass lagring av desse periodane
+    const nyttForslag = useUttaksplanForslag(valgteStønadskontoer, annenPartPerioder).filter(
+        (periode) =>
+            Uttaksperioden.erIkkeEøsPeriode(periode) &&
+            periode.forelder === (erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
+    );
+
+    const annenPartsPerioderEllerUndefined =
+        annenPartPerioder && annenPartPerioder.length > 0 ? annenPartPerioder : undefined;
+
+    const låstePerioderFraBackend = planFraEksisterendeSak ?? annenPartsPerioderEllerUndefined;
+    const initiellPlan = låstePerioderFraBackend ?? nyttForslag;
+
+    const gjeldendeUttaksplan = mellomlagretPlan ?? initiellPlan;
+
+    const erPlanenEndret =
+        mellomlagretPlan !== undefined &&
+        (mellomlagretPlan.length !== initiellPlan.length ||
+            initiellPlan.some((initiellPeriode) => !erPeriodeIOpprinneligPlan(mellomlagretPlan, initiellPeriode)));
+
+    return {
+        planFraEksisterendeSak,
+        initiellPlan,
+        gjeldendeUttaksplan,
+        harMellomlagretPlan: mellomlagretPlan !== undefined,
+        erPeriodeneTilAnnenPartLåst: !!låstePerioderFraBackend,
+        erPlanenEndret,
+    };
+};


### PR DESCRIPTION
Innfører hook useGjeldendeUttaksplan som samlar logikken for å avgjere kva uttaksplan som skal visast (mellomlagra, frå eksisterande sak, annen part eller nytt forslag).

UttaksplanSteg får eit klart datagrunnlag og UttaksplanForm tek imot gjeldendeUttaksplan, initiellPlan, harMellomlagretPlan og planFraEksisterendeSak som props i staden for å rekonstruere desse sjølv frå context. Det fjernar dobbel utleiing av same verdi i Steg og Form og gjer dataflyten lettare å lese.

Tydelegare namnsetjing:
- defaultUttaksperioder -> initiellPlan
- tidligereUttaksperioder -> låstePerioderFraBackend (intern i hook)
- opprinneligPlan / uttaksplanForEksisterendeSak -> planFraEksisterendeSak

Eksisterande oppførsel er bevart, inkludert dei subtile særreglane for endringssøknad i onSubmit.