### PR TITLE
Oppdater grunnbeløp (G) for 2026

### DIFF
--- a/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.test.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.test.tsx
@@ -180,9 +180,11 @@ describe('<ArbeidssituasjonSide>', () => {
         expect(screen.getByText('Gjennomsnittlig årslønn')).toBeInTheDocument();
         expect(screen.getByText('12 000 kr')).toBeInTheDocument();
 
-        expect(screen.getByText('Med årslønn under 65 080 kr har du ikke rett til foreldrepenger')).toBeInTheDocument();
+        expect(
+            screen.getByText('Med årslønn under 68 274,50 kr har du ikke rett til foreldrepenger'),
+        ).toBeInTheDocument();
         expect(screen.getByText(/12 000 kr i året/)).toBeInTheDocument();
-        expect(screen.getByText(/65 080 kr i året/)).toBeInTheDocument();
+        expect(screen.getByText(/68 274,50 kr i året/)).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Se resultatet'));
 
@@ -224,7 +226,7 @@ describe('<ArbeidssituasjonSide>', () => {
         expect(screen.getByText('Gjennomsnittlig årslønn')).toBeInTheDocument();
         expect(screen.getByText('1 200 000 kr')).toBeInTheDocument();
 
-        expect(screen.getByText('Du får dekket opptil 780 960 kr av din inntekt')).toBeInTheDocument();
+        expect(screen.getByText('Du får dekket opptil 819 294 kr av din inntekt')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Se resultatet'));
 

--- a/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.test.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.test.tsx
@@ -42,20 +42,20 @@ describe('<OppsummeringSide>', () => {
 
         expect(await screen.findByText('Oppsummering')).toBeInTheDocument();
 
-        expect(screen.getByText('Du får dekket opptil 780 960 kr av din inntekt')).toBeInTheDocument();
+        expect(screen.getByText('Du får dekket opptil 819 294 kr av din inntekt')).toBeInTheDocument();
 
         expect(screen.getByText('Gjennomsnittlig utbetaling med 100 % foreldrepenger i 49 uker')).toBeInTheDocument();
         expect(screen.getByText('Gjennomsnittlig utbetaling med 80 % foreldrepenger i 59 uker')).toBeInTheDocument();
         expect(screen.getAllByText('Månedlig før skatt')).toHaveLength(2);
-        expect(screen.getByText('65 080 kr')).toBeInTheDocument();
-        expect(screen.getByText('52 064 kr')).toBeInTheDocument();
+        expect(screen.getByText('68 275 kr')).toBeInTheDocument();
+        expect(screen.getByText('54 620 kr')).toBeInTheDocument();
         expect(screen.getAllByText('Daglig før skatt')).toHaveLength(2);
-        expect(screen.getByText('3 004 kr')).toBeInTheDocument();
-        expect(screen.getByText('2 403 kr')).toBeInTheDocument();
+        expect(screen.getByText('3 151 kr')).toBeInTheDocument();
+        expect(screen.getByText('2 521 kr')).toBeInTheDocument();
         expect(screen.getByText('Totalt for 25 uker før skatt')).toBeInTheDocument();
-        expect(screen.getByText('375 500 kr')).toBeInTheDocument();
+        expect(screen.getByText('393 875 kr')).toBeInTheDocument();
         expect(screen.getByText('Totalt for 30 uker før skatt')).toBeInTheDocument();
-        expect(screen.getByText('360 450 kr')).toBeInTheDocument();
+        expect(screen.getByText('378 150 kr')).toBeInTheDocument();
 
         expect(
             screen.getByText('Mange får lønn utbetalt som vanlig fra arbeidsgiveren sin mens man har permisjon'),
@@ -72,9 +72,11 @@ describe('<OppsummeringSide>', () => {
 
         expect(await screen.findByText('Oppsummering')).toBeInTheDocument();
 
-        expect(screen.getByText('Med årslønn under 65 080 kr har du ikke rett til foreldrepenger')).toBeInTheDocument();
+        expect(
+            screen.getByText('Med årslønn under 68 274,50 kr har du ikke rett til foreldrepenger'),
+        ).toBeInTheDocument();
         expect(screen.getByText(/12 000 kr i året/)).toBeInTheDocument();
-        expect(screen.getByText(/65 080 kr i året/)).toBeInTheDocument();
+        expect(screen.getByText(/68 274,50 kr i året/)).toBeInTheDocument();
         expect(screen.getByText('Hva er engangsstønad?')).toBeInTheDocument();
     });
 

--- a/packages/constants/src/grunnbeløp.ts
+++ b/packages/constants/src/grunnbeløp.ts
@@ -43,6 +43,10 @@ export const DEFAULT_SATSER = {
     ],
     grunnbeløp: [
         {
+            fom: '01.05.2026',
+            verdi: 136549,
+        },
+        {
             fom: '01.05.2025',
             verdi: 130160,
         },


### PR DESCRIPTION
## Endring

Legger til nytt grunnbeløp gjeldende fra 01.05.2026: **136 549 kr**.

Oppdaterer `packages/constants/src/grunnbeløp.ts` med ny sats.

## Kilde

https://www.nav.no/regulering-2026