### PR TITLE
Fiks validering: far med kun utsettelse + mor med uttak gav tom uttak…

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
@@ -29,7 +29,7 @@ const uttakMor: UttakPeriode_fpoversikt = {
 
 describe('harKunPerioderForAnnenForelder', () => {
     it('returnerer false når perioder er undefined eller tom', () => {
-        expect(harKunPerioderForAnnenForelder(true, undefined)).toBe(false);
+        expect(harKunPerioderForAnnenForelder(true)).toBe(false);
         expect(harKunPerioderForAnnenForelder(true, [])).toBe(false);
     });
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
@@ -1,0 +1,49 @@
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { harKunPerioderForAnnenForelder } from './UttaksplanForm';
+
+const utsettelseFar: UttakPeriode_fpoversikt = {
+    fom: '2026-06-01',
+    tom: '2026-06-05',
+    forelder: 'FAR_MEDMOR',
+    flerbarnsdager: false,
+    kontoType: 'FEDREKVOTE',
+    utsettelseÅrsak: 'LOVBESTEMT_FERIE',
+};
+
+const uttakFar: UttakPeriode_fpoversikt = {
+    fom: '2026-07-01',
+    tom: '2026-07-31',
+    forelder: 'FAR_MEDMOR',
+    flerbarnsdager: false,
+    kontoType: 'FEDREKVOTE',
+};
+
+const uttakMor: UttakPeriode_fpoversikt = {
+    fom: '2026-05-01',
+    tom: '2026-05-31',
+    forelder: 'MOR',
+    flerbarnsdager: false,
+    kontoType: 'MØDREKVOTE',
+};
+
+describe('harKunPerioderForAnnenForelder', () => {
+    it('returnerer false når perioder er undefined eller tom', () => {
+        expect(harKunPerioderForAnnenForelder(true, undefined)).toBe(false);
+        expect(harKunPerioderForAnnenForelder(true, [])).toBe(false);
+    });
+
+    it('returnerer true når søker (far) kun har utsettelser og mor har uttaksperioder', () => {
+        // Sak 152610557: far søker, mor har eksisterende vedtak/uttak,
+        // far har kun utsettelse (ferie/barn syk). Skal blokkeres med feilmelding.
+        expect(harKunPerioderForAnnenForelder(true, [uttakMor, utsettelseFar])).toBe(true);
+    });
+
+    it('returnerer false når søker (far) har minst én ekte uttaksperiode', () => {
+        expect(harKunPerioderForAnnenForelder(true, [uttakMor, uttakFar])).toBe(false);
+    });
+
+    it('returnerer true når planen kun har perioder for annen forelder', () => {
+        expect(harKunPerioderForAnnenForelder(true, [uttakMor])).toBe(true);
+    });
+});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -123,7 +123,14 @@ export const UttaksplanForm = ({
             }
 
             scrollToKvoteOppsummering();
-        } else if (!erEndringssøknad && !planForValidering.some((p) => Uttaksperioden.erUttaksperiode(p))) {
+        } else if (
+            !erEndringssøknad &&
+            !planForValidering.some(
+                (p) =>
+                    Uttaksperioden.erUttaksperiode(p) &&
+                    p.forelder === (erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
+            )
+        ) {
             setFeilmelding(<FormattedMessage id="UttaksplanSteg.IngenUttaksperioder" />);
             scrollToKvoteOppsummering();
         } else if (erAntallDagerOvertrukket) {

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -343,7 +343,7 @@ const harBrukerKunSlettetPerioder = (
     return false;
 };
 
-const harKunPerioderForAnnenForelder = (
+export const harKunPerioderForAnnenForelder = (
     erSøkerFarEllerMedmor: boolean,
     perioder?: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
 ) => {
@@ -353,7 +353,12 @@ const harKunPerioderForAnnenForelder = (
 
     const søkersForelder = erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR';
 
-    return perioder.every((periode) => Uttaksperioden.erEøsPeriode(periode) || periode.forelder !== søkersForelder);
+    return perioder.every(
+        (periode) =>
+            Uttaksperioden.erEøsPeriode(periode) ||
+            periode.forelder !== søkersForelder ||
+            !Uttaksperioden.erUttaksperiode(periode),
+    );
 };
 
 const utledRettighet = (erAleneOmOmsorg: boolean, erDeltUttak: boolean): RettighetType_fpoversikt => {

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -123,14 +123,7 @@ export const UttaksplanForm = ({
             }
 
             scrollToKvoteOppsummering();
-        } else if (
-            !erEndringssøknad &&
-            !planForValidering.some(
-                (p) =>
-                    Uttaksperioden.erUttaksperiode(p) &&
-                    p.forelder === (erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
-            )
-        ) {
+        } else if (!erEndringssøknad && !planForValidering.some((p) => Uttaksperioden.erUttaksperiode(p))) {
             setFeilmelding(<FormattedMessage id="UttaksplanSteg.IngenUttaksperioder" />);
             scrollToKvoteOppsummering();
         } else if (erAntallDagerOvertrukket) {


### PR DESCRIPTION
…splan

Sak 152610557: Førstegangssøknad fra far der mor har eksisterende uttak og far kun har utsettelse (ferie/barn syk) ble sluppet gjennom valideringa. Resultatet vart avslag i fp-sak og NoSuchElementException i fp-formidling ved brevproduksjon (Avslagsårsak.fraKode).

har'KunPerioderForAnnenForelder' tok ikkje høgde for at søkers eigne utsettelses-/opphold-/overføringsperioder ikkje er ekte uttaksperioder. Når mor hadde uttak i planen, slapp far gjennom utan å ha lagt til ein einaste uttaksperiode for seg sjølv.