### PR TITLE
Fix: handter tom gjeldendeUttaksplan array i endringssøknad

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -119,7 +119,8 @@ export const UttaksplanForm = ({
     const finnFørsteSubmitFeilmelding = useFinnFørsteSubmitFeilmelding({ opprinneligPlan });
 
     const onSubmit = (formValues: FormValues) => {
-        const planForValidering = gjeldendeUttaksplan ?? defaultUttaksperioder;
+        const planForValidering =
+            uttaksplan === undefined ? defaultUttaksperioder : (gjeldendeUttaksplan ?? defaultUttaksperioder);
         const feilmelding = finnFørsteSubmitFeilmelding(planForValidering);
 
         if (feilmelding) {

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -131,7 +131,7 @@ export const UttaksplanForm = ({
 
         oppdaterHarJustertUttakVedFødsel(visAutomatiskJustering ? formValues.ønskerJustertUttakVedFødsel : undefined);
 
-        if (!gjeldendeUttaksplan || gjeldendeUttaksplan.length === 0) {
+        if (uttaksplan === undefined) {
             oppdaterUttaksplan(defaultUttaksperioder);
         }
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -131,7 +131,7 @@ export const UttaksplanForm = ({
 
         oppdaterHarJustertUttakVedFødsel(visAutomatiskJustering ? formValues.ønskerJustertUttakVedFødsel : undefined);
 
-        if (!gjeldendeUttaksplan) {
+        if (!gjeldendeUttaksplan || gjeldendeUttaksplan.length === 0) {
             oppdaterUttaksplan(defaultUttaksperioder);
         }
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'api/queries';
-import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
+import { Action, ContextDataMap, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
@@ -65,6 +65,7 @@ type StoryArgs = {
     mellomlagreSøknadOgNaviger?: () => Promise<void>;
     avbrytSøknad: () => void;
     gåTilNesteSide?: (action: Action) => void;
+    initialState?: ContextDataMap;
     søkersituasjon: SøkersituasjonFp;
     annenForelder: AnnenForelder;
     barnet: Barn;
@@ -86,6 +87,7 @@ const meta = {
         mellomlagreSøknadOgNaviger,
         avbrytSøknad,
         gåTilNesteSide,
+        initialState,
         søkersituasjon,
         annenForelder,
         barnet,
@@ -107,6 +109,7 @@ const meta = {
                         [ContextDataType.ANNEN_FORELDER]: annenForelder,
                         [ContextDataType.FORDELING]: fordeling,
                         [ContextDataType.PERIODE_MED_FORELDREPENGER]: dekningsgrad,
+                        ...initialState,
                     }}
                 >
                     <UttaksplanSteg

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
@@ -120,6 +120,33 @@ describe('<UttaksplanSteg>', () => {
     );
 
     it(
+        'skal initialisere uttaksplan i endringssøknad når den mangler i context',
+        mswWrapper(async ({ setHandlers }) => {
+            const gåTilNesteSide = vi.fn();
+            const mellomlagreSøknadOgNaviger = vi.fn();
+            setHandlers(FødselMorOgFarBeggeHarRett.parameters.msw);
+
+            render(
+                <FødselMorOgFarBeggeHarRett
+                    gåTilNesteSide={gåTilNesteSide}
+                    mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                    initialState={{ [ContextDataType.VALGT_EKSISTERENDE_SAKSNR]: 'SAKSNR-1' }}
+                />,
+            );
+
+            expect(await screen.findAllByText('Din plan med foreldrepenger')).toHaveLength(2);
+
+            await userEvent.click(screen.getByText('Neste steg'));
+
+            const uttaksplanAction = gåTilNesteSide.mock.calls.find(
+                ([action]) => action.key === ContextDataType.UTTAKSPLAN,
+            );
+            expect(uttaksplanAction).toBeDefined();
+            expect((uttaksplanAction![0].data as unknown[]).length).toBeGreaterThan(0);
+        }),
+    );
+
+    it(
         'skal skjule info-teksten når annen forelder ikke har rett',
         mswWrapper(async ({ setHandlers }) => {
             setHandlers(FødselMorOgFarKunMorHarRett.parameters.msw);


### PR DESCRIPTION
 For endringssøknad der uttaksplan er undefined i context, blir
 gjeldendeUttaksplan sett til ein tom array (truthy), slik at
 oppdaterUttaksplan aldri vart kalla. Dette førte til at UTTAKSPLAN
 forblei undefined i context, og UttaksplanOppsummeringsliste kasta
 'Data er ikke oppgitt' ved navigasjon til oppsummering.

 Løysing: utvid sjekken til å også inkludere tom array.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>