### PR TITLE
TFP-6959: Fiks: inkluder morsAktivitet i periodesammenligning for endringssøknad

### DIFF
--- a/apps/foreldrepengesoknad/src/utils/dateUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/dateUtils.test.ts
@@ -409,6 +409,28 @@ describe('dateUtils', () => {
                 expect(endringstidspunkt).toBe(opprinneligPlanMedAnnenPart[0]!.fom);
             },
         );
+
+        it('Skal finne endringstidspunkt når morsAktivitet endres fra undefined til en verdi (aktivitetskrav legges til)', () => {
+            const opprinneligPlanUtenAktivitetskrav: UttakPeriode_fpoversikt[] = [
+                { fom: '2025-01-06', tom: '2025-02-14', flerbarnsdager: false, forelder: 'FAR_MEDMOR', kontoType: 'FORELDREPENGER' },
+                { fom: '2025-02-17', tom: '2025-03-10', flerbarnsdager: false, forelder: 'FAR_MEDMOR', kontoType: 'FORELDREPENGER' },
+            ];
+
+            const endretPlanMedAktivitetskrav: UttakPeriode_fpoversikt[] = [
+                { fom: '2025-01-06', tom: '2025-02-14', flerbarnsdager: false, forelder: 'FAR_MEDMOR', kontoType: 'FORELDREPENGER' },
+                {
+                    fom: '2025-02-17',
+                    tom: '2025-03-10',
+                    flerbarnsdager: false,
+                    forelder: 'FAR_MEDMOR',
+                    kontoType: 'FORELDREPENGER',
+                    morsAktivitet: 'ARBEID',
+                },
+            ];
+
+            const endringstidspunkt = getEndringstidspunktNy(opprinneligPlanUtenAktivitetskrav, endretPlanMedAktivitetskrav);
+            expect(endringstidspunkt).toBe('2025-02-17');
+        });
     });
 });
 

--- a/apps/foreldrepengesoknad/src/utils/eksisterendeSakUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/eksisterendeSakUtils.ts
@@ -474,7 +474,8 @@ export const erPeriodeIOpprinneligPlan = (
             nyPeriode.resultat?.trekkerMinsterett === p.resultat?.trekkerMinsterett &&
             nyPeriode.resultat?.årsak === p.resultat?.årsak &&
             nyPeriode.oppholdÅrsak === p.oppholdÅrsak &&
-            nyPeriode.overføringÅrsak === p.overføringÅrsak
+            nyPeriode.overføringÅrsak === p.overføringÅrsak &&
+            nyPeriode.morsAktivitet === p.morsAktivitet
         );
     });
 };


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6959

erPeriodeIOpprinneligPlan() manglet sammenligning av morsAktivitet, slik at endring fra foreldrepenger uten aktivitetskrav til med aktivitetskrav ikke ble detektert. Dette førte til feil endringstidspunkt og at oppholdsperioder ble sendt som uttaksperioder.