### PR TITLE
Tillat periode som krysser familiehendelsedato når kun far har rett

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -122,7 +122,11 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
     const morSøkerOmOverføring = kontoTypeMor === 'FEDREKVOTE' && forelder === 'MOR';
     const farMedmorSøkerOmOverføring = kontoTypeFarMedmor === 'MØDREKVOTE' && forelder === 'FAR_MEDMOR';
 
+    const kunFarHarRett =
+        søker === 'FAR_MEDMOR' && (rettighetType === 'BARE_SØKER_RETT' || rettighetType === 'ALENEOMSORG');
+
     const erValgtePerioderKrysserFamiliehendelse =
+        !kunFarHarRett &&
         UttaksperiodeValidatorer.erNoenPerioderFørOgNoenLikEllerEtterFamiliehendelsesdato(
             valgtePerioder,
             familiehendelsedato,

--- a/packages/uttaksplan/src/felles/useHentGyldigeKontotyper.test.tsx
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKontotyper.test.tsx
@@ -451,14 +451,55 @@ describe('useHentGyldigeKontotyper - fars kvoter', () => {
         expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
     });
 
-    it('skal ikke ha gyldige perioder for far når én periode krysser familiehendelsedato', () => {
+    it('skal tillate periode som krysser familiehendelsedato for far når kun far har rett', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKontotyper([{ fom: '2024-06-13', tom: '2024-06-21' }], !HAR_VALGT_SAMTIDIG_UTTAK, false),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'FAR_MEDMOR',
+                        rettighetType: 'BARE_SØKER_RETT',
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                        erMedmorDelAvSøknaden: false,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForFarMedmor.length).toBeGreaterThan(0);
+    });
+
+    it('skal tillate perioder både før og etter familiehendelsedato for far når kun far har rett', () => {
         const { result } = renderHook(
             () =>
                 useHentGyldigeKontotyper(
-                    [{ fom: '2024-06-13', tom: '2024-06-21' }],
+                    [
+                        { fom: '2024-06-03', tom: '2024-06-14' },
+                        { fom: '2024-06-20', tom: '2024-06-21' },
+                    ],
                     !HAR_VALGT_SAMTIDIG_UTTAK,
                     false,
                 ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'FAR_MEDMOR',
+                        rettighetType: 'BARE_SØKER_RETT',
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                        erMedmorDelAvSøknaden: false,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForFarMedmor.length).toBeGreaterThan(0);
+    });
+
+    it('skal ikke ha gyldige perioder for far når én periode krysser familiehendelsedato', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKontotyper([{ fom: '2024-06-13', tom: '2024-06-21' }], !HAR_VALGT_SAMTIDIG_UTTAK, false),
             {
                 wrapper: getWrapper({
                     foreldreInfo: {

--- a/packages/uttaksplan/src/felles/useHentGyldigeKontotyper.ts
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKontotyper.ts
@@ -173,6 +173,9 @@ const erGyldigForFarMedmor = (
         return false;
     }
 
+    const kunFarHarRett =
+        søker === 'FAR_MEDMOR' && (rettighetType === 'BARE_SØKER_RETT' || rettighetType === 'ALENEOMSORG');
+
     if (
         familiesituasjon === 'adopsjon' &&
         UttaksperiodeValidatorer.erNoenPerioderFørFamiliehendelsesdato(valgtePerioder, familiehendelsedato)
@@ -181,6 +184,7 @@ const erGyldigForFarMedmor = (
     }
 
     if (
+        !kunFarHarRett &&
         UttaksperiodeValidatorer.erNoenPerioderFørOgNoenLikEllerEtterFamiliehendelsesdato(
             valgtePerioder,
             familiehendelsedato,


### PR DESCRIPTION
Når kun far har rett (BARE_SØKER_RETT eller ALENEOMSORG med søker FAR_MEDMOR) er det ingen mor-kvote som ligg fast rundt familiehendelsedatoen, og far skal kunne velje perioder som krysser datoen.