### PR TITLE
Deaktiver forskyving for graderte periodar i dei 6 første vekene ette…

### DIFF
--- a/packages/uttaksplan/src/felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel.tsx
+++ b/packages/uttaksplan/src/felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel.tsx
@@ -11,6 +11,7 @@ import { erDetReadonlyPerioderEtterValgtePerioder } from '../../utils/periodeUti
 interface Props {
     valgtePerioder: Array<{ fom: string; tom: string }>;
     erFerie: boolean;
+    erGradert: boolean;
     setVisEndreEllerForskyvPanel: (skalVisPanel: boolean) => void;
     leggTilEllerForskyvPeriode: (skalForskyve: boolean) => void;
 }
@@ -18,6 +19,7 @@ interface Props {
 export const LeggTilPeriodeForskyvEllerErstattPanel = ({
     valgtePerioder,
     erFerie,
+    erGradert,
     setVisEndreEllerForskyvPanel,
     leggTilEllerForskyvPeriode,
 }: Props) => {
@@ -32,12 +34,13 @@ export const LeggTilPeriodeForskyvEllerErstattPanel = ({
     const [skalForskyvePeriode, setSkalForskyvePeriode] = useState<boolean | undefined>(undefined);
 
     const harPeriodeFørFamiliehendelsedato = valgtePerioder.some((p) => dayjs(p.fom).isBefore(familiehendelsedato));
-    const harPeriodeFørSeksUkerEtterFamiliehendelsedato = erFerie
-        ? UttaksperiodeValidatorer.erNoenPerioderFørSeksUkerEtterFamiliehendelsesdato(
-              valgtePerioder,
-              familiehendelsedato,
-          )
-        : false;
+    const harPeriodeFørSeksUkerEtterFamiliehendelsedato =
+        erFerie || erGradert
+            ? UttaksperiodeValidatorer.erNoenPerioderFørSeksUkerEtterFamiliehendelsesdato(
+                  valgtePerioder,
+                  familiehendelsedato,
+              )
+            : false;
 
     const forelderSomHarLåstePerioder = erPeriodeneTilAnnenPartLåst
         ? søker === 'MOR'

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -146,6 +146,7 @@ export const HvaVilDuEndreTilPanel = ({ åpneRedigeringsmodus, labels }: Props) 
                     <LeggTilPeriodeForskyvEllerErstattPanel
                         valgtePerioder={sammenslåtteValgtePerioder}
                         erFerie
+                        erGradert={false}
                         setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                         leggTilEllerForskyvPeriode={leggTilEllerForskyvPeriode}
                     />

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -62,6 +62,8 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
         defaultValues,
     });
 
+    const skalDuKombinereArbeidOgUttakMor = formMethods.watch('skalDuKombinereArbeidOgUttakMor');
+
     const formSubmitValidator = useFormSubmitValidator<LeggTilEllerEndrePeriodeFormFormValues>();
 
     const resetFormValuesVedEndringAvForelder = (forelder: BrukerRolleSak_fpoversikt | 'BEGGE' | undefined) => {
@@ -143,6 +145,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
                 <LeggTilPeriodeForskyvEllerErstattPanel
                     valgtePerioder={sammenslåtteValgtePerioder}
                     erFerie={false}
+                    erGradert={skalDuKombinereArbeidOgUttakMor === true}
                     setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                     leggTilEllerForskyvPeriode={leggIKalender}
                 />

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -67,20 +67,20 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
 
     const formSubmitValidator = useFormSubmitValidator<LeggTilEllerEndrePeriodeFormFormValues>();
 
-    const resetFormValuesVedEndringAvForelder = (forelder: BrukerRolleSak_fpoversikt | 'BEGGE' | undefined) => {
+    const resetFormValuesVedEndringAvForelder = (forelderVerdi: BrukerRolleSak_fpoversikt | 'BEGGE' | undefined) => {
         const erFarMedmorLåst = erPeriodeneTilAnnenPartLåst && søker === 'MOR';
         const erMorLåst = erPeriodeneTilAnnenPartLåst && søker === 'FAR_MEDMOR';
 
-        if (forelder === 'BEGGE' && (erFarMedmorLåst || erMorLåst)) {
+        if (forelderVerdi === 'BEGGE' && (erFarMedmorLåst || erMorLåst)) {
             const nyeDefaultVerdier = lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm(
                 uttakPerioder,
                 sammenslåtteValgtePerioder[0]!,
                 søker,
                 false,
             );
-            formMethods.reset({ ...nyeDefaultVerdier, forelder });
+            formMethods.reset({ ...nyeDefaultVerdier, forelder: forelderVerdi });
         } else {
-            formMethods.reset({ forelder });
+            formMethods.reset({ forelder: forelderVerdi });
         }
     };
 

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -63,6 +63,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
     });
 
     const skalDuKombinereArbeidOgUttakMor = formMethods.watch('skalDuKombinereArbeidOgUttakMor');
+    const forelder = formMethods.watch('forelder');
 
     const formSubmitValidator = useFormSubmitValidator<LeggTilEllerEndrePeriodeFormFormValues>();
 
@@ -145,7 +146,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
                 <LeggTilPeriodeForskyvEllerErstattPanel
                     valgtePerioder={sammenslåtteValgtePerioder}
                     erFerie={false}
-                    erGradert={skalDuKombinereArbeidOgUttakMor === true}
+                    erGradert={skalDuKombinereArbeidOgUttakMor === true && (forelder === 'MOR' || forelder === 'BEGGE')}
                     setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                     leggTilEllerForskyvPeriode={leggIKalender}
                 />

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -101,6 +101,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const hvaVilDuGjøre = formMethods.watch('hvaVilDuGjøre');
     const forelder = formMethods.watch('forelder');
     const ønskerFlerbarnsdager = formMethods.watch('ønskerFlerbarnsdager');
+    const skalDuKombinereArbeidOgUttakMor = formMethods.watch('skalDuKombinereArbeidOgUttakMor');
 
     const { visEndreEllerForskyvPanel, setVisEndreEllerForskyvPanel } = useVisForskyvEllerErstattPanel(
         fomValue && tomValue
@@ -348,6 +349,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                     <LeggTilPeriodeForskyvEllerErstattPanel
                         valgtePerioder={[{ fom: fomValue, tom: tomValue }]}
                         erFerie={hvaVilDuGjøre === 'LEGG_TIL_FERIE'}
+                        erGradert={hvaVilDuGjøre === 'LEGG_TIL_PERIODE' && skalDuKombinereArbeidOgUttakMor === true}
                         setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                         leggTilEllerForskyvPeriode={leggIListe}
                     />

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -349,7 +349,11 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                     <LeggTilPeriodeForskyvEllerErstattPanel
                         valgtePerioder={[{ fom: fomValue, tom: tomValue }]}
                         erFerie={hvaVilDuGjøre === 'LEGG_TIL_FERIE'}
-                        erGradert={hvaVilDuGjøre === 'LEGG_TIL_PERIODE' && skalDuKombinereArbeidOgUttakMor === true}
+                        erGradert={
+                            hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
+                            (forelder === 'MOR' || forelder === 'BEGGE') &&
+                            skalDuKombinereArbeidOgUttakMor === true
+                        }
                         setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                         leggTilEllerForskyvPeriode={leggIListe}
                     />


### PR DESCRIPTION
…r fødsel

Når mor legg inn ein gradert periode (delvis arbeid) som har minimum éin dag innanfor dei 6 første vekene etter fødsel, skal ein ikkje kunne velja å forskyva eksisterande periodar. Ein kan berre overskriva.

Denne regelen gjeld allereie for ferie, og er no utvida til å også gjelda for graderte periodar.