### PR TITLE
TFP-6964: ekskluder fri utsettelse fra dagtellingen i uttaksplanen

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.test.tsx
@@ -884,4 +884,78 @@ describe('useUttaksplanForEksisterendeSak', () => {
             },
         ]);
     });
+
+    // TFP-6964: Fri utsettelse frå annen part (pleiepenger etter termin) skal filtrerast bort
+    it('testcase 9 - fri utsettelse frå annen part skal fjernast', () => {
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-10-01',
+                tom: '2025-12-10',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+            // Fri utsettelse frå mor (pga pleiepenger) - skal fjernast
+            {
+                fom: '2025-12-11',
+                tom: '2026-02-15',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                utsettelseÅrsak: 'FRI',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-03-01',
+                tom: '2026-06-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const saker: Saker_fpoversikt = {
+            engangsstønad: [],
+            svangerskapspenger: [],
+            foreldrepenger: [
+                {
+                    saksnummer: SAKSNUMMER,
+                    familiehendelse: { antallBarn: 1, fødselsdato: '2025-10-01' },
+                    forelder: 'FAR_MEDMOR',
+                    gjelderAdopsjon: false,
+                    kanSøkeOmEndring: true,
+                    morUføretrygd: false,
+                    oppdatertTidspunkt: '2025-01-01T00:00:00',
+                    rettighetType: 'BEGGE_RETT',
+                    sakAvsluttet: false,
+                    sakTilhørerMor: false,
+                    gjeldendeVedtak: { perioder: perioderSøker },
+                },
+            ],
+        };
+
+        const { result } = renderHook(() => useUttaksplanForEksisterendeSak(perioderAnnenPart), {
+            wrapper: getWrapper(saker),
+        });
+
+        // Fri utsettelse frå annen part skal vere fjerna
+        expect(result.current).toEqual([
+            {
+                fom: '2025-10-01',
+                tom: '2025-12-10',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-03-01',
+                tom: '2026-06-01',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
 });

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -54,7 +54,12 @@ export const useUttaksplanForEksisterendeSak = (
     );
     const processedAnnenPart = trimmedAnnenPart
         ? slåSammenTilstøtande(
-              fjernOverlappUtenSamtidigUttak(midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef), søkerRef),
+              fjernFrieUtsettelser(
+                  fjernOverlappUtenSamtidigUttak(
+                      midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef),
+                      søkerRef,
+                  ),
+              ),
           )
         : [];
 

--- a/packages/uttaksplan/src/KvoteOppsummering.stories.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.stories.tsx
@@ -773,6 +773,138 @@ export const BeggeRettMangeOvertrukneDagerMedOverføringsÅrsak: Story = {
     },
 };
 
+// TFP-6964: Fri utsettelse med pleiepenger etter termin skal ikkje teljast som brukte dagar
+export const BeggeRettMedFriUtsettelseAnnenPart: Story = {
+    name: 'Fri utsettelse frå annen part skal ikkje teljast',
+    args: {
+        valgtStønadskvote: kontoNårBeggeHarRett,
+        barn: {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2025-05-06'],
+            antallBarn: 1,
+        },
+        uttakPerioder: [
+            {
+                fom: '2025-04-15',
+                tom: '2025-05-05',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: true,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-05-06',
+                tom: '2025-08-18',
+                kontoType: 'MØDREKVOTE',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: true,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            // Denne "fri utsettelse"-perioden frå mor (pga pleiepenger) skal IKKJE teljast
+            {
+                fom: '2025-08-19',
+                tom: '2025-11-28',
+                kontoType: 'MØDREKVOTE',
+                utsettelseÅrsak: 'FRI',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: false,
+                    trekkerDager: false,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-12-01',
+                tom: '2026-03-13',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+        ],
+        foreldreInfo: {
+            ...DEFAULT_FORELDRE_INFO,
+            rettighetType: 'BEGGE_RETT',
+            søker: 'FAR_MEDMOR',
+        },
+        erEndringssøknad: false,
+    },
+};
+
+// TFP-6964: Variant der trekkerDager er undefined (kan skje med eldre vedtak)
+export const BeggeRettMedFriUtsettelseUtenTrekkerDager: Story = {
+    name: 'Fri utsettelse utan trekkerDager-flagg skal ikkje teljast',
+    args: {
+        valgtStønadskvote: kontoNårBeggeHarRett,
+        barn: {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2025-05-06'],
+            antallBarn: 1,
+        },
+        uttakPerioder: [
+            {
+                fom: '2025-04-15',
+                tom: '2025-05-05',
+                kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: true,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-05-06',
+                tom: '2025-08-18',
+                kontoType: 'MØDREKVOTE',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: true,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            // Fri utsettelse utan resultat (eldre vedtak kan mangle dette feltet)
+            {
+                fom: '2025-08-19',
+                tom: '2025-11-28',
+                kontoType: 'MØDREKVOTE',
+                utsettelseÅrsak: 'FRI',
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-12-01',
+                tom: '2026-03-13',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+        ],
+        foreldreInfo: {
+            ...DEFAULT_FORELDRE_INFO,
+            rettighetType: 'BEGGE_RETT',
+            søker: 'FAR_MEDMOR',
+        },
+        erEndringssøknad: false,
+    },
+};
+
 export const BHFRMedAvslåttePerioder: Story = {
     args: {
         valgtStønadskvote: kontoNårBareFarHarRett,

--- a/packages/uttaksplan/src/KvoteOppsummering.test.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.test.tsx
@@ -17,6 +17,8 @@ const {
     BeggeRettMorIngenDagerBrukt,
     MorHarPrematuruker,
     BeggeRettMangeOvertrukneDagerMedOverføringsÅrsak,
+    BeggeRettMedFriUtsettelseAnnenPart,
+    BeggeRettMedFriUtsettelseUtenTrekkerDager,
     BHFRMedAvslåttePerioder,
 } = composeStories(stories);
 
@@ -156,5 +158,31 @@ describe('<KvoteOppsummering >', () => {
         await userEvent.click(expandButton);
 
         expect(screen.getByText('8 uker og 1 dag er lagt til, 21 uker og 4 dager gjenstår')).toBeInTheDocument();
+    });
+
+    it('TFP-6964: Fri utsettelse frå annen part (pleiepenger) skal ikkje teljast som brukte dagar', async () => {
+        render(<BeggeRettMedFriUtsettelseAnnenPart />);
+
+        // Utan fixen ville dette vist "for mange dager" fordi fri utsettelse-perioden vart telt
+        expect(screen.queryByText(/for mye/)).not.toBeInTheDocument();
+
+        const expandButton = screen.getByRole('button', { expanded: false });
+        await userEvent.click(expandButton);
+
+        // Mødrekvote og fedrekvote har begge 75 dagar (15 uker) og begge er fylte
+        expect(screen.getAllByText('15 uker er lagt til')).toHaveLength(2);
+    });
+
+    it('TFP-6964: Fri utsettelse utan trekkerDager-flagg skal heller ikkje teljast', async () => {
+        render(<BeggeRettMedFriUtsettelseUtenTrekkerDager />);
+
+        // Sjølv om trekkerDager er undefined, skal utsettelseperiodar ikkje teljast
+        expect(screen.queryByText(/for mye/)).not.toBeInTheDocument();
+
+        const expandButton = screen.getByRole('button', { expanded: false });
+        await userEvent.click(expandButton);
+
+        // Mødrekvote og fedrekvote har begge 75 dagar (15 uker) og begge er fylte
+        expect(screen.getAllByText('15 uker er lagt til')).toHaveLength(2);
     });
 });

--- a/packages/uttaksplan/src/KvoteOppsummering.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.tsx
@@ -16,7 +16,7 @@ import { useUttaksplanData } from './context/UttaksplanDataContext';
 import { erVanligUttakPeriode } from './types/UttaksplanPeriode';
 import { getVarighetString } from './utils/dateUtils';
 import {
-    filtrerAvslåttePerioderMenBeholdPleiepenger,
+    filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger,
     finnAntallDagerDerKunEnHarForeldrepenger,
     getUttaksKontoType,
     summerDagerIPerioder,
@@ -83,7 +83,7 @@ const KvoteTittelKunEnHarForeldrepenger = ({
     const intl = useIntl();
     const { uttakPerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const { antallBrukteDager, antallOvertrukketDager, antallUbrukteDager } = finnAntallDagerDerKunEnHarForeldrepenger(
         filtrertePerioder,
@@ -160,7 +160,7 @@ const KvoteTittel = ({
     const { foreldreInfo, uttakPerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato } =
         useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const {
         antallOvertrukketDager,
@@ -412,7 +412,7 @@ const TittelKomponent = ({
 const ForeldrepengerFørFødselKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
     const { uttakPerioder, valgtStønadskvote } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const relevantePerioder = filtrertePerioder.filter((p) => getUttaksKontoType(p) === 'FORELDREPENGER_FØR_FØDSEL');
     const relevantKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'FORELDREPENGER_FØR_FØDSEL');
@@ -422,7 +422,7 @@ const ForeldrepengerFørFødselKvoter = ({ visStatusIkoner }: { visStatusIkoner:
 const KunEnHarForeldrepengeKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
     const { uttakPerioder, valgtStønadskvote } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const relevantKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'FORELDREPENGER');
     const relevantePerioder = filtrertePerioder.filter(
@@ -436,7 +436,7 @@ const KunEnHarForeldrepengeKvoter = ({ visStatusIkoner }: { visStatusIkoner: boo
 const FedreKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
     const { uttakPerioder, valgtStønadskvote } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const relevantKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'FEDREKVOTE');
     const relevantePerioder = filtrertePerioder.filter(
@@ -453,7 +453,7 @@ const AktivitetsfriKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) 
 
     const relevantKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'AKTIVITETSFRI_KVOTE');
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const relevantePerioder = filtrertePerioder.filter((p) => {
         // I planlegger og søknad brukes denne kontoen på periodene.
@@ -471,7 +471,7 @@ const AktivitetsfriKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) 
 const MødreKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
     const { uttakPerioder, valgtStønadskvote } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     const relevantKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'MØDREKVOTE');
     const relevantePerioder = filtrertePerioder.filter(
@@ -489,7 +489,7 @@ const FellesKvoter = ({ visStatusIkoner }: { visStatusIkoner: boolean }) => {
 
     const forelder = foreldreInfo.søker;
     const fellesKonto = valgtStønadskvote.kontoer.find((k) => k.konto === 'FELLESPERIODE');
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     if (!fellesKonto) {
         return null;

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -24,7 +24,7 @@ export const useErAntallDagerOvertrukketIUttaksplan = () => {
         familiehendelsedato,
     } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     if (rettighetType === 'ALENEOMSORG' || rettighetType === 'BARE_SØKER_RETT') {
         return (
@@ -113,7 +113,7 @@ export const finnAntallDagerDerKunEnHarForeldrepenger = (
     };
 };
 
-export const filtrerAvslåttePerioderMenBeholdPleiepenger = (
+export const filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger = (
     periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt,
 ) => {
     if (erEøsUttakPeriode(periode)) {
@@ -131,7 +131,7 @@ export const filtrerAvslåttePerioderMenBeholdPleiepenger = (
 export const useTellDagerIUttaksPeriodene = () => {
     const { uttakPerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato } = useUttaksplanData();
 
-    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+    const filtrertePerioder = uttakPerioder.filter(filtrerBortUtsettelserOgAvslåttePerioderMenBeholdPleiepenger);
 
     return tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato);
 };

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -24,10 +24,12 @@ export const useErAntallDagerOvertrukketIUttaksplan = () => {
         familiehendelsedato,
     } = useUttaksplanData();
 
+    const filtrertePerioder = uttakPerioder.filter(filtrerAvslåttePerioderMenBeholdPleiepenger);
+
     if (rettighetType === 'ALENEOMSORG' || rettighetType === 'BARE_SØKER_RETT') {
         return (
             finnAntallDagerDerKunEnHarForeldrepenger(
-                uttakPerioder,
+                filtrertePerioder,
                 familiesituasjon,
                 valgtStønadskvote,
                 familiehendelsedato,
@@ -36,7 +38,7 @@ export const useErAntallDagerOvertrukketIUttaksplan = () => {
     }
 
     return (
-        tellDagerIUttaksPeriodene(uttakPerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato)
+        tellDagerIUttaksPeriodene(filtrertePerioder, familiesituasjon, valgtStønadskvote, familiehendelsedato)
             .antallOvertrukketDager > 0
     );
 };
@@ -116,6 +118,11 @@ export const filtrerAvslåttePerioderMenBeholdPleiepenger = (
 ) => {
     if (erEøsUttakPeriode(periode)) {
         return true;
+    }
+
+    // Utsettelseperiodar trekker ikkje dagar frå kvoten og skal ikkje reknast med.
+    if (periode.utsettelseÅrsak !== undefined && periode.resultat?.årsak !== 'AVSLAG_FRATREKK_PLEIEPENGER') {
+        return false;
     }
 
     return periode.resultat?.trekkerDager ?? true;


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6964

 Fri utsettelse-perioder registrert på mors vedtak (typisk pga
 pleiepenger etter termin) ble feilaktig telt som forbrukte kvotedager.
 Dette førte til at far fikk feilmeldingen "du har lagt inn for mange
 dager" ved søknad.

 Endringer:
 - Filtrer ut utsettelsesperioder fra dagtellingen, med unntak for perioder med AVSLAG_FRATREKK_PLEIEPENGER (prematuruker)
 - Anvend fjernFrieUtsettelser også på annen parts perioder i useUttaksplanForEksisterendeSak
 - Legg til tester for begge scenarioer

 Løser TFP-6964

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>