### PR TITLE
TFP-6959: avslåtte perioder vises og sendes som foreldrepenger i endringss…

### DIFF
--- a/apps/foreldrepengesoknad/src/api/apiUtils.ts
+++ b/apps/foreldrepengesoknad/src/api/apiUtils.ts
@@ -269,7 +269,7 @@ export const mapTilEndringssøknadDto = (
         : søkersNyePerioder;
 
     const mappaUttaksperioder = midlertidigMappingAvUttaksplan(
-        filtrerUtEøsPeriode(perioderForInnsending),
+        filtrerUtAvslåttePerioder(filtrerUtEøsPeriode(perioderForInnsending)),
         barn,
         annenForelder,
     );
@@ -312,6 +312,10 @@ const filtrerUtEøsPeriode = (
     nyUttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
 ): UttakPeriode_fpoversikt[] => {
     return nyUttaksplan.filter((periode) => Uttaksperioden.erIkkeEøsPeriode(periode));
+};
+
+const filtrerUtAvslåttePerioder = (perioder: UttakPeriode_fpoversikt[]): UttakPeriode_fpoversikt[] => {
+    return perioder.filter((periode) => periode.resultat?.innvilget !== false);
 };
 
 const filtrerUtAnnenPartsPerioder = (

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -99,7 +99,7 @@
     "uttaksplan.periodeListeHeader.HarForeldrepenger": "{navn} has parental benefits",
     "uttaksplan.periodeListeHeader.HarEøsForeldrepenger": "{navn} has parental benefits (EU/EEA)",
     "uttaksplan.periodeListeHeader.pleiepenger": "Attendance allowance",
-    "uttaksplan.periodeListeHeader.avslåttAnnet": "Rejected period",
+    "uttaksplan.periodeListeHeader.avslåttAnnet": "Deducted days",
     "uttaksplan.slettPeriode.tittel": "Delete period",
     "uttaksplan.slettPeriode.hvilkePerioder": "Which periods would you like to delete?",
     "uttaksplan.ingenPerioder.tittel": "All periods have been removed from the plan.",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -99,7 +99,7 @@
     "uttaksplan.periodeListeHeader.HarForeldrepenger": "{navn} har foreldrepenger",
     "uttaksplan.periodeListeHeader.HarEøsForeldrepenger": "{navn} har foreldrepenger (EU/EØS)",
     "uttaksplan.periodeListeHeader.pleiepenger": "Pleiepenger",
-    "uttaksplan.periodeListeHeader.avslåttAnnet": "Avslått periode",
+    "uttaksplan.periodeListeHeader.avslåttAnnet": "Trekte dager",
     "uttaksplan.slettPeriode.tittel": "Slett periode",
     "uttaksplan.slettPeriode.hvilkePerioder": "Hvilke perioder vil du slette?",
     "uttaksplan.ingenPerioder.tittel": "Alle perioder er fjernet fra planen.",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -99,7 +99,7 @@
     "uttaksplan.periodeListeHeader.HarForeldrepenger": "{navn} har foreldrepengar",
     "uttaksplan.periodeListeHeader.HarEøsForeldrepenger": "{navn} har foreldrepengar (EU/EØS)",
     "uttaksplan.periodeListeHeader.pleiepenger": "Pleiepengar",
-    "uttaksplan.periodeListeHeader.avslåttAnnet": "Avslått periode",
+    "uttaksplan.periodeListeHeader.avslåttAnnet": "Trekte dagar",
     "uttaksplan.slettPeriode.tittel": "Slett periode",
     "uttaksplan.slettPeriode.hvilkePerioder": "Kva periodar vil du slette?",
     "uttaksplan.ingenPerioder.tittel": "Alle periodar er fjerna frå planen.",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -99,7 +99,7 @@
     "uttaksplan.periodeListeHeader.HarForeldrepenger": "{navn} har foreldrepengar",
     "uttaksplan.periodeListeHeader.HarEøsForeldrepenger": "{navn} har foreldrepengar (EU/EØS)",
     "uttaksplan.periodeListeHeader.pleiepenger": "Pleiepengar",
-    "uttaksplan.periodeListeHeader.avslåttAnnet": "Trekte dagar",
+    "uttaksplan.periodeListeHeader.avslåttAnnet": "Avslått periode",
     "uttaksplan.slettPeriode.tittel": "Slett periode",
     "uttaksplan.slettPeriode.hvilkePerioder": "Kva periodar vil du slette?",
     "uttaksplan.ingenPerioder.tittel": "Alle periodar er fjerna frå planen.",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -99,7 +99,7 @@
     "uttaksplan.periodeListeHeader.HarForeldrepenger": "{navn} har foreldrepengar",
     "uttaksplan.periodeListeHeader.HarEøsForeldrepenger": "{navn} har foreldrepengar (EU/EØS)",
     "uttaksplan.periodeListeHeader.pleiepenger": "Pleiepengar",
-    "uttaksplan.periodeListeHeader.avslåttAnnet": "Avslått periode",
+    "uttaksplan.periodeListeHeader.avslåttAnnet": "Trekte dager",
     "uttaksplan.slettPeriode.tittel": "Slett periode",
     "uttaksplan.slettPeriode.hvilkePerioder": "Kva periodar vil du slette?",
     "uttaksplan.ingenPerioder.tittel": "Alle periodar er fjerna frå planen.",

--- a/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.stories.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.stories.tsx
@@ -163,3 +163,77 @@ export const PrematurUker: Story = {
         erPeriodeneTilAnnenPartLåst: false,
     },
 };
+
+export const AvslåttePerioder: Story = {
+    name: 'Mor har avslåtte perioder',
+    args: {
+        foreldreInfo: {
+            rettighetType: 'BEGGE_RETT',
+            søker: 'MOR',
+            navnPåForeldre: {
+                farMedmor: 'Far',
+                mor: 'Mor',
+            },
+            erMedmorDelAvSøknaden: true,
+        },
+        barn: {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2025-09-01'],
+            termindato: '2025-09-01',
+            antallBarn: 1,
+        },
+        harAktivitetskravIPeriodeUtenUttak: false,
+        uttakPerioder: [
+            {
+                fom: '2025-09-01',
+                tom: '2025-10-10',
+                kontoType: 'MØDREKVOTE',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-10-13',
+                tom: '2025-11-21',
+                kontoType: 'FELLESPERIODE',
+                resultat: {
+                    innvilget: false,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'AVSLAG_HULL_MELLOM_FORELDRENES_PERIODER',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+            {
+                fom: '2025-11-24',
+                tom: '2026-01-02',
+                kontoType: 'FELLESPERIODE',
+                resultat: {
+                    innvilget: true,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'MOR',
+            },
+        ],
+        valgtStønadskvote: {
+            kontoer: [
+                { konto: 'MØDREKVOTE', dager: 75 },
+                { konto: 'FEDREKVOTE', dager: 75 },
+                { konto: 'FELLESPERIODE', dager: 80 },
+                { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+            ],
+            minsteretter: MINSTERETTER,
+        },
+        erEndringssøknad: true,
+        erPeriodeneTilAnnenPartLåst: false,
+    },
+};

--- a/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
@@ -58,8 +58,8 @@ describe('<UttaksplanListe - innsyn - fødsel mor >', () => {
         // Opna den avslåtte perioden
         await userEvent.click(screen.getByText('13. okt. 25 - 21. nov. 25'));
 
-        // Sjekk at innhaldet viser "Trekte dager"
-        expect(screen.getByText('Trekte dager')).toBeInTheDocument();
+        // Sjekk at innhaldet viser "Trekte dager" (vises både i header og i innhald)
+        expect(screen.getAllByText('Trekte dager').length).toBeGreaterThanOrEqual(1);
 
         // Skal ikkje ha endre/slett-knappar
         expect(screen.queryByText('Endre')).not.toBeInTheDocument();

--- a/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
@@ -58,8 +58,8 @@ describe('<UttaksplanListe - innsyn - fødsel mor >', () => {
         // Opna den avslåtte perioden
         await userEvent.click(screen.getByText('13. okt. 25 - 21. nov. 25'));
 
-        // Sjekk at innhaldet viser "Avslått periode"
-        expect(screen.getByText('Avslått periode')).toBeInTheDocument();
+        // Sjekk at innhaldet viser "Trekte dager"
+        expect(screen.getByText('Trekte dager')).toBeInTheDocument();
 
         // Skal ikkje ha endre/slett-knappar
         expect(screen.queryByText('Endre')).not.toBeInTheDocument();

--- a/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.innsyn.fødsel.mor.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import * as stories from './UttaksplanListe.innsyn.fødsel.mor.stories';
 
-const { MorAleneOmOmsorg, PrematurUker } = composeStories(stories);
+const { MorAleneOmOmsorg, PrematurUker, AvslåttePerioder } = composeStories(stories);
 
 describe('<UttaksplanListe - innsyn - fødsel mor >', () => {
     it('Mor er alene om omsorg', async () => {
@@ -39,6 +39,29 @@ describe('<UttaksplanListe - innsyn - fødsel mor >', () => {
         ).toBeInTheDocument();
         expect(screen.getByText('Denne perioden kan ikke endres eller slettes.')).toBeInTheDocument();
 
+        expect(screen.queryByText('Endre')).not.toBeInTheDocument();
+        expect(screen.queryByText('Slett')).not.toBeInTheDocument();
+    });
+
+    it('Avslåtte perioder vises med korrekt tekst og er ikkje redigerbare', async () => {
+        render(<AvslåttePerioder />);
+
+        // Innvilga periode
+        expect(screen.getByText('01. sep. 25 - 10. okt. 25')).toBeInTheDocument();
+
+        // Avslått periode
+        expect(screen.getByText('13. okt. 25 - 21. nov. 25')).toBeInTheDocument();
+
+        // Innvilga periode etter avslått
+        expect(screen.getByText('24. nov. 25 - 02. jan. 26')).toBeInTheDocument();
+
+        // Opna den avslåtte perioden
+        await userEvent.click(screen.getByText('13. okt. 25 - 21. nov. 25'));
+
+        // Sjekk at innhaldet viser "Avslått periode"
+        expect(screen.getByText('Avslått periode')).toBeInTheDocument();
+
+        // Skal ikkje ha endre/slett-knappar
         expect(screen.queryByText('Endre')).not.toBeInTheDocument();
         expect(screen.queryByText('Slett')).not.toBeInTheDocument();
     });

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -797,21 +797,21 @@ describe('UttaksplanListe', () => {
         const { BareFarHarRettMedAvslåttePerioder } = composeStories(stories);
         render(<BareFarHarRettMedAvslåttePerioder />);
 
-        // Alle 3 perioder (fom 2026-03-09 til 2026-07-10) er gruppert i én rad.
-        // Klikk for å åpne:
-        // - Periode 1 (09. mars - 15. mai): innvilget, morsAktivitet=IKKE_OPPGITT → "Foreldrepenger uten aktivitetskrav"
-        // - Periode 2 (18. mai - 12. juni): avslått, morsAktivitet=ARBEID → skal vise "Foreldrepenger" (ikke "med aktivitetskrav")
-        // - Periode 3 (15. juni - 10. juli): innvilget, morsAktivitet=ARBEID → "Foreldrepenger med aktivitetskrav"
-        const periodeRad = screen.getByTestId('2026-03-09 - 2026-07-10');
-        await userEvent.click(periodeRad);
+        // Avslåtte perioder vert no skilde ut i eiga rad, så me får 3 rader:
+        // - Rad 1 (09. mars - 15. mai): innvilget, morsAktivitet=IKKE_OPPGITT → "Foreldrepenger uten aktivitetskrav"
+        // - Rad 2 (18. mai - 12. juni): avslått, morsAktivitet=ARBEID → skal vise "Trekte dager" (ikkje "med aktivitetskrav")
+        // - Rad 3 (15. juni - 10. juli): innvilget, morsAktivitet=ARBEID → "Foreldrepenger med aktivitetskrav"
+        await userEvent.click(screen.getByTestId('2026-03-09 - 2026-05-15'));
+        await userEvent.click(screen.getByTestId('2026-05-18 - 2026-06-12'));
+        await userEvent.click(screen.getByTestId('2026-06-15 - 2026-07-10'));
 
         // Innvilget med IKKE_OPPGITT skal vise "uten aktivitetskrav"
         expect(screen.getByText('Foreldrepenger uten aktivitetskrav')).toBeInTheDocument();
 
-        // Innvilget med ARBEID skal vise "med aktivitetskrav" (bare 1 gang, ikke 2 – avslått periode skal ikke ha det)
+        // Innvilget med ARBEID skal vise "med aktivitetskrav" (bare 1 gang – avslått periode skal ikke ha det)
         expect(screen.getAllByText('Foreldrepenger med aktivitetskrav')).toHaveLength(1);
 
-        // Avslått periode skal vise bare "Foreldrepenger" uten aktivitetskrav-tekst
-        expect(screen.getAllByText(/^Foreldrepenger$/)).toHaveLength(1);
+        // Avslått periode skal ikke vise "Foreldrepenger" som tekst i innhaldet
+        expect(screen.queryByText(/^Foreldrepenger$/)).not.toBeInTheDocument();
     });
 });

--- a/packages/uttaksplan/src/liste/periode-liste-item/PeriodeListeItem.stories.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/PeriodeListeItem.stories.tsx
@@ -241,3 +241,33 @@ export const PeriodeUtenUttak: Story = {
         erEndringssøknad: false,
     },
 };
+
+export const AvslåttPeriode: Story = {
+    args: {
+        barn: {
+            antallBarn: 1,
+            fødselsdatoer: ['2024-06-01'],
+            type: BarnType.FØDT,
+            termindato: '2024-06-01',
+        },
+        erAleneOmOmsorg: false,
+        erFarEllerMedmor: false,
+        familiehendelsedato: '2024-06-01',
+        uttaksplanperioder: [
+            {
+                fom: '2024-06-01',
+                tom: '2024-06-28',
+                forelder: 'MOR',
+                kontoType: 'FELLESPERIODE',
+                flerbarnsdager: false,
+                resultat: {
+                    innvilget: false,
+                    trekkerMinsterett: false,
+                    trekkerDager: true,
+                    årsak: 'AVSLAG_HULL_MELLOM_FORELDRENES_PERIODER',
+                },
+            },
+        ],
+        erEndringssøknad: true,
+    },
+};

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
@@ -196,16 +196,16 @@ const Periode = ({
         );
     }
 
+    if (erPrematuruker(periode)) {
+        return <PrematurukerContent key={genererPeriodeKey(periode)} />;
+    }
+
     if (erVanligUttakPeriode(periode) && erAvslåttPeriode(periode)) {
         return <AvslåttPeriodeContent key={genererPeriodeKey(periode)} periode={periode} />;
     }
 
     if (erVanligUttakPeriode(periode) && erUtsettelsesperiode(periode)) {
         return <UtsettelsesPeriodeContent key={genererPeriodeKey(periode)} periode={periode} />;
-    }
-
-    if (erPrematuruker(periode)) {
-        return <PrematurukerContent key={genererPeriodeKey(periode)} />;
     }
 
     if ((erVanligUttakPeriode(periode) && erUttaksperiode(periode)) || erEøsUttakPeriode(periode)) {

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/PeriodeListeContent.tsx
@@ -1,10 +1,11 @@
-import { CalendarIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
+import { CalendarIcon, InformationSquareFillIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
 import { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Button, HStack, VStack } from '@navikt/ds-react';
 
 import { NavnPåForeldre } from '@navikt/fp-types';
+import { Uttaksdagen, formatDateExtended } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../../../context/UttaksplanDataContext';
 import { useUttaksplanRedigering } from '../../../context/UttaksplanRedigeringContext';
@@ -16,7 +17,9 @@ import {
     erVanligUttakPeriode,
 } from '../../../types/UttaksplanPeriode';
 import { UttakPeriodeBuilder } from '../../../utils/UttakPeriodeBuilder';
+import { getVarighetString } from '../../../utils/dateUtils';
 import {
+    erAvslåttPeriode,
     erDetEksisterendePerioderEtterValgtePerioder,
     erOppholdsperiode,
     erOverføringsperiode,
@@ -26,6 +29,7 @@ import {
 } from '../../../utils/periodeUtils';
 import { genererPeriodeKey } from '../../utils/uttaksplanListeUtils';
 import {
+    erAlleUttaksplanperioderAvslått,
     erUttaksplanperiodeEøs,
     erUttaksplanperiodeFamiliehendelseDato,
     erUttaksplanperiodeSamtidigUttak,
@@ -72,7 +76,8 @@ export const PeriodeListeContent = ({ isReadOnly, uttaksplanperioder }: Props) =
     const erRedigerbar =
         !erUttaksplanperiodeTapteDager(uttaksplanperioder) &&
         !erUttaksplanperiodeUtenUttak(uttaksplanperioder) &&
-        !harUttaksplanperiodePrematuruker(uttaksplanperioder);
+        !harUttaksplanperiodePrematuruker(uttaksplanperioder) &&
+        !erAlleUttaksplanperioderAvslått(uttaksplanperioder);
 
     const erFamiliehendelse = erUttaksplanperiodeFamiliehendelseDato(uttaksplanperioder);
 
@@ -191,6 +196,10 @@ const Periode = ({
         );
     }
 
+    if (erVanligUttakPeriode(periode) && erAvslåttPeriode(periode)) {
+        return <AvslåttPeriodeContent key={genererPeriodeKey(periode)} periode={periode} />;
+    }
+
     if (erVanligUttakPeriode(periode) && erUtsettelsesperiode(periode)) {
         return <UtsettelsesPeriodeContent key={genererPeriodeKey(periode)} periode={periode} />;
     }
@@ -217,6 +226,33 @@ const Periode = ({
                 <CalendarIcon width={24} height={24} />
             </div>
             <BodyShort weight="semibold">Ikke implementert</BodyShort>
+        </HStack>
+    );
+};
+
+const AvslåttPeriodeContent = ({ periode }: { periode: Uttaksplanperiode }) => {
+    const intl = useIntl();
+    return (
+        <HStack gap="space-8">
+            <div>
+                <InformationSquareFillIcon width={24} height={24} className="text-ax-neutral-800" />
+            </div>
+            <VStack gap="space-4">
+                <HStack gap="space-8">
+                    <BodyShort weight="semibold">
+                        {`${formatDateExtended(periode.fom)} - ${formatDateExtended(periode.tom)}`}
+                    </BodyShort>
+                    <BodyShort>
+                        {getVarighetString(
+                            Uttaksdagen.denneEllerNeste(periode.fom).getUttaksdagerFremTilOgMedDato(periode.tom),
+                            intl,
+                        )}
+                    </BodyShort>
+                </HStack>
+                <BodyShort>
+                    <FormattedMessage id="uttaksplan.periodeListeHeader.avslåttAnnet" />
+                </BodyShort>
+            </VStack>
         </HStack>
     );
 };

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
@@ -23,10 +23,10 @@ import {
     erUttaksplanperiodeTapteDager,
     erUttaksplanperiodeUtenUttak,
     erUttaksplanperiodeUtsettelse,
+    erAlleUttaksplanperioderAvslått,
     getSisteUttaksplanperiodeTom,
     getUttaksplanperiodeForelder,
     getUttaksplanperiodeUtsettelseÅrsak,
-    harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet,
     harUttaksplanperiodePrematuruker,
 } from '../../utils/uttaksplanperiodeUtils';
 
@@ -45,6 +45,10 @@ export const finnBakgrunnsfarge = (
 
     if (erUttaksplanperiodeEøs(uttaksplanperioder)) {
         return 'bg-ax-accent-400';
+    }
+
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
+        return 'bg-ax-bg-default shadow-[inset_0_0_0_2px_var(--ax-bg-neutral-strong)]';
     }
 
     if (erUttaksplanperiodeTapteDager(uttaksplanperioder)) {
@@ -73,6 +77,10 @@ export const finnBakgrunnsfarge = (
 const getIkonFarge = (uttaksplanperiode: Uttaksplanperiode[], erFamiliehendelse?: boolean) => {
     if (erFamiliehendelse) {
         return 'text-ax-danger-600';
+    }
+
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperiode)) {
+        return 'text-ax-neutral-800';
     }
 
     if (erUttaksplanperiodeTapteDager(uttaksplanperiode)) {
@@ -132,7 +140,7 @@ export const getTekst = (
     if (harUttaksplanperiodePrematuruker(uttaksplanperioder)) {
         return intl.formatMessage({ id: 'uttaksplan.periodeListeHeader.pleiepenger' });
     }
-    if (harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet(uttaksplanperioder)) {
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
         return intl.formatMessage({ id: 'uttaksplan.periodeListeHeader.avslåttAnnet' });
     }
 
@@ -212,7 +220,11 @@ export const getIkon = (uttaksplanperioder: Uttaksplanperiode[], familiehendelse
         return <HeartFillIcon className={ikonfarge} width={24} height={24} />;
     }
 
-    if (erUttaksplanperiodeTapteDager(uttaksplanperioder) || harUttaksplanperiodePrematuruker(uttaksplanperioder)) {
+    if (
+        erUttaksplanperiodeTapteDager(uttaksplanperioder) ||
+        harUttaksplanperiodePrematuruker(uttaksplanperioder) ||
+        erAlleUttaksplanperioderAvslått(uttaksplanperioder)
+    ) {
         return <InformationSquareFillIcon className={ikonfarge} width={24} height={24} />;
     }
 
@@ -247,6 +259,10 @@ export const getBorderFarge = (uttaksplanperioder: Uttaksplanperiode[]) => {
 
     if (erUttaksplanperiodeFamiliehendelseDato(uttaksplanperioder)) {
         return 'border-ax-danger-100';
+    }
+
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperioder)) {
+        return 'border-ax-bg-neutral-strong';
     }
 
     if (erUttaksplanperiodeTapteDager(uttaksplanperioder)) {

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeaderUtils.tsx
@@ -79,11 +79,7 @@ const getIkonFarge = (uttaksplanperiode: Uttaksplanperiode[], erFamiliehendelse?
         return 'text-ax-danger-600';
     }
 
-    if (erAlleUttaksplanperioderAvslått(uttaksplanperiode)) {
-        return 'text-ax-neutral-800';
-    }
-
-    if (erUttaksplanperiodeTapteDager(uttaksplanperiode)) {
+    if (erAlleUttaksplanperioderAvslått(uttaksplanperiode) || erUttaksplanperiodeTapteDager(uttaksplanperiode)) {
         return 'text-ax-neutral-800';
     }
 

--- a/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.test.ts
+++ b/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.test.ts
@@ -63,4 +63,38 @@ describe('Skal gruppere perioder på søker og ikke kvote', () => {
             : undefined;
         expect(periode4?.forelder).toEqual('MOR');
     });
+
+    it('Skal ikke gruppere avslått og innvilget periode på samme rad', () => {
+        const perioder: Uttaksplanperiode[] = [
+            {
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                fom: '2024-05-03',
+                tom: '2024-05-16',
+                flerbarnsdager: false,
+            },
+            {
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                fom: '2024-05-17',
+                tom: '2024-05-30',
+                flerbarnsdager: false,
+                resultat: { innvilget: false, trekkerMinsterett: false, trekkerDager: false, årsak: 'ANNET' },
+            },
+            {
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                fom: '2024-05-31',
+                tom: '2024-06-13',
+                flerbarnsdager: false,
+            },
+        ];
+
+        const uttaksplanperioderPerRadIListe = mapUttaksplanperioderTilRaderIListe(perioder, '2024-05-03');
+
+        expect(uttaksplanperioderPerRadIListe).toHaveLength(3);
+        expect(uttaksplanperioderPerRadIListe[0]).toHaveLength(1);
+        expect(uttaksplanperioderPerRadIListe[1]).toHaveLength(1);
+        expect(uttaksplanperioderPerRadIListe[2]).toHaveLength(1);
+    });
 });

--- a/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.ts
+++ b/packages/uttaksplan/src/liste/utils/mapUttaksplanperioderTilRaderIListe.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
-import { Uttaksplanperiode, erUttaksplanHull } from '../../types/UttaksplanPeriode';
-import { erPrematuruker, erUtsettelsesperiode } from '../../utils/periodeUtils';
+import { Uttaksplanperiode, erUttaksplanHull, erVanligUttakPeriode } from '../../types/UttaksplanPeriode';
+import { erAvslåttPeriode, erPrematuruker, erUtsettelsesperiode } from '../../utils/periodeUtils';
 
 export const mapUttaksplanperioderTilRaderIListe = (
     saksperioderInkludertHull: Uttaksplanperiode[],
@@ -86,7 +86,14 @@ const kanGrupperesPåSammeRad = (
     !erUttaksplanHull(forrige) &&
     !erUttaksplanHull(nestePeriode) &&
     harSammeForelder(forrige, nestePeriode) &&
+    harSammeAvslåttStatus(forrige, nestePeriode) &&
     beggePerioderFørEllerEtterFamiliehendelsedato(forrige, nestePeriode, familiehendelsesdato);
+
+const harSammeAvslåttStatus = (a: Uttaksplanperiode, b: Uttaksplanperiode): boolean => {
+    const aErAvslått = erVanligUttakPeriode(a) && erAvslåttPeriode(a);
+    const bErAvslått = erVanligUttakPeriode(b) && erAvslåttPeriode(b);
+    return aErAvslått === bErAvslått;
+};
 
 const beggePerioderFørEllerEtterFamiliehendelsedato = (
     uttaksplanperiode: Uttaksplanperiode | undefined,

--- a/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
@@ -6,6 +6,7 @@ import {
     erTapteDagerHull,
     erVanligUttakPeriode,
 } from '../../types/UttaksplanPeriode';
+import { erAvslåttPeriode } from '../../utils/periodeUtils';
 
 export const getFørsteUttaksplanperiodeFom = (uttaksplanperioder: Uttaksplanperiode[]) => {
     return uttaksplanperioder.at(0)!.fom;
@@ -64,6 +65,18 @@ export const harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet = (uttaksplanperi
     const periode = uttaksplanperioder.at(0)!;
     return (
         erVanligUttakPeriode(periode) && periode.resultat?.innvilget === false && periode.resultat?.årsak === 'ANNET'
+    );
+};
+
+export const erAlleUttaksplanperioderAvslått = (uttaksplanperioder: Uttaksplanperiode[]) => {
+    return (
+        uttaksplanperioder.length > 0 &&
+        uttaksplanperioder.every(
+            (p) =>
+                erVanligUttakPeriode(p) &&
+                erAvslåttPeriode(p) &&
+                p.resultat?.årsak !== 'AVSLAG_FRATREKK_PLEIEPENGER',
+        )
     );
 };
 

--- a/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanperiodeUtils.ts
@@ -58,16 +58,6 @@ export const harUttaksplanperiodePrematuruker = (uttaksplanperioder: Uttaksplanp
     return erVanligUttakPeriode(periode) && periode.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER';
 };
 
-export const harUttaksplanperiodeAvslåttPeriodeMedÅrsakAnnet = (uttaksplanperioder: Uttaksplanperiode[]) => {
-    if (uttaksplanperioder.length !== 1) {
-        return false;
-    }
-    const periode = uttaksplanperioder.at(0)!;
-    return (
-        erVanligUttakPeriode(periode) && periode.resultat?.innvilget === false && periode.resultat?.årsak === 'ANNET'
-    );
-};
-
 export const erAlleUttaksplanperioderAvslått = (uttaksplanperioder: Uttaksplanperiode[]) => {
     return (
         uttaksplanperioder.length > 0 &&


### PR DESCRIPTION
…øknad

https://jira.adeo.no/browse/TFP-6959

Rotårsak: Avslåtte perioder (rødpølser) frå gjeldande vedtak blei ikkje handtert korrekt i listevisning eller ved innsending av endringssøknad. Kalenderen viste dei rett, men listevisninga viste dei som vanleg 'foreldrepenger' og dei blei sendt til backend som nye uttaksperiodar.

Endringar:
- Ny util erAlleUttaksplanperioderAvslått() for generell avslått-sjekk
- Listevisning: header, ikon, bakgrunn, border og content viser no avslåtte periodar med eige design og 'Avslått periode'-tekst
- Gruppering: avslåtte periodar vert ikkje grupperte med ikkje-avslåtte
- Innsending: filtrerUtAvslåttePerioder() fjerner avslåtte periodar før dei vert sende til backend som endringssøknad
- Avslåtte periodar er ikkje redigerbare i listevisninga