### PR TITLE
fix: vis mors aktivitetskrav for FORELDREPENGER ved samtidig uttak

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -654,7 +654,9 @@ const getSkalViseMorsAktivitetskravVedSamtidigUttak = (
     }
 
     const skalViseMorsAktivitetskravVedSamtidigUttak =
-        forelder === 'BEGGE' && kontoTypeFarMedmor === 'FELLESPERIODE' && morsTotaleProsent < 100;
+        forelder === 'BEGGE' &&
+        (kontoTypeFarMedmor === 'FELLESPERIODE' || kontoTypeFarMedmor === 'FORELDREPENGER') &&
+        morsTotaleProsent < 100;
 
     return skalViseMorsAktivitetskravVedSamtidigUttak;
 };

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
@@ -255,7 +255,7 @@ const erUgyldigSamtidigUttak = <T extends LeggTilEllerEndrePeriodeFormFormValues
 
     if (
         kombinertUttaksprosent === 100 &&
-        kontoTypeFarMedmor === 'FELLESPERIODE' &&
+        (kontoTypeFarMedmor === 'FELLESPERIODE' || kontoTypeFarMedmor === 'FORELDREPENGER') &&
         totalProsentMor !== 100 &&
         !morsAktivitet
     ) {

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -100,4 +100,53 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
 
         expect(result).toBe(false);
     });
+
+    it('skal returnere true når far har FORELDREPENGER uten morsAktivitet', () => {
+        const perioder = [lagFarPeriode({ kontoType: 'FORELDREPENGER' })];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(true);
+    });
+
+    it('skal returnere false når far har FORELDREPENGER med morsAktivitet satt', () => {
+        const perioder = [lagFarPeriode({ kontoType: 'FORELDREPENGER', morsAktivitet: 'ARBEID' })];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(false);
+    });
+
+    it('skal returnere false når far har FORELDREPENGER og overlappende mor har 100% total', () => {
+        const perioder = [
+            lagFarPeriode({ kontoType: 'FORELDREPENGER', samtidigUttak: 50 }),
+            lagMorPeriode({
+                samtidigUttak: 50,
+                gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ANNET' } },
+            }),
+        ];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(false);
+    });
+
+    it('skal returnere true når far har FORELDREPENGER og overlappende mor har under 100% total', () => {
+        const perioder = [
+            lagFarPeriode({ kontoType: 'FORELDREPENGER', samtidigUttak: 50 }),
+            lagMorPeriode({ samtidigUttak: 50 }),
+        ];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(true);
+    });
+
+    it('skal returnere false når far har FEDREKVOTE uten morsAktivitet', () => {
+        const perioder = [lagFarPeriode({ kontoType: 'FEDREKVOTE' })];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(false);
+    });
 });


### PR DESCRIPTION
getSkalViseMorsAktivitetskravVedSamtidigUttak og erUgyldigSamtidigUttak sjekket kun FELLESPERIODE som kontotype, mens post-lagring-validatoren harPeriodeDerMorsAktivitetIkkeErValgt korrekt sjekker både FELLESPERIODE og FORELDREPENGER. Dette ga en deadlock der spørsmålet om mors aktivitet aldri ble vist i skjemaet, men valideringen blokkerte innsending.

Fikser ved å legge til FORELDREPENGER-sjekk i både skjemavisning og skjemavalidering, slik at de er konsistente med post-lagring-validatoren.