### PR TITLE
fix: sanitiser tom streng for morsAktivitet før lagring i context

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -696,7 +696,7 @@ export const mapFraFormValuesTilUttakPeriode = (
             fom: periode.fom,
             tom: periode.tom,
             kontoType: values.kontoTypeMor === 'AKTIVITETSFRI_KVOTE' ? 'FORELDREPENGER' : values.kontoTypeMor,
-            morsAktivitet: values.morsAktivitet,
+            morsAktivitet: values.morsAktivitet || undefined,
             forelder: 'MOR',
             gradering:
                 !erOverføringMor && values.skalDuKombinereArbeidOgUttakMor
@@ -715,7 +715,7 @@ export const mapFraFormValuesTilUttakPeriode = (
             tom: periode.tom,
             kontoType:
                 values.kontoTypeFarMedmor === 'AKTIVITETSFRI_KVOTE' ? 'FORELDREPENGER' : values.kontoTypeFarMedmor,
-            morsAktivitet: values.kontoTypeFarMedmor === 'AKTIVITETSFRI_KVOTE' ? 'IKKE_OPPGITT' : values.morsAktivitet,
+            morsAktivitet: values.kontoTypeFarMedmor === 'AKTIVITETSFRI_KVOTE' ? 'IKKE_OPPGITT' : (values.morsAktivitet || undefined),
             forelder: 'FAR_MEDMOR',
             gradering:
                 !erOverføringFarMedmor && values.skalDuKombinereArbeidOgUttakFarMedmor

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/utsettelse/LeggTilPausePanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/utsettelse/LeggTilPausePanel.tsx
@@ -36,7 +36,7 @@ export const LeggTilPausePanel = ({ setVisPausePanel }: Props) => {
                         tom: p.tom,
                         utsettelseÅrsak: 'FRI',
                         flerbarnsdager: false,
-                        morsAktivitet: formValues.morsAktivitet,
+                        morsAktivitet: formValues.morsAktivitet || undefined,
                     }) satisfies UttakPeriode_fpoversikt,
             ),
             false,

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -214,7 +214,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                         tom,
                         forelder: søker,
                         utsettelseÅrsak: 'FRI',
-                        morsAktivitet: values.morsAktivitet,
+                        morsAktivitet: values.morsAktivitet || undefined,
                         flerbarnsdager: false,
                     },
                 ],


### PR DESCRIPTION
Når RhfSelect for morsAktivitet vert skjult etter å ha vore vist (f.eks. ved toggling av flerbarnsdager), kan form-verdien bli ein tom streng frå select-elementets placeholder-option. Denne tomme strengen flyt gjennom til backend som ikkje kan deserialisere "" til MorsAktivitet-enum.

Konverterer no "" til undefined i mapFraFormValuesTilUttakPeriode og tilsvarande stader der form-verdiar vert mappa til periodar.

