### PR TITLE
TFP-6933: Tillat FORELDREPENGER før termin når mor er alene

### DIFF
--- a/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
@@ -338,7 +338,7 @@ describe('useHentGyldigeKvotetyper - mors kvoter', () => {
             },
         );
 
-        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['MØDREKVOTE', 'FORELDREPENGER_FØR_FØDSEL']);
+        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['FORELDREPENGER_FØR_FØDSEL']);
     });
 
     it('skal ikke ha foreldrepenger som gyldig kontotype for mor med aleneomsorg i treukersperioden før fødsel', () => {
@@ -361,7 +361,7 @@ describe('useHentGyldigeKvotetyper - mors kvoter', () => {
             },
         );
 
-        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['MØDREKVOTE', 'FORELDREPENGER_FØR_FØDSEL']);
+        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['FORELDREPENGER_FØR_FØDSEL']);
     });
 
     it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn 60 dager før fødsel', () => {

--- a/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
@@ -271,6 +271,75 @@ describe('useHentGyldigeKvotetyper - mors kvoter', () => {
 
         expect(result.current.gyldigeStønadskontoerForMor).toEqual(['MØDREKVOTE', 'FORELDREPENGER']);
     });
+
+    it('skal ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn tre uker før fødsel', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKvotetyper(
+                    [{ fom: '2024-04-22', tom: '2024-05-24' }],
+                    !HAR_VALGT_SAMTIDIG_UTTAK,
+                    false,
+                ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'MOR',
+                        rettighetType: 'BARE_SØKER_RETT',
+                        erMedmorDelAvSøknaden: false,
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForMor).toContain('FORELDREPENGER');
+    });
+
+    it('skal ha foreldrepenger som gyldig kontotype for mor med aleneomsorg og perioden er mer enn tre uker før fødsel', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKvotetyper(
+                    [{ fom: '2024-04-22', tom: '2024-05-24' }],
+                    !HAR_VALGT_SAMTIDIG_UTTAK,
+                    false,
+                ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'MOR',
+                        rettighetType: 'ALENEOMSORG',
+                        erMedmorDelAvSøknaden: false,
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForMor).toContain('FORELDREPENGER');
+    });
+
+    it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn 60 dager før fødsel', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKvotetyper(
+                    [{ fom: '2024-03-24', tom: '2024-05-24' }],
+                    !HAR_VALGT_SAMTIDIG_UTTAK,
+                    false,
+                ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'MOR',
+                        rettighetType: 'BARE_SØKER_RETT',
+                        erMedmorDelAvSøknaden: false,
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForMor).not.toContain('FORELDREPENGER');
+    });
 });
 
 describe('useHentGyldigeKvotetyper - fars kvoter', () => {

--- a/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.test.tsx
@@ -318,6 +318,52 @@ describe('useHentGyldigeKvotetyper - mors kvoter', () => {
         expect(result.current.gyldigeStønadskontoerForMor).toContain('FORELDREPENGER');
     });
 
+    it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett i treukersperioden før fødsel', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKvotetyper(
+                    [{ fom: '2024-05-27', tom: '2024-06-14' }],
+                    !HAR_VALGT_SAMTIDIG_UTTAK,
+                    false,
+                ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'MOR',
+                        rettighetType: 'BARE_SØKER_RETT',
+                        erMedmorDelAvSøknaden: false,
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['MØDREKVOTE', 'FORELDREPENGER_FØR_FØDSEL']);
+    });
+
+    it('skal ikke ha foreldrepenger som gyldig kontotype for mor med aleneomsorg i treukersperioden før fødsel', () => {
+        const { result } = renderHook(
+            () =>
+                useHentGyldigeKvotetyper(
+                    [{ fom: '2024-05-27', tom: '2024-06-14' }],
+                    !HAR_VALGT_SAMTIDIG_UTTAK,
+                    false,
+                ),
+            {
+                wrapper: getWrapper({
+                    foreldreInfo: {
+                        søker: 'MOR',
+                        rettighetType: 'ALENEOMSORG',
+                        erMedmorDelAvSøknaden: false,
+                        navnPåForeldre: NAVN_PÅ_FORELDRE,
+                    },
+                }),
+            },
+        );
+
+        expect(result.current.gyldigeStønadskontoerForMor).toEqual(['MØDREKVOTE', 'FORELDREPENGER_FØR_FØDSEL']);
+    });
+
     it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn 60 dager før fødsel', () => {
         const { result } = renderHook(
             () =>

--- a/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.ts
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.ts
@@ -119,6 +119,16 @@ const erGyldigForMor = (
         ) {
             return false;
         }
+
+        if (
+            harKunEnPartRett &&
+            UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletTreUkerFørFamDatoOgFamDato(
+                valgtePerioder,
+                familiehendelsedato,
+            )
+        ) {
+            return false;
+        }
     }
 
     if (konto === 'FORELDREPENGER_FØR_FØDSEL') {

--- a/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.ts
+++ b/packages/uttaksplan/src/felles/useHentGyldigeKvotetyper.ts
@@ -112,7 +112,10 @@ const erGyldigForMor = (
 
         if (
             harKunEnPartRett &&
-            UttaksperiodeValidatorer.erNoenPerioderFørFamiliehendelsesdato(valgtePerioder, familiehendelsedato)
+            UttaksperiodeValidatorer.erNoenPerioderMerEnn60DagerFørFamiliehendelsesdato(
+                valgtePerioder,
+                familiehendelsedato,
+            )
         ) {
             return false;
         }


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6933

Når mor har ALENEOMSORG eller BARE_SØKER_RETT ble FORELDREPENGER blokkert for alle perioder før familiehendelsesdato. Dette gjorde at mor kun kunne starte uttak 3 uker før termin (via FORELDREPENGER_FØR_FØDSEL), i stedet for opptil 12 uker (60 uttaksdager) som reglene tilsier.

Endrer validering fra erNoenPerioderFørFamiliehendelsesdato til erNoenPerioderMerEnn60DagerFørFamiliehendelsesdato for FORELDREPENGER når harKunEnPartRett, tilsvarende FELLESPERIODE i delt uttak.