### PR TITLE
TFP-6975: Hindre gradering ved overføring av kvote

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    LeggTilEllerEndrePeriodeFormFormValues,
+    mapFraFormValuesTilUttakPeriode,
+} from './LeggTilEllerEndrePeriodeFellesForm';
+
+const PERIODE = { fom: '2026-01-01', tom: '2026-01-10' };
+
+describe('mapFraFormValuesTilUttakPeriode', () => {
+    it('setter gradering til undefined for mor ved overføring selv om gradering-felter er satt i form state', () => {
+        const values = {
+            forelder: 'MOR',
+            kontoTypeMor: 'FEDREKVOTE',
+            skalDuKombinereArbeidOgUttakMor: true,
+            stillingsprosentMor: '50',
+            hvorSkalDuJobbe: '123456789',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR');
+
+        expect(periode?.gradering).toBeUndefined();
+    });
+
+    it('setter gradering til undefined for far/medmor ved overføring selv om gradering-felter er satt i form state', () => {
+        const values = {
+            forelder: 'FAR_MEDMOR',
+            kontoTypeFarMedmor: 'MØDREKVOTE',
+            skalDuKombinereArbeidOgUttakFarMedmor: true,
+            stillingsprosentFarMedmor: '40',
+            hvorSkalDuJobbe: 'FRILANS',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'FAR_MEDMOR');
+
+        expect(periode?.gradering).toBeUndefined();
+    });
+});

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -174,6 +174,26 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
         }
     };
 
+    const resetGraderingFelterForMor = (nyKontoType: KontoTypeUttak | undefined) => {
+        if (nyKontoType === 'FEDREKVOTE') {
+            formMethods.resetField('skalDuKombinereArbeidOgUttakMor', { defaultValue: undefined });
+            formMethods.resetField('stillingsprosentMor', { defaultValue: undefined });
+            if (søker === 'MOR') {
+                formMethods.resetField('hvorSkalDuJobbe', { defaultValue: undefined });
+            }
+        }
+    };
+
+    const resetGraderingFelterForFarMedmor = (nyKontoType: KontoTypeUttak | undefined) => {
+        if (nyKontoType === 'MØDREKVOTE') {
+            formMethods.resetField('skalDuKombinereArbeidOgUttakFarMedmor', { defaultValue: undefined });
+            formMethods.resetField('stillingsprosentFarMedmor', { defaultValue: undefined });
+            if (søker === 'FAR_MEDMOR') {
+                formMethods.resetField('hvorSkalDuJobbe', { defaultValue: undefined });
+            }
+        }
+    };
+
     const erFarMedmorLåst = erPeriodeneTilAnnenPartLåst && søker === 'MOR';
     const erMorLåst = erPeriodeneTilAnnenPartLåst && søker === 'FAR_MEDMOR';
     const erMinstEnEøsPeriode = uttakPerioder.some((periode) => erEøsUttakPeriode(periode));
@@ -251,6 +271,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                         isRequired(intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.KvoteTypeMor.Påkrevd' })),
                     ]}
                     label={intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.KvoteTypeMor' })}
+                    onChange={resetGraderingFelterForMor}
                 >
                     {gyldigeStønadskontoerForMor.map((konto) => {
                         return (
@@ -283,6 +304,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                             values={{ erMedmor: erMedmorDelAvSøknaden }}
                         />
                     }
+                    onChange={resetGraderingFelterForFarMedmor}
                 >
                     {gyldigeStønadskontoerForFarMedmor.map((konto) => {
                         return (
@@ -667,15 +689,17 @@ export const mapFraFormValuesTilUttakPeriode = (
     const nye = new Array<UttakPeriode_fpoversikt>();
 
     if (values.forelder === 'MOR' || values.forelder === 'BEGGE') {
+        const erOverføringMor = values.kontoTypeMor === 'FEDREKVOTE';
         nye.push({
             fom: periode.fom,
             tom: periode.tom,
             kontoType: values.kontoTypeMor === 'AKTIVITETSFRI_KVOTE' ? 'FORELDREPENGER' : values.kontoTypeMor,
             morsAktivitet: values.morsAktivitet,
             forelder: 'MOR',
-            gradering: values.skalDuKombinereArbeidOgUttakMor
-                ? getGradering(søker === 'MOR', values.stillingsprosentMor, values.hvorSkalDuJobbe)
-                : undefined,
+            gradering:
+                !erOverføringMor && values.skalDuKombinereArbeidOgUttakMor
+                    ? getGradering(søker === 'MOR', values.stillingsprosentMor, values.hvorSkalDuJobbe)
+                    : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentMor) : undefined,
             overføringÅrsak: values.overføringsårsak,
@@ -683,6 +707,7 @@ export const mapFraFormValuesTilUttakPeriode = (
         });
     }
     if (values.forelder === 'FAR_MEDMOR' || values.forelder === 'BEGGE') {
+        const erOverføringFarMedmor = values.kontoTypeFarMedmor === 'MØDREKVOTE';
         nye.push({
             fom: periode.fom,
             tom: periode.tom,
@@ -690,9 +715,10 @@ export const mapFraFormValuesTilUttakPeriode = (
                 values.kontoTypeFarMedmor === 'AKTIVITETSFRI_KVOTE' ? 'FORELDREPENGER' : values.kontoTypeFarMedmor,
             morsAktivitet: values.kontoTypeFarMedmor === 'AKTIVITETSFRI_KVOTE' ? 'IKKE_OPPGITT' : values.morsAktivitet,
             forelder: 'FAR_MEDMOR',
-            gradering: values.skalDuKombinereArbeidOgUttakFarMedmor
-                ? getGradering(søker === 'FAR_MEDMOR', values.stillingsprosentFarMedmor, values.hvorSkalDuJobbe)
-                : undefined,
+            gradering:
+                !erOverføringFarMedmor && values.skalDuKombinereArbeidOgUttakFarMedmor
+                    ? getGradering(søker === 'FAR_MEDMOR', values.stillingsprosentFarMedmor, values.hvorSkalDuJobbe)
+                    : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentFarMedmor) : undefined,
             overføringÅrsak: values.overføringsårsak,


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6975

Når en forelder først svarte at de skulle gradere uttaket mot arbeid og deretter endret kvotetype til den andre forelderens kvote (overføring), ble gradering-feltene skjult i UI-et men ble liggende igjen i form-state. Søknaden ble dermed sendt med både overføringÅrsak og gradering, noe FP-sak ikke kan behandle.

- Nullstiller skalDuKombinereArbeidOgUttak/stillingsprosent/hvorSkalDuJobbe når brukeren bytter til en overføringskvote (FEDREKVOTE for mor, MØDREKVOTE for far/medmor)
- Defensiv guard i mapFraFormValuesTilUttakPeriode slik at gradering alltid er undefined når perioden er en overføring