### PR TITLE
TFP-6890 "Foreldrepenger med aktivitetskrav" i endre til-panelet for bare …

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -125,6 +125,8 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
     const kunFarHarRett =
         søker === 'FAR_MEDMOR' && (rettighetType === 'BARE_SØKER_RETT' || rettighetType === 'ALENEOMSORG');
 
+    const erBareFarHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
+
     const erValgtePerioderKrysserFamiliehendelse =
         !kunFarHarRett &&
         UttaksperiodeValidatorer.erNoenPerioderFørOgNoenLikEllerEtterFamiliehendelsesdato(
@@ -287,7 +289,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                     {gyldigeStønadskontoerForFarMedmor.map((konto) => {
                         return (
                             <Radio key={konto} value={konto} disabled={!!kontoTypeFarMedmor && erFarMedmorLåst}>
-                                {getStønadskvoteNavnSimple(intl, konto, erMedmorDelAvSøknaden)}
+                                {getStønadskvoteNavnSimple(intl, konto, erMedmorDelAvSøknaden, erBareFarHarRett)}
                             </Radio>
                         );
                     })}

--- a/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
@@ -18,9 +18,17 @@ import {
     erTapteDagerHull,
 } from '../../types/UttaksplanPeriode';
 
-export const getStønadskvoteNavnSimple = (intl: IntlShape, konto: KontoTypeUttak, erMedmorDelAvSøknaden?: boolean) => {
+export const getStønadskvoteNavnSimple = (
+    intl: IntlShape,
+    konto: KontoTypeUttak,
+    erMedmorDelAvSøknaden?: boolean,
+    erBareFarHarRett?: boolean,
+) => {
     if (konto === 'FEDREKVOTE' && erMedmorDelAvSøknaden) {
         return intl.formatMessage({ id: 'uttaksplan.stønadskvotetype.MEDMORSKVOTE' });
+    }
+    if (konto === 'FORELDREPENGER' && erBareFarHarRett) {
+        return intl.formatMessage({ id: 'uttaksplan.stønadskvotetype.AKTIVITETSKRAV_KVOTE_BFHR' });
     }
     return intl.formatMessage({ id: `uttaksplan.stønadskvotetype.${konto}` });
 };


### PR DESCRIPTION
…far har rett

Når bare far har rett viste endre til-panelet "Foreldrepenger" og "Foreldrepenger uten aktivitetskrav". Endrer slik at "Foreldrepenger" vises som "Foreldrepenger med aktivitetskrav" for å samsvare med terminologien i søknaden og PDF.