### PR TITLE
TFP-6948: vis mors aktivitetsspørsmål ved samtidig uttak med fellesperiode

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -103,13 +103,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
 
     const skalViseMorsAktivitetskravVedSamtidigUttak =
         !ønskerFlerbarnsdager &&
-        getSkalViseMorsAktivitetskravVedSamtidigUttak(
-            forelder,
-            samtidigUttaksprosentMor,
-            stillingsprosentMor,
-            samtidigUttaksprosentFarMedmor,
-            kontoTypeFarMedmor,
-        );
+        getSkalViseMorsAktivitetskravVedSamtidigUttak(forelder, samtidigUttaksprosentMor, stillingsprosentMor, kontoTypeFarMedmor);
 
     const { gyldigeStønadskontoerForMor, gyldigeStønadskontoerForFarMedmor } = useHentGyldigeKvotetyper(
         valgtePerioder,
@@ -638,25 +632,13 @@ const getSkalViseMorsAktivitetskravVedSamtidigUttak = (
     forelder: ForelderValg,
     samtidigUttaksprosentMor?: string,
     stillingsprosentMor?: string,
-    samtidigUttaksprosentFarMedmor?: string,
     kontoTypeFarMedmor?: KontoTypeUttak,
 ) => {
     const morsSamtidigUttakprosent = forelder === 'BEGGE' ? (getFloatFromString(samtidigUttaksprosentMor) ?? 0) : 0;
     const morsStillingProsent = forelder === 'BEGGE' ? (getFloatFromString(stillingsprosentMor) ?? 0) : 0;
     const morsTotaleProsent = morsSamtidigUttakprosent + morsStillingProsent;
 
-    const farMedmorsSamtidigUttakprosent =
-        forelder === 'BEGGE' ? (getFloatFromString(samtidigUttaksprosentFarMedmor) ?? 0) : 0;
-    const kombinertUttaksprosent = morsSamtidigUttakprosent + farMedmorsSamtidigUttakprosent;
-
-    if (kombinertUttaksprosent !== 100) {
-        return false;
-    }
-
-    const skalViseMorsAktivitetskravVedSamtidigUttak =
-        forelder === 'BEGGE' && kontoTypeFarMedmor === 'FELLESPERIODE' && morsTotaleProsent < 100;
-
-    return skalViseMorsAktivitetskravVedSamtidigUttak;
+    return forelder === 'BEGGE' && kontoTypeFarMedmor === 'FELLESPERIODE' && morsTotaleProsent < 100;
 };
 
 export const mapFraFormValuesTilUttakPeriode = (

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -706,6 +706,8 @@ describe('UttaksplanKalender', () => {
         expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Fellesperiode')[1]!);
 
+        await userEvent.selectOptions(screen.getByLabelText('Hva skal mor gjøre i denne perioden?'), 'ARBEID');
+
         const samtidigprosentMor = screen.getByLabelText('Hvor mange prosent til mor?');
         await userEvent.type(samtidigprosentMor, '40');
 
@@ -768,6 +770,8 @@ describe('UttaksplanKalender', () => {
 
         expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Fellesperiode')[1]!);
+
+        await userEvent.selectOptions(screen.getByLabelText('Hva skal mor gjøre i denne perioden?'), 'ARBEID');
 
         const samtidigprosentMor = screen.getByLabelText('Hvor mange prosent til mor?');
         await userEvent.type(samtidigprosentMor, '60');


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6948

Fjerner kombinertUttaksprosent !== 100 guard i
getSkalViseMorsAktivitetskravVedSamtidigUttak som blokkerte aktivitetsspørsmålet fra å vises. Spørsmålet vises nå basert på morsTotaleProsent < 100 alene, som samsvarer med valideringen i harPeriodeDerMorsAktivitetIkkeErValgt.