### PR TITLE
TFP-6961: vis avslåtte perioder korrekt i listevisning

### DIFF
--- a/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
@@ -1029,3 +1029,126 @@ export const BareFarHarRettMedAvslåttePerioder: Story = {
         erEndringssøknad: true,
     },
 };
+
+export const BeggeRettMedAvslåttMødrekvote: Story = {
+    args: {
+        barn: {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2026-01-05'],
+            antallBarn: 1,
+        },
+        foreldreInfo: {
+            rettighetType: 'BEGGE_RETT',
+            søker: 'MOR',
+            navnPåForeldre: { mor: 'Kari', farMedmor: 'Ola' },
+            erMedmorDelAvSøknaden: false,
+        },
+        harAktivitetskravIPeriodeUtenUttak: false,
+        uttakPerioder: [
+            {
+                fom: '2026-01-05',
+                tom: '2026-03-20',
+                kontoType: 'MØDREKVOTE',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2026-03-23',
+                tom: '2026-06-30',
+                kontoType: 'MØDREKVOTE',
+                resultat: {
+                    innvilget: false,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+        ] satisfies Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+        valgtStønadskvote: {
+            kontoer: [
+                { konto: 'MØDREKVOTE', dager: 75 },
+                { konto: 'FEDREKVOTE', dager: 75 },
+                { konto: 'FELLESPERIODE', dager: 80 },
+                { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+            ],
+            minsteretter: MINSTERETTER,
+        },
+        erEndringssøknad: true,
+    },
+};
+
+export const BareFarHarRettMedAvslåttUtsettelse: Story = {
+    args: {
+        barn: {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2026-01-05'],
+            antallBarn: 1,
+        },
+        foreldreInfo: {
+            rettighetType: 'BARE_SØKER_RETT',
+            søker: 'FAR_MEDMOR',
+            navnPåForeldre: { mor: 'Hanne', farMedmor: 'Hans' },
+            erMedmorDelAvSøknaden: false,
+        },
+        harAktivitetskravIPeriodeUtenUttak: false,
+        uttakPerioder: [
+            {
+                fom: '2026-01-05',
+                tom: '2026-05-15',
+                kontoType: 'FORELDREPENGER',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: true,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                morsAktivitet: 'IKKE_OPPGITT',
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+            {
+                fom: '2026-05-18',
+                tom: '2026-06-12',
+                utsettelseÅrsak: 'FRI',
+                resultat: {
+                    innvilget: false,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'AVSLAG_UTSETTELSE_TILBAKE_I_TID',
+                },
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+            {
+                fom: '2026-06-15',
+                tom: '2026-07-10',
+                kontoType: 'FORELDREPENGER',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                morsAktivitet: 'ARBEID',
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+        ] satisfies Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+        valgtStønadskvote: {
+            kontoer: [
+                { konto: 'AKTIVITETSFRI_KVOTE', dager: 50 },
+                { konto: 'FORELDREPENGER', dager: 150 },
+            ],
+            minsteretter: MINSTERETTER,
+        },
+        erEndringssøknad: true,
+    },
+};

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -828,7 +828,7 @@ describe('UttaksplanListe', () => {
         expect(screen.getAllByText('Avslått periode')).toHaveLength(3);
     });
 
-    it('Begge rett - avslått mødrekvote skal vise "Avslått periode" i listevisningen, ikke "mødrekvote"', async () => {
+    it('Begge rett - avslått mødrekvote skal vise "Avslått periode" i listevisningen, ikke "mødrekvote"', () => {
         const { BeggeRettMedAvslåttMødrekvote } = composeStories(stories);
         render(<BeggeRettMedAvslåttMødrekvote />);
 

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -793,25 +793,65 @@ describe('UttaksplanListe', () => {
         expect(screen.getByText('Hva skal skje med resten av planen?')).toBeInTheDocument();
     });
 
-    it('Bare far har rett - avslåtte perioder skal ikke vise "med aktivitetskrav" i listevisningen', async () => {
+    it('Bare far har rett - avslåtte perioder skal vise "Avslått periode" i listevisningen', async () => {
         const { BareFarHarRettMedAvslåttePerioder } = composeStories(stories);
         render(<BareFarHarRettMedAvslåttePerioder />);
 
-        // Alle 3 perioder (fom 2026-03-09 til 2026-07-10) er gruppert i én rad.
-        // Klikk for å åpne:
-        // - Periode 1 (09. mars - 15. mai): innvilget, morsAktivitet=IKKE_OPPGITT → "Foreldrepenger uten aktivitetskrav"
-        // - Periode 2 (18. mai - 12. juni): avslått, morsAktivitet=ARBEID → skal vise "Foreldrepenger" (ikke "med aktivitetskrav")
-        // - Periode 3 (15. juni - 10. juli): innvilget, morsAktivitet=ARBEID → "Foreldrepenger med aktivitetskrav"
-        const periodeRad = screen.getByTestId('2026-03-09 - 2026-07-10');
-        await userEvent.click(periodeRad);
+        // Med grupperings-fix: avslått periode (18. mai - 12. juni) er nå i en egen rad, separert fra innvilgede perioder.
+        // Rad 1 (09. mars - 15. mai): innvilget, morsAktivitet=IKKE_OPPGITT → "Du har foreldrepenger" i header
+        // Rad 2 (18. mai - 12. juni): avslått → "Avslått periode" i header
+        // Rad 3 (15. juni - 10. juli): innvilget, morsAktivitet=ARBEID → "Du har foreldrepenger" i header
 
-        // Innvilget med IKKE_OPPGITT skal vise "uten aktivitetskrav"
+        // Avslått perioden skal ha "Avslått periode" i headeren
+        const avslåttRad = screen.getByTestId('2026-05-18 - 2026-06-12');
+        expect(avslåttRad).toBeInTheDocument();
+        expect(within(avslåttRad).getAllByText('Avslått periode')).toHaveLength(2); // mobile + desktop
+
+        // Innvilgede perioder skal ikke vise "Avslått periode"
+        const innvilgetRad1 = screen.getByTestId('2026-03-09 - 2026-05-15');
+        expect(innvilgetRad1).toBeInTheDocument();
+
+        const innvilgetRad2 = screen.getByTestId('2026-06-15 - 2026-07-10');
+        expect(innvilgetRad2).toBeInTheDocument();
+
+        // Åpne innvilget rad 1 for å sjekke content
+        await userEvent.click(innvilgetRad1);
         expect(screen.getByText('Foreldrepenger uten aktivitetskrav')).toBeInTheDocument();
 
-        // Innvilget med ARBEID skal vise "med aktivitetskrav" (bare 1 gang, ikke 2 – avslått periode skal ikke ha det)
-        expect(screen.getAllByText('Foreldrepenger med aktivitetskrav')).toHaveLength(1);
+        // Åpne innvilget rad 2 for å sjekke content
+        await userEvent.click(innvilgetRad2);
+        expect(screen.getByText('Foreldrepenger med aktivitetskrav')).toBeInTheDocument();
 
-        // Avslått periode skal vise bare "Foreldrepenger" uten aktivitetskrav-tekst
-        expect(screen.getAllByText(/^Foreldrepenger$/)).toHaveLength(1);
+        // Åpne avslått rad for å sjekke content viser "Avslått periode" (ikke "med aktivitetskrav")
+        await userEvent.click(avslåttRad);
+        // Header viser det to ganger (mobile + desktop) + content viser det én gang = 3 totalt
+        expect(screen.getAllByText('Avslått periode')).toHaveLength(3);
+    });
+
+    it('Begge rett - avslått mødrekvote skal vise "Avslått periode" i listevisningen, ikke "mødrekvote"', async () => {
+        const { BeggeRettMedAvslåttMødrekvote } = composeStories(stories);
+        render(<BeggeRettMedAvslåttMødrekvote />);
+
+        // Rad 1 (05. jan - 20. mars): innvilget mødrekvote → "{navn} har foreldrepenger"
+        // Rad 2 (23. mars - 30. juni): avslått mødrekvote → "Avslått periode"
+
+        const avslåttRad = screen.getByTestId('2026-03-23 - 2026-06-30');
+        expect(avslåttRad).toBeInTheDocument();
+        expect(within(avslåttRad).getAllByText('Avslått periode')).toHaveLength(2); // mobile + desktop
+    });
+
+    it('Bare far har rett - avslått utsettelse skal vise "Avslått periode" i listevisningen, ikke utsettelsestekst', async () => {
+        const { BareFarHarRettMedAvslåttUtsettelse } = composeStories(stories);
+        render(<BareFarHarRettMedAvslåttUtsettelse />);
+
+        // Rad med avslått utsettelse (18. mai - 12. juni) skal vise "Avslått periode" i header
+        const avslåttRad = screen.getByTestId('2026-05-18 - 2026-06-12');
+        expect(avslåttRad).toBeInTheDocument();
+        expect(within(avslåttRad).getAllByText('Avslått periode')).toHaveLength(2); // mobile + desktop
+
+        // Skal IKKE vise "Pause i uttaket" eller "Uten foreldrepenger" for den avslåtte perioden
+        await userEvent.click(avslåttRad);
+        expect(within(avslåttRad).queryByText('Pause i uttaket')).not.toBeInTheDocument();
+        expect(within(avslåttRad).queryByText('Uten foreldrepenger')).not.toBeInTheDocument();
     });
 });

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
@@ -1,10 +1,11 @@
 import { CalendarIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
 import { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Button, HStack, VStack } from '@navikt/ds-react';
 
 import { NavnPåForeldre } from '@navikt/fp-types';
+import { Uttaksdagen, formatDateExtended } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../../../context/UttaksplanDataContext';
 import { useUttaksplanRedigering } from '../../../context/UttaksplanRedigeringContext';
@@ -15,8 +16,10 @@ import {
     erTapteDagerHull,
     erVanligUttakPeriode,
 } from '../../../types/UttaksplanPeriode';
+import { getVarighetString } from '../../../utils/dateUtils';
 import { UttakPeriodeBuilder } from '../../../utils/UttakPeriodeBuilder';
 import {
+    erAvslåttPeriode,
     erDetEksisterendePerioderEtterValgtePerioder,
     erOppholdsperiode,
     erOverføringsperiode,
@@ -191,6 +194,16 @@ const Periode = ({
         );
     }
 
+    if (erVanligUttakPeriode(periode) && erAvslåttPeriode(periode) && !erPrematuruker(periode)) {
+        return (
+            <AvslåttPeriodeContent
+                key={genererPeriodeKey(periode)}
+                periode={periode}
+                inneholderKunEnPeriode={inneholderKunEnPeriode}
+            />
+        );
+    }
+
     if (erVanligUttakPeriode(periode) && erUtsettelsesperiode(periode)) {
         return <UtsettelsesPeriodeContent key={genererPeriodeKey(periode)} periode={periode} />;
     }
@@ -270,6 +283,42 @@ const EndreOgSlettKnapper = ({
             <Button type="button" size="small" variant="secondary" icon={<TrashIcon />} onClick={onSlettPeriodeClick}>
                 <FormattedMessage id="uttaksplan.slett" />
             </Button>
+        </HStack>
+    );
+};
+
+const AvslåttPeriodeContent = ({
+    periode,
+    inneholderKunEnPeriode,
+}: {
+    periode: Uttaksplanperiode;
+    inneholderKunEnPeriode: boolean;
+}) => {
+    const intl = useIntl();
+
+    const lengdeTekst = inneholderKunEnPeriode
+        ? intl.formatMessage({ id: 'uttaksplan.varighet.helePerioden' })
+        : `${formatDateExtended(periode.fom)} - ${formatDateExtended(periode.tom)}`;
+
+    return (
+        <HStack gap="space-8">
+            <div>
+                <CalendarIcon width={24} height={24} />
+            </div>
+            <VStack gap="space-4">
+                <HStack gap="space-8">
+                    <BodyShort weight="semibold">{lengdeTekst}</BodyShort>
+                    <BodyShort>
+                        {getVarighetString(
+                            Uttaksdagen.denneEllerNeste(periode.fom).getUttaksdagerFremTilOgMedDato(periode.tom),
+                            intl,
+                        )}
+                    </BodyShort>
+                </HStack>
+                <BodyShort>
+                    <FormattedMessage id="uttaksplan.periodeListeHeader.avslåttAnnet" />
+                </BodyShort>
+            </VStack>
         </HStack>
     );
 };

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
@@ -16,6 +16,7 @@ import { capitalizeFirstLetter } from '@navikt/fp-utils';
 
 import { Uttaksplanperiode, erVanligUttakPeriode } from '../../../types/UttaksplanPeriode';
 import {
+    erAlleUttaksplanperioderAvslått,
     erUttaksplanperiodeErForelderMor,
     erUttaksplanperiodeEøs,
     erUttaksplanperiodeFamiliehendelseDato,
@@ -26,7 +27,6 @@ import {
     getSisteUttaksplanperiodeTom,
     getUttaksplanperiodeForelder,
     getUttaksplanperiodeUtsettelseÅrsak,
-    harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet,
     harUttaksplanperiodePrematuruker,
 } from '../../utils/uttaksplanperiodeUtils';
 
@@ -41,6 +41,10 @@ export const finnBakgrunnsfarge = (
 
     if (harMorsAktivitetIkkeErValgt) {
         return 'bg-ax-danger-200';
+    }
+
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
+        return 'bg-ax-bg-default shadow-[inset_0_0_0_2px_var(--ax-bg-neutral-strong)]';
     }
 
     if (erUttaksplanperiodeEøs(uttaksplanperioder)) {
@@ -73,6 +77,10 @@ export const finnBakgrunnsfarge = (
 const getIkonFarge = (uttaksplanperiode: Uttaksplanperiode[], erFamiliehendelse?: boolean) => {
     if (erFamiliehendelse) {
         return 'text-ax-danger-600';
+    }
+
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperiode)) {
+        return 'text-ax-neutral-800';
     }
 
     if (erUttaksplanperiodeTapteDager(uttaksplanperiode)) {
@@ -132,7 +140,7 @@ export const getTekst = (
     if (harUttaksplanperiodePrematuruker(uttaksplanperioder)) {
         return intl.formatMessage({ id: 'uttaksplan.periodeListeHeader.pleiepenger' });
     }
-    if (harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet(uttaksplanperioder)) {
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
         return intl.formatMessage({ id: 'uttaksplan.periodeListeHeader.avslåttAnnet' });
     }
 
@@ -241,6 +249,10 @@ export const getIkon = (uttaksplanperioder: Uttaksplanperiode[], familiehendelse
 };
 
 export const getBorderFarge = (uttaksplanperioder: Uttaksplanperiode[]) => {
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
+        return 'border-ax-bg-neutral-strong';
+    }
+
     if (erUttaksplanperiodeEøs(uttaksplanperioder)) {
         return 'border-ax-success-400';
     }

--- a/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.ts
+++ b/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { Uttaksplanperiode, erUttaksplanHull } from '../../types/UttaksplanPeriode';
-import { erPrematuruker, erUtsettelsesperiode } from '../../utils/periodeUtils';
+import { erAvslåttPeriode, erPrematuruker, erUtsettelsesperiode } from '../../utils/periodeUtils';
 
 export const mapUttaksplanperioderTilRaderIListe = (
     saksperioderInkludertHull: Uttaksplanperiode[],
@@ -78,6 +78,9 @@ const erSamtidigUttak = (a: Uttaksplanperiode, b: Uttaksplanperiode): boolean =>
 const harSammeForelder = (a: Uttaksplanperiode, b: Uttaksplanperiode): boolean =>
     'forelder' in a && 'forelder' in b && a.forelder === b.forelder;
 
+const harSammeAvslåttStatus = (a: Uttaksplanperiode, b: Uttaksplanperiode): boolean =>
+    !!erAvslåttPeriode(a) === !!erAvslåttPeriode(b);
+
 const kanGrupperesPåSammeRad = (
     forrige: Uttaksplanperiode,
     nestePeriode: Uttaksplanperiode,
@@ -86,6 +89,7 @@ const kanGrupperesPåSammeRad = (
     !erUttaksplanHull(forrige) &&
     !erUttaksplanHull(nestePeriode) &&
     harSammeForelder(forrige, nestePeriode) &&
+    harSammeAvslåttStatus(forrige, nestePeriode) &&
     beggePerioderFørEllerEtterFamiliehendelsedato(forrige, nestePeriode, familiehendelsesdato);
 
 const beggePerioderFørEllerEtterFamiliehendelsedato = (

--- a/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
@@ -6,6 +6,7 @@ import {
     erTapteDagerHull,
     erVanligUttakPeriode,
 } from '../../types/UttaksplanPeriode';
+import { erAvslåttPeriode } from '../../utils/periodeUtils';
 
 export const getFørsteUttaksplanperiodeFom = (uttaksplanperioder: Uttaksplanperiode[]) => {
     return uttaksplanperioder.at(0)!.fom;
@@ -57,16 +58,6 @@ export const harUttaksplanperiodePrematuruker = (uttaksplanperioder: Uttaksplanp
     return erVanligUttakPeriode(periode) && periode.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER';
 };
 
-export const harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet = (uttaksplanperioder: Uttaksplanperiode[]) => {
-    if (uttaksplanperioder.length !== 1) {
-        return false;
-    }
-    const periode = uttaksplanperioder.at(0)!;
-    return (
-        erVanligUttakPeriode(periode) && periode.resultat?.innvilget === false && periode.resultat?.årsak === 'ANNET'
-    );
-};
-
 export const erUttaksplanperiodeUtsettelseOpphold = (uttaksplanperioder: Uttaksplanperiode[]) => {
     if (uttaksplanperioder.length !== 1) {
         return false;
@@ -98,6 +89,17 @@ export const getUttaksplanperiodeForelder = (uttaksplanperioder: Uttaksplanperio
 export const erUttaksplanperiodeErForelderMor = (uttaksplanperioder: Uttaksplanperiode[]) => {
     const forelder = getUttaksplanperiodeForelder(uttaksplanperioder);
     return forelder === 'MOR';
+};
+
+export const erAlleUttaksplanperioderAvslått = (uttaksplanperioder: Uttaksplanperiode[]) => {
+    return (
+        uttaksplanperioder.length > 0 &&
+        uttaksplanperioder.every(
+            (p) =>
+                erAvslåttPeriode(p) &&
+                !(erVanligUttakPeriode(p) && p.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER'),
+        )
+    );
 };
 
 export const erUttaksplanperiodeEøs = (uttaksplanperioder: Uttaksplanperiode[]) => {


### PR DESCRIPTION
Listevisningen viste feil tekst for avslåtte perioder (f.eks. 'foreldrepenger', 'mødrekvote', 'dager du kan tape') i stedet for 'Avslått periode'. Kalendervisningen viste riktig. Feilen gjaldt både 'bare far har rett' og 'begge har rett'.

Endringer:
- Lagt til erAlleUttaksplanperioderAvslått() som fanger alle avslåtte perioder
- Header viser nå 'Avslått periode' med riktig styling (hvit bg, mørk ramme)
- Avslåtte perioder grupperes ikke sammen med innvilgede perioder
- Ny AvslåttPeriodeContent-komponent for innholdsvisning
- Oppdatert tester og lagt til nye stories