### PR TITLE
 TFP-6946: Fiks visning av samtidig uttak i din plan (foreldrepengeov…

### DIFF
--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.tsx
@@ -9,11 +9,16 @@ import { Button, HStack, ToggleGroup, VStack } from '@navikt/ds-react';
 import {
     BrukerRolleSak_fpoversikt,
     NavnPåForeldre,
-    UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksperioden, useMedia } from '@navikt/fp-utils';
-import { KvoteOppsummering, UttaksplanDataProvider, UttaksplanKalender, UttaksplanListe } from '@navikt/fp-uttaksplan';
+import { useMedia } from '@navikt/fp-utils';
+import {
+    KvoteOppsummering,
+    UttaksplanDataProvider,
+    UttaksplanKalender,
+    UttaksplanListe,
+    prosesserPerioderForVisning,
+} from '@navikt/fp-uttaksplan';
 
 import { hentUttakskvoteOptions } from '../../api/queries';
 import { getBarnFraSak } from '../../utils/sakerUtils';
@@ -65,8 +70,21 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre, sak }: Props) => 
     const barn = getBarnFraSak(familiehendelse, gjelderAdopsjon);
 
     const perioderAnnenPartEØS = sak.gjeldendeVedtak?.perioderAnnenpartEøs;
-    const relevanteAnnenPartsPerioder =
-        perioderAnnenPartEØS && perioderAnnenPartEØS.length > 0 ? perioderAnnenPartEØS : annenPartsPerioder;
+
+    const søkerPerioderMedForelder = leggTilForelderOmMangler(
+        relevantePerioder,
+        sakTilhørerMor ? 'MOR' : 'FAR_MEDMOR',
+    );
+    const annenPartPerioderMedForelder = leggTilForelderOmMangler(
+        annenPartsPerioder,
+        sakTilhørerMor ? 'FAR_MEDMOR' : 'MOR',
+    );
+
+    const uttakPerioder = prosesserPerioderForVisning(
+        søkerPerioderMedForelder,
+        annenPartPerioderMedForelder,
+        perioderAnnenPartEØS,
+    );
 
     return (
         <VStack gap="space-40">
@@ -101,11 +119,7 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre, sak }: Props) => 
                     />
                 </ToggleGroup>
                 <UttaksplanDataProvider
-                    uttakPerioder={leggTilForelderIPerioder(
-                        relevantePerioder,
-                        relevanteAnnenPartsPerioder,
-                        sakTilhørerMor,
-                    )}
+                    uttakPerioder={uttakPerioder}
                     barn={barn}
                     foreldreInfo={{
                         søker: sakTilhørerMor ? 'MOR' : 'FAR_MEDMOR',
@@ -132,22 +146,12 @@ export const DinPlan = ({ annenPartsPerioder, navnPåForeldre, sak }: Props) => 
 };
 
 // TODO (TOR) Burde kunne setta forelder backend og så fjerna denne koden
-const leggTilForelderIPerioder = (
-    søkersPerioder: UttakPeriode_fpoversikt[],
-    annenPartsPerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
-    sakTilhørerMor: boolean,
-): Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> => {
-    return leggTilForelderOmMangler(søkersPerioder, sakTilhørerMor ? 'MOR' : 'FAR_MEDMOR').concat(
-        leggTilForelderOmMangler(annenPartsPerioder, sakTilhørerMor ? 'FAR_MEDMOR' : 'MOR'),
-    );
-};
-
 const leggTilForelderOmMangler = (
-    perioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    perioder: UttakPeriode_fpoversikt[],
     forelder: BrukerRolleSak_fpoversikt,
-) => {
+): UttakPeriode_fpoversikt[] => {
     return perioder.map((periode) => {
-        if (Uttaksperioden.erEøsPeriode(periode) || periode.forelder !== undefined) {
+        if (periode.forelder !== undefined) {
             return periode;
         }
         return {

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForEksisterendeSak.ts
@@ -1,16 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { sakerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
-import dayjs from 'dayjs';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
-import { Uttaksdagen } from '@navikt/fp-utils/src/uttak/Uttaksdagen';
-import { sorterUttakPerioder } from '@navikt/fp-uttaksplan';
+import { prosesserPerioderForVisning } from '@navikt/fp-uttaksplan';
 
 import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
-
-dayjs.extend(isSameOrBefore);
 
 export const useUttaksplanForEksisterendeSak = (
     perioderAnnenPart: UttakPeriode_fpoversikt[] | undefined,
@@ -23,49 +18,11 @@ export const useUttaksplanForEksisterendeSak = (
     const gjeldendeVedtak = valgtSak?.gjeldendeVedtak;
     const perioderFraBackend = gjeldendeVedtak?.perioder;
 
-    // Deler opp begge partar ved kvarandre sine grenser slik at kvart segment anten
-    // heilt overlappar eller ikkje overlappar i det heile. Algoritmane vert då enkle
-    // filter/map-operasjonar. Tilstøytande like segment vert slått saman att til slutt.
-    const splitSøker =
-        perioderFraBackend && perioderAnnenPart
-            ? splitPerioder(perioderFraBackend, perioderAnnenPart)
-            : perioderFraBackend;
-    const splitAnnenPart =
-        perioderFraBackend && perioderAnnenPart
-            ? splitPerioder(perioderAnnenPart, perioderFraBackend)
-            : perioderAnnenPart;
-
-    // Periodar med utsettelseÅrsak som overlappar motparten skal fjernast, uansett kven som eig perioden
-    const trimmedSøker =
-        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitSøker, splitAnnenPart) : splitSøker;
-    const trimmedAnnenPart =
-        splitSøker && splitAnnenPart ? fjernUtsettelseOverlapp(splitAnnenPart, splitSøker) : splitAnnenPart;
-
-    const søkerRef = trimmedSøker ?? [];
-    const justeringSøkerPerioder =
-        trimmedSøker && trimmedAnnenPart
-            ? midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart)
-            : undefined;
-
-    // Slår saman kvar part for seg før kombinering, slik at tilstøytande segment
-    // med identiske eigenskapar vert gjenoppretta til enkeltperiodar i output.
-    const mergedSøker = slåSammenTilstøtande(
-        fjernFrieUtsettelser(justeringSøkerPerioder ?? trimmedSøker ?? gjeldendeVedtak?.perioder ?? []),
-    );
-    const processedAnnenPart = trimmedAnnenPart
-        ? slåSammenTilstøtande(
-              fjernFrieUtsettelser(
-                  fjernOverlappUtenSamtidigUttak(
-                      midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, søkerRef),
-                      søkerRef,
-                  ),
-              ),
-          )
-        : [];
-
     const uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined = gjeldendeVedtak
-        ? [...mergedSøker, ...(gjeldendeVedtak.perioderAnnenpartEøs ?? []), ...processedAnnenPart].sort(
-              sorterUttakPerioder,
+        ? prosesserPerioderForVisning(
+              perioderFraBackend ?? [],
+              perioderAnnenPart ?? [],
+              gjeldendeVedtak.perioderAnnenpartEøs,
           )
         : undefined;
 
@@ -77,136 +34,4 @@ export const useUttaksplanForEksisterendeSak = (
 
     // uttaksplan er alltid definert når gjeldendeVedtak er definert
     return uttaksplan!;
-};
-
-// Deler opp periodar ved grensene til motparten slik at kvart segment
-// anten heilt overlappar eller ikkje overlappar med motparten sine periodar.
-const splitPerioder = (
-    perioderToSplit: UttakPeriode_fpoversikt[],
-    splittBasertPå: UttakPeriode_fpoversikt[],
-): UttakPeriode_fpoversikt[] => {
-    const splitDatoar = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort(
-        (a, b) => a.localeCompare(b),
-    );
-
-    return perioderToSplit.flatMap((periode) => {
-        const relevante = splitDatoar.filter(
-            (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
-        );
-
-        if (relevante.length === 0) {
-            return [periode];
-        }
-
-        const resultat: UttakPeriode_fpoversikt[] = [];
-        let gjeldandeFom = periode.fom;
-
-        for (const dato of relevante) {
-            resultat.push({ ...periode, fom: gjeldandeFom, tom: Uttaksdagen.forrige(dato).getDato() });
-            gjeldandeFom = dato;
-        }
-
-        resultat.push({ ...periode, fom: gjeldandeFom });
-        return resultat;
-    });
-};
-
-// Slår saman tilstøytande periodar med identiske eigenskapar.
-// Vert kalla separat for søkar og annenPart for å gjenopprette periodar
-// som vart delt av splitPerioder.
-const slåSammenTilstøtande = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
-    return perioder.reduce<UttakPeriode_fpoversikt[]>((acc, periode) => {
-        if (acc.length === 0) {
-            return [periode];
-        }
-        const forrige = acc.at(-1)!;
-        const erTilstøtande = Uttaksdagen.neste(forrige.tom).getDato() === periode.fom;
-        if (erTilstøtande && erLikeUtenDatoar(forrige, periode)) {
-            return [...acc.slice(0, -1), { ...forrige, tom: periode.tom }];
-        }
-        return [...acc, periode];
-    }, []);
-};
-
-const erLikeUtenDatoar = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>
-    a.forelder === b.forelder &&
-    a.kontoType === b.kontoType &&
-    a.flerbarnsdager === b.flerbarnsdager &&
-    a.gradering?.arbeidstidprosent === b.gradering?.arbeidstidprosent &&
-    a.gradering?.aktivitet === b.gradering?.aktivitet &&
-    a.morsAktivitet === b.morsAktivitet &&
-    a.oppholdÅrsak === b.oppholdÅrsak &&
-    a.utsettelseÅrsak === b.utsettelseÅrsak &&
-    a.overføringÅrsak === b.overføringÅrsak &&
-    a.resultat?.innvilget === b.resultat?.innvilget &&
-    a.resultat?.trekkerDager === b.resultat?.trekkerDager &&
-    a.resultat?.trekkerMinsterett === b.resultat?.trekkerMinsterett &&
-    a.resultat?.årsak === b.resultat?.årsak &&
-    a.samtidigUttak === b.samtidigUttak;
-
-const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
-    // Dersom perioden har eit aktivitetskrav er det ein periode lagt inn for kun far har rett,
-    // og den skal difor ikkje fjernast sjølv om det er ei utsettelse med årsak fri.
-    return perioder.filter(
-        (periode) =>
-            (periode.utsettelseÅrsak === 'FRI' && periode.morsAktivitet !== undefined) ||
-            periode.utsettelseÅrsak !== 'FRI',
-    );
-};
-
-// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
-// Om annen part har søkt først og har lagt til ein periode som overlappar med søkar sin samtidig uttaksperiode (er muligens kun
-// synleg om søkar har har lagt til samtidig uttak og så seinare ser på ein endringssøknad), så må en endra
-// annen part sin periode til samtidig uttak for å få rett visning i kalender.
-// Periodane er pre-splitta, så overlapp er alltid fullstendig.
-const midlertidigJusteringAvSamtidigUttak = (
-    perioderSøker1: UttakPeriode_fpoversikt[],
-    perioderSøker2: UttakPeriode_fpoversikt[],
-): UttakPeriode_fpoversikt[] => {
-    return perioderSøker1.map((p) => {
-        const overlappande = perioderSøker2.find((s) => harOverlapp(p, s));
-        if (!overlappande) {
-            return p;
-        }
-        return overlappande.samtidigUttak !== undefined && p.samtidigUttak === undefined
-            ? { ...p, samtidigUttak: 100 }
-            : p;
-    });
-};
-
-const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
-    dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
-
-// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
-// Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
-// Den overlappande delen vert kasta. Denne algoritmen har prioritet over dei to andre og skal køyrast først.
-// Periodane er pre-splitta, så overlappande segment kan kastast direkte.
-const fjernUtsettelseOverlapp = (
-    perioder: UttakPeriode_fpoversikt[],
-    motpartPerioder: UttakPeriode_fpoversikt[],
-): UttakPeriode_fpoversikt[] => {
-    return perioder.filter(
-        (periode) => periode.utsettelseÅrsak === undefined || !motpartPerioder.some((m) => harOverlapp(periode, m)),
-    );
-};
-
-// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
-// Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
-// er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
-// Periodar med utsettelseÅrsak hjå søkar tel ikkje som overlapp her.
-// Periodane er pre-splitta, så overlappande segment kan kastast direkte.
-const fjernOverlappUtenSamtidigUttak = (
-    perioderAnnenPart: UttakPeriode_fpoversikt[],
-    perioderSøker: UttakPeriode_fpoversikt[],
-): UttakPeriode_fpoversikt[] => {
-    return perioderAnnenPart.filter(
-        (periodeAnnenPart) =>
-            periodeAnnenPart.samtidigUttak !== undefined ||
-            !perioderSøker.some(
-                (søker) =>
-                    søker.samtidigUttak === undefined &&
-                    søker.utsettelseÅrsak === undefined &&
-                    harOverlapp(periodeAnnenPart, søker),
-            ),
-    );
 };

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -24,5 +24,6 @@ export { useErAntallDagerOvertrukketIUttaksplan } from './src/utils/kvoteOppsumm
 export { UttaksperiodeValidatorer } from './src/utils/UttaksperiodeValidatorer';
 export { skalBesvareFlerbarnsdager } from './src/felles/LeggTilEllerEndrePeriodeFellesForm';
 export { sorterUttakPerioder, harPeriodeDerMorsAktivitetIkkeErValgt, getAntallUttaksdagerIVinduRundtFødsel } from './src/utils/periodeUtils';
+export { prosesserPerioderForVisning } from './src/utils/prosesserPerioderForVisning';
 export { deltUttak } from './src/utils/forslag/deltUttak';
 export { ikkeDeltUttak } from './src/utils/forslag/ikkeDeltUttak';

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.test.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { prosesserPerioderForVisning } from './prosesserPerioderForVisning';
+
+describe('prosesserPerioderForVisning', () => {
+    it('markerer søkar med samtidig uttak for overlappande del når berre annen part har samtidig uttak', () => {
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-15',
+                tom: '2026-06-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ];
+
+        const result = prosesserPerioderForVisning(perioderSøker, perioderAnnenPart);
+
+        expect(result).toEqual([
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-14',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-05-15',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+            {
+                fom: '2026-05-15',
+                tom: '2026-06-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+                samtidigUttak: 100,
+            },
+        ]);
+    });
+
+    it('fjernar overlappande del frå annen part utan samtidig uttak når søkar har uttaksperiode', () => {
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-09-01',
+                tom: '2026-09-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-09-10',
+                tom: '2026-09-20',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const result = prosesserPerioderForVisning(perioderSøker, perioderAnnenPart);
+
+        expect(result).toEqual([
+            {
+                fom: '2026-09-01',
+                tom: '2026-09-30',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ]);
+    });
+
+    it('trimmar vekk utsettelse-delar som overlappar motparten', () => {
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                utsettelseÅrsak: 'ARBEID',
+            },
+        ];
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2026-05-15',
+                tom: '2026-05-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const result = prosesserPerioderForVisning(perioderSøker, perioderAnnenPart);
+
+        expect(result).toEqual([
+            {
+                fom: '2026-05-01',
+                tom: '2026-05-14',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                utsettelseÅrsak: 'ARBEID',
+            },
+            {
+                fom: '2026-05-15',
+                tom: '2026-05-20',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2026-05-21',
+                tom: '2026-05-31',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                utsettelseÅrsak: 'ARBEID',
+            },
+        ]);
+    });
+});

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
@@ -34,7 +34,9 @@ export const prosesserPerioderForVisning = (
 
     const mergedSøker = slåSammenTilstøtande(fjernFrieUtsettelser(justeringSøkerPerioder));
     const processedAnnenPart = slåSammenTilstøtande(
-        fjernOverlappUtenSamtidigUttak(midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, trimmedSøker), trimmedSøker),
+        fjernFrieUtsettelser(
+            fjernOverlappUtenSamtidigUttak(midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, trimmedSøker), trimmedSøker),
+        ),
     );
 
     return [...mergedSøker, ...(perioderAnnenpartEøs ?? []), ...processedAnnenPart].sort(sorterUttakPerioder);

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
@@ -1,0 +1,163 @@
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+
+import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { Uttaksdagen } from '@navikt/fp-utils';
+
+import { sorterUttakPerioder } from './periodeUtils';
+
+dayjs.extend(isSameOrBefore);
+
+/**
+ * Prosesserer søkers og annen parts perioder slik at de kan visast korrekt saman.
+ *
+ * - Splittar periodar ved kvarandre sine grenser
+ * - Fjernar utsettelsesoverlapp
+ * - Justerer samtidig uttak (sett 100 % dersom berre ein av partane har det)
+ * - Fjernar overlapp utan samtidig uttak frå annen part
+ * - Slår saman tilstøytande like segment att
+ *
+ * TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar i backend
+ */
+export const prosesserPerioderForVisning = (
+    søkersPerioder: UttakPeriode_fpoversikt[],
+    annenPartsPerioder: UttakPeriode_fpoversikt[],
+    perioderAnnenpartEøs?: UttakPeriodeAnnenpartEøs_fpoversikt[],
+): Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> => {
+    const splitSøker = splitPerioder(søkersPerioder, annenPartsPerioder);
+    const splitAnnenPart = splitPerioder(annenPartsPerioder, søkersPerioder);
+
+    const trimmedSøker = fjernUtsettelseOverlapp(splitSøker, splitAnnenPart);
+    const trimmedAnnenPart = fjernUtsettelseOverlapp(splitAnnenPart, splitSøker);
+
+    const justeringSøkerPerioder = midlertidigJusteringAvSamtidigUttak(trimmedSøker, trimmedAnnenPart);
+
+    const mergedSøker = slåSammenTilstøtande(fjernFrieUtsettelser(justeringSøkerPerioder));
+    const processedAnnenPart = slåSammenTilstøtande(
+        fjernOverlappUtenSamtidigUttak(midlertidigJusteringAvSamtidigUttak(trimmedAnnenPart, trimmedSøker), trimmedSøker),
+    );
+
+    return [...mergedSøker, ...(perioderAnnenpartEøs ?? []), ...processedAnnenPart].sort(sorterUttakPerioder);
+};
+
+// Deler opp periodar ved grensene til motparten slik at kvart segment
+// anten heilt overlappar eller ikkje overlappar med motparten sine periodar.
+const splitPerioder = (
+    perioderToSplit: UttakPeriode_fpoversikt[],
+    splittBasertPå: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    const splitDatoar = [...new Set(splittBasertPå.flatMap((p) => [p.fom, Uttaksdagen.neste(p.tom).getDato()]))].sort(
+        (a, b) => a.localeCompare(b),
+    );
+
+    return perioderToSplit.flatMap((periode) => {
+        const relevante = splitDatoar.filter(
+            (dato) => dayjs(dato).isAfter(periode.fom, 'day') && dayjs(dato).isSameOrBefore(periode.tom, 'day'),
+        );
+
+        if (relevante.length === 0) {
+            return [periode];
+        }
+
+        const resultat: UttakPeriode_fpoversikt[] = [];
+        let gjeldandeFom = periode.fom;
+
+        for (const dato of relevante) {
+            resultat.push({ ...periode, fom: gjeldandeFom, tom: Uttaksdagen.forrige(dato).getDato() });
+            gjeldandeFom = dato;
+        }
+
+        resultat.push({ ...periode, fom: gjeldandeFom });
+        return resultat;
+    });
+};
+
+// Slår saman tilstøytande periodar med identiske eigenskapar.
+const slåSammenTilstøtande = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
+    return perioder.reduce<UttakPeriode_fpoversikt[]>((acc, periode) => {
+        if (acc.length === 0) {
+            return [periode];
+        }
+        const forrige = acc.at(-1)!;
+        const erTilstøtande = Uttaksdagen.neste(forrige.tom).getDato() === periode.fom;
+        if (erTilstøtande && erLikeUtenDatoar(forrige, periode)) {
+            return [...acc.slice(0, -1), { ...forrige, tom: periode.tom }];
+        }
+        return [...acc, periode];
+    }, []);
+};
+
+const erLikeUtenDatoar = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>
+    a.forelder === b.forelder &&
+    a.kontoType === b.kontoType &&
+    a.flerbarnsdager === b.flerbarnsdager &&
+    a.gradering?.arbeidstidprosent === b.gradering?.arbeidstidprosent &&
+    a.gradering?.aktivitet === b.gradering?.aktivitet &&
+    a.morsAktivitet === b.morsAktivitet &&
+    a.oppholdÅrsak === b.oppholdÅrsak &&
+    a.utsettelseÅrsak === b.utsettelseÅrsak &&
+    a.overføringÅrsak === b.overføringÅrsak &&
+    a.resultat?.innvilget === b.resultat?.innvilget &&
+    a.resultat?.trekkerDager === b.resultat?.trekkerDager &&
+    a.resultat?.trekkerMinsterett === b.resultat?.trekkerMinsterett &&
+    a.resultat?.årsak === b.resultat?.årsak &&
+    a.samtidigUttak === b.samtidigUttak;
+
+const fjernFrieUtsettelser = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
+    return perioder.filter(
+        (periode) =>
+            (periode.utsettelseÅrsak === 'FRI' && periode.morsAktivitet !== undefined) ||
+            periode.utsettelseÅrsak !== 'FRI',
+    );
+};
+
+// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
+// Om annen part har søkt først og har lagt til ein periode som overlappar med søkar sin samtidig uttaksperiode,
+// så må en endra annen part sin periode til samtidig uttak for å få rett visning i kalender.
+const midlertidigJusteringAvSamtidigUttak = (
+    perioderSøker1: UttakPeriode_fpoversikt[],
+    perioderSøker2: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    return perioderSøker1.map((p) => {
+        const overlappande = perioderSøker2.find((s) => harOverlapp(p, s));
+        if (!overlappande) {
+            return p;
+        }
+        return overlappande.samtidigUttak !== undefined && p.samtidigUttak === undefined
+            ? { ...p, samtidigUttak: 100 }
+            : p;
+    });
+};
+
+const harOverlapp = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt) =>
+    dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
+// Periodar med utsettelseÅrsak skal ikkje overlappe med den andre søkaren sine periodar.
+const fjernUtsettelseOverlapp = (
+    perioder: UttakPeriode_fpoversikt[],
+    motpartPerioder: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    return perioder.filter(
+        (periode) => periode.utsettelseÅrsak === undefined || !motpartPerioder.some((m) => harOverlapp(periode, m)),
+    );
+};
+
+// TODO (TOR) Fjern denne når ein byrjar å lagre annen parts periodar
+// Om søkar har ein periode som overlappar med annen part sin periode, og ingen av dei har samtidigattak,
+// er dette eit duplikat. Den overlappande delen av annen part sin periode skal fjernast.
+const fjernOverlappUtenSamtidigUttak = (
+    perioderAnnenPart: UttakPeriode_fpoversikt[],
+    perioderSøker: UttakPeriode_fpoversikt[],
+): UttakPeriode_fpoversikt[] => {
+    return perioderAnnenPart.filter(
+        (periodeAnnenPart) =>
+            periodeAnnenPart.samtidigUttak !== undefined ||
+            !perioderSøker.some(
+                (søker) =>
+                    søker.samtidigUttak === undefined &&
+                    søker.utsettelseÅrsak === undefined &&
+                    harOverlapp(periodeAnnenPart, søker),
+            ),
+    );
+};


### PR DESCRIPTION
…ersikt)

https://jira.adeo.no/browse/TFP-6946

 Oversiktsappen manglet prosesseringslogikken som søknadsappen
 bruker i useUttaksplanForEksisterendeSak. Utan denne prosesseringen
 vart ikkje samtidigUttak-feltet satt på perioder der berre den
 andre forelderen hadde søkt om samtidig uttak.

 Endring:
 - Ekstraherer prosesserPerioderForVisning til packages/uttaksplan (split, merge, justering av samtidigUttak, fjerning av overlapp)
 - Bruker prosesserPerioderForVisning i DinPlan.tsx i staden for enkel samanslåing av periodane

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>