### PR TITLE
TFP-6974: begrens morsAktivitet for far i første seks uker etter fødsel

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -111,6 +111,19 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
             kontoTypeFarMedmor,
         );
 
+    const erValgtPeriodeInnenforFørsteSeksUkerEtterFødsel =
+        familiesituasjon !== 'adopsjon' &&
+        UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletFamDatoOgSeksUkerEtterFamDato(
+            valgtePerioder,
+            familiehendelsedato,
+        );
+
+    const skalViseAktivitetskravFordiFedrekvoteFørsteSeksUker =
+        forelder === 'FAR_MEDMOR' &&
+        rettighetType !== 'ALENEOMSORG' &&
+        kontoTypeFarMedmor === 'FEDREKVOTE' &&
+        erValgtPeriodeInnenforFørsteSeksUkerEtterFødsel;
+
     const { gyldigeStønadskontoerForMor, gyldigeStønadskontoerForFarMedmor } = useHentGyldigeKvotetyper(
         valgtePerioder,
         forelder === 'BEGGE',
@@ -424,7 +437,9 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                 </VStack>
             )}
 
-            {(erFarMedmorUtenAleneomsorg || skalViseMorsAktivitetskravVedSamtidigUttak) && (
+            {(erFarMedmorUtenAleneomsorg ||
+                skalViseMorsAktivitetskravVedSamtidigUttak ||
+                skalViseAktivitetskravFordiFedrekvoteFørsteSeksUker) && (
                 <>
                     <hr className="text-ax-border-neutral-subtle" />
                     <RhfSelect
@@ -434,7 +449,10 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                         validate={[isRequired(intl.formatMessage({ id: 'AktivitetskravSpørsmål.Påkrevd' }))]}
                         description={intl.formatMessage({ id: 'AktivitetskravSpørsmål.Description' })}
                     >
-                        {getAktivitetskravOptions(skalViseMorsAktivitetskravVedSamtidigUttak).map((value) => {
+                        {getAktivitetskravOptions(
+                            skalViseMorsAktivitetskravVedSamtidigUttak,
+                            erValgtPeriodeInnenforFørsteSeksUkerEtterFødsel,
+                        ).map((value) => {
                             return (
                                 <option key={value} value={value}>
                                     {getAktivitetskravTekst(value, intl)}

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -1107,6 +1107,8 @@ describe('UttaksplanKalender', () => {
         expect(screen.getByText('Skal far kombinere foreldrepenger med arbeid?')).toBeInTheDocument();
         await userEvent.click(screen.getByText('Nei'));
 
+        await userEvent.selectOptions(screen.getByLabelText('Hva skal mor gjøre i denne perioden?'), 'INNLAGT');
+
         await userEvent.click(screen.getByText('Legg til'));
 
         expect(await screen.findByText('Hva skal skje med resten av planen?')).toBeInTheDocument();

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -238,7 +238,10 @@ export const erDetReadonlyPerioderEtterValgtePerioder = (
     return harEøsEllerPleiepenger || harAnnenPartSomErLåst;
 };
 
-export const getAktivitetskravOptions = (skalViseMorsAktivitetskravVedSamtidigUttak: boolean): MorsAktivitet[] => {
+export const getAktivitetskravOptions = (
+    skalViseMorsAktivitetskravVedSamtidigUttak: boolean,
+    erInnenforFørsteSeksUkerEtterFødsel = false,
+): MorsAktivitet[] => {
     const aktivitetsKrav = [
         'ARBEID',
         'ARBEID_OG_UTDANNING',
@@ -248,6 +251,10 @@ export const getAktivitetskravOptions = (skalViseMorsAktivitetskravVedSamtidigUt
         'KVALPROG',
         'UTDANNING',
     ] satisfies MorsAktivitet[];
+
+    if (erInnenforFørsteSeksUkerEtterFødsel) {
+        return aktivitetsKrav.filter((k) => k === 'INNLAGT' || k === 'TRENGER_HJELP');
+    }
 
     return skalViseMorsAktivitetskravVedSamtidigUttak
         ? aktivitetsKrav.filter((k) => k !== 'INNLAGT' && k !== 'TRENGER_HJELP')


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6974

Far kunne legge inn foreldrepenger med ulovlig morsAktivitet eller fedrekvote uten varsel i de første seks ukene etter fødsel.

- getAktivitetskravOptions filtrerer til kun INNLAGT og TRENGER_HJELP når valgt periode ligger innenfor første seks uker etter fødsel.
- Spørsmålet 'Hva skal mor gjøre i denne perioden?' vises også når far velger FEDREKVOTE i denne perioden, ikke bare FORELDREPENGER/ FELLESPERIODE, slik at brukeren får beskjed allerede i 'hva vil du endre til'-panelet.