### PR TITLE
feat(foreldrepengesoknad): aktiver bakovernavigasjon via stegvelgar og tydeliggjør stegnavigering

### DIFF
--- a/apps/foreldrepengesoknad/src/AppContainer.test.tsx
+++ b/apps/foreldrepengesoknad/src/AppContainer.test.tsx
@@ -86,32 +86,19 @@ describe('<AppContainer>', () => {
             await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
             expect(screen.getByText('Steg 9 av 9')).toBeInTheDocument();
 
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Din plan med foreldrepenger')).toHaveLength(2);
+            // Stegvelger: hopp frå Oppsummering (steg 9) tilbake til Bo i utlandet (steg 3) via stegvelgar
+            await userEvent.click(screen.getByText('Vis alle steg'));
+            await userEvent.click(screen.getByText('Bo i utlandet'));
+            await waitFor(() => expect(screen.getAllByText('Bo i utlandet')).toHaveLength(2));
+            expect(screen.getByText('Steg 3 av 9')).toBeInTheDocument();
 
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getByText('Uttaksplanen kan bli nullstilt')).toBeInTheDocument();
-            await userEvent.click(screen.getByText('Ja, gå tilbake'));
-            expect(screen.getAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
+            // Stegvelger: hopp frå Bo i utlandet (steg 3) tilbake til Din situasjon (steg 1) via stegvelgar
+            await userEvent.click(screen.getByText('Vis alle steg'));
+            await userEvent.click(screen.getByText('Din situasjon'));
+            await waitFor(() => expect(screen.getAllByText('Din situasjon')).toHaveLength(2));
+            expect(screen.getByText('Steg 1 av 9')).toBeInTheDocument();
 
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Periode med foreldrepenger')).toHaveLength(2);
-
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Den andre forelderen')).toHaveLength(2);
-
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Arbeidsforhold og inntekt')).toHaveLength(2);
-
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Bo i utlandet')).toHaveLength(2);
-
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Barnet')).toHaveLength(2);
-
-            await userEvent.click(screen.getByText('Forrige steg'));
-            expect(screen.getAllByText('Din situasjon')).toHaveLength(2);
-
+            // Forrige steg frå steg 1 → Velkommen
             await userEvent.click(screen.getByText('Forrige steg'));
             expect(screen.getByText('Hvilket barn gjelder søknaden din?')).toBeInTheDocument();
         }),

--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -59,12 +59,12 @@ export const useFpNavigator = (
         navigerTilDefaultSteg('previous');
     };
 
-    const goToNextStep = (path: SøknadRoutes) => {
+    const goToStep = (path: SøknadRoutes) => {
         oppdaterPath(path);
         void mellomlagreOgNaviger();
     };
 
-    const goToNextDefaultStep = () => {
+    const goToNextStep = () => {
         navigerTilDefaultSteg('next');
     };
 
@@ -75,8 +75,8 @@ export const useFpNavigator = (
 
     return {
         goToPreviousDefaultStep,
+        goToStep,
         goToNextStep,
-        goToNextDefaultStep,
         fortsettSøknadSenere,
     };
 };

--- a/apps/foreldrepengesoknad/src/pages/forside/Forside.tsx
+++ b/apps/foreldrepengesoknad/src/pages/forside/Forside.tsx
@@ -81,7 +81,7 @@ export const Forside = ({
     const gåTilSøkersituasjonSomNySøknad = () => {
         setErEndringssøknad(false);
         setSøknadGjelderNyttBarn(true);
-        return navigator.goToNextStep(SøknadRoutes.SØKERSITUASJON);
+        return navigator.goToStep(SøknadRoutes.SØKERSITUASJON);
     };
 
     const finnValgtEksisterendeSak = (valgteBarn: ValgtBarn) => {
@@ -97,7 +97,7 @@ export const Forside = ({
 
         setErEndringssøknad(true);
         setSøknadGjelderNyttBarn(false);
-        return navigator.goToNextStep(SøknadRoutes.UTTAKSPLAN);
+        return navigator.goToStep(SøknadRoutes.UTTAKSPLAN);
     };
 
     const opprettNySøknadBasertPåValgtBarn = (valgteBarn: ValgtBarn) => {
@@ -163,7 +163,7 @@ export const Forside = ({
 
         setErEndringssøknad(false);
         setSøknadGjelderNyttBarn(false);
-        return navigator.goToNextStep(SøknadRoutes.SØKERSITUASJON);
+        return navigator.goToStep(SøknadRoutes.SØKERSITUASJON);
     };
 
     const formMethods = useForm<ForsideFormValues>({

--- a/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
@@ -41,7 +41,7 @@ export const AndreInntektskilderSteg = ({ arbeidsforhold, mellomlagreSøknadOgNa
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
@@ -36,12 +36,12 @@ export const AndreInntektskilderSteg = ({ arbeidsforhold, mellomlagreSøknadOgNa
 
     const onSubmit = (values: AndreInntekterFormValues) => {
         oppdaterAndreInntektskilder(values.andreInntektskilder.filter(erFerdigUtfylt));
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
@@ -145,7 +145,7 @@ export const AnnenForelderSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avb
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
@@ -78,7 +78,7 @@ export const AnnenForelderSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avb
                 resetUttaksplanData();
             }
             oppdaterAnnenForeldre({ kanIkkeOppgis: true });
-            return navigator.goToNextDefaultStep();
+            return navigator.goToNextStep();
         }
 
         const skalIkkeOppgiPersonaliaOgHarFraRegBarn = !skalOppgiPersonalia && annenForelderFraRegistrertBarn;
@@ -125,7 +125,7 @@ export const AnnenForelderSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avb
             harRettPåForeldrepengerIEØS,
         });
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     const formMethods = useForm<AnnenForelder>({
@@ -145,7 +145,7 @@ export const AnnenForelderSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avb
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
@@ -61,16 +61,16 @@ export const ArbeidsforholdOgInntektSteg = ({ mellomlagreSøknadOgNaviger, avbry
         }
 
         if (values.harJobbetSomFrilans) {
-            return navigator.goToNextStep(SøknadRoutes.FRILANS);
+            return navigator.goToStep(SøknadRoutes.FRILANS);
         }
         if (values.harJobbetSomSelvstendigNæringsdrivende) {
-            return navigator.goToNextStep(SøknadRoutes.EGEN_NÆRING);
+            return navigator.goToStep(SøknadRoutes.EGEN_NÆRING);
         }
         if (values.harHattAndreInntektskilder) {
-            return navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER);
+            return navigator.goToStep(SøknadRoutes.ANDRE_INNTEKTER);
         }
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
@@ -83,7 +83,7 @@ export const ArbeidsforholdOgInntektSteg = ({ mellomlagreSøknadOgNaviger, avbry
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 appOrigin="foreldrepengesoknad"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
@@ -83,6 +83,7 @@ export const ArbeidsforholdOgInntektSteg = ({ mellomlagreSøknadOgNaviger, avbry
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
                 appOrigin="foreldrepengesoknad"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
@@ -31,10 +31,10 @@ export const EgenNæringSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, ar
         });
 
         if (arbeidsforholdOgInntekt.harHattAndreInntektskilder) {
-            return navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER);
+            return navigator.goToStep(SøknadRoutes.ANDRE_INNTEKTER);
         }
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
@@ -46,7 +46,7 @@ export const EgenNæringSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, ar
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 appOrigin="foreldrepengesoknad"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
@@ -46,6 +46,7 @@ export const EgenNæringSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, ar
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
                 appOrigin="foreldrepengesoknad"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
@@ -133,7 +133,7 @@ export const FordelingSteg = ({ person, arbeidsforhold, mellomlagreSøknadOgNavi
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 <VStack gap="space-20">
                     <FordelingOversikt
                         kontoer={valgtStønadskvote}

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
@@ -133,7 +133,7 @@ export const FordelingSteg = ({ person, arbeidsforhold, mellomlagreSøknadOgNavi
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 <VStack gap="space-20">
                     <FordelingOversikt
                         kontoer={valgtStønadskvote}
@@ -148,7 +148,7 @@ export const FordelingSteg = ({ person, arbeidsforhold, mellomlagreSøknadOgNavi
                         navnPåForeldre={navnPåForeldre}
                         dagerMedFellesperiode={dagerMedFellesperiode}
                         goToPreviousDefaultStep={navigator.goToPreviousDefaultStep}
-                        goToNextDefaultStep={navigator.goToNextDefaultStep}
+                        goToNextDefaultStep={navigator.goToNextStep}
                         onAvsluttOgSlett={avbrytSøknad}
                         onFortsettSenere={navigator.fortsettSøknadSenere}
                         førsteDagEtterAnnenForelder={førsteDagEtterAnnenForelder}

--- a/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
@@ -28,13 +28,13 @@ export const FrilansSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, arbeid
         oppdaterFrilans(values);
 
         if (arbeidsforholdOgInntekt.harJobbetSomSelvstendigNæringsdrivende) {
-            return navigator.goToNextStep(SøknadRoutes.EGEN_NÆRING);
+            return navigator.goToStep(SøknadRoutes.EGEN_NÆRING);
         }
         if (arbeidsforholdOgInntekt.harHattAndreInntektskilder) {
-            return navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER);
+            return navigator.goToStep(SøknadRoutes.ANDRE_INNTEKTER);
         }
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
@@ -46,7 +46,7 @@ export const FrilansSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, arbeid
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
@@ -46,6 +46,7 @@ export const FrilansSteg = ({ mellomlagreSøknadOgNaviger, avbrytSøknad, arbeid
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
@@ -209,7 +209,7 @@ export const ManglendeVedlegg = ({
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} noFieldsRequired>
+            <Step steps={stepConfig} noFieldsRequired onStepChange={navigator.goToNextStep}>
                 <RhfForm formMethods={formMethods} onSubmit={lagre}>
                     <VStack gap="space-40">
                         <MorInnlagtDokumentasjon

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
@@ -166,7 +166,7 @@ export const ManglendeVedlegg = ({
 
         saveVedlegg(alleVedlegg);
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     const formMethods = useForm<ManglendeVedleggFormData>({
@@ -209,7 +209,7 @@ export const ManglendeVedlegg = ({
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} noFieldsRequired onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} noFieldsRequired onStepChange={navigator.goToStep}>
                 <RhfForm formMethods={formMethods} onSubmit={lagre}>
                     <VStack gap="space-40">
                         <MorInnlagtDokumentasjon

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
@@ -167,7 +167,7 @@ const OmBarnetStegInner = ({
 
         oppdaterOmBarnet(oppdatertBarn);
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     const defaultValues = useMemo(
@@ -189,7 +189,7 @@ const OmBarnetStegInner = ({
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
@@ -189,7 +189,7 @@ const OmBarnetStegInner = ({
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
@@ -100,22 +100,22 @@ export const OppsummeringSteg = (props: Props) => {
                 onAvsluttOgSlett={avbrytSøknad}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 ekstraSamtykketekst={ekstraSamtykketekst}
             >
                 {!erEndringssøknad && (
                     <>
                         <BarnOppsummering
                             barn={barn}
-                            onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.OM_BARNET)}
+                            onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.OM_BARNET)}
                         />
                         <AnnenForelderOppsummering
                             annenForelder={annenForelder}
                             søkerrolle={søkersituasjon.rolle}
-                            onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.ANNEN_FORELDER)}
+                            onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.ANNEN_FORELDER)}
                         />
                         <BoIUtlandetOppsummering
-                            onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.UTENLANDSOPPHOLD)}
+                            onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.UTENLANDSOPPHOLD)}
                             tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
                             senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                         />
@@ -128,32 +128,32 @@ export const OppsummeringSteg = (props: Props) => {
                     skalViseAlertOmIM={aktiveArbeidsforhold.length > 0}
                     arbeidsforholdOgInntekt={arbeidsforholdOgInntekt}
                     arbeidsforhold={aktiveArbeidsforhold}
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.ARBEID_OG_INNTEKT)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.ARBEID_OG_INNTEKT)}
                 />
                 <FrilansOppsummering
                     frilans={frilans}
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.FRILANS)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.FRILANS)}
                 />
                 <SelvstendigNæringsdrivendeOppsummering
                     egenNæring={egenNæring}
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.EGEN_NÆRING)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.EGEN_NÆRING)}
                 />
                 <AndreInntektskilderOppsummering
                     andreInntektskilder={andreInntektskilder}
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.ANDRE_INNTEKTER)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.ANDRE_INNTEKTER)}
                 />
                 {!erEndringssøknad && (
                     <PeriodeMedForeldrepengerOppsummering
-                        onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.PERIODE_MED_FORELDREPENGER)}
+                        onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.PERIODE_MED_FORELDREPENGER)}
                     />
                 )}
                 <UttaksplanOppsummering
                     navnPåForeldre={navnPåForeldre}
                     registrerteArbeidsforhold={aktiveArbeidsforhold}
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.UTTAKSPLAN)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.UTTAKSPLAN)}
                 />
                 <DokumentasjonOppsummering
-                    onVilEndreSvar={() => navigator.goToNextStep(SøknadRoutes.DOKUMENTASJON)}
+                    onVilEndreSvar={() => navigator.goToStep(SøknadRoutes.DOKUMENTASJON)}
                     navnPåForeldre={navnPåForeldre}
                 />
                 <>

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
@@ -100,6 +100,7 @@ export const OppsummeringSteg = (props: Props) => {
                 onAvsluttOgSlett={avbrytSøknad}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
+                onStepChange={navigator.goToNextStep}
                 ekstraSamtykketekst={ekstraSamtykketekst}
             >
                 {!erEndringssøknad && (

--- a/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
@@ -49,7 +49,7 @@ export const PeriodeMedForeldrepengerSteg = ({ arbeidsforhold, mellomlagreSøkna
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 {tilgjengeligeStønadskvoterQuery.data && (
                     <>
                         {vis1Juli2024Info && (

--- a/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
@@ -49,7 +49,7 @@ export const PeriodeMedForeldrepengerSteg = ({ arbeidsforhold, mellomlagreSøkna
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 {tilgjengeligeStønadskvoterQuery.data && (
                     <>
                         {vis1Juli2024Info && (
@@ -67,7 +67,7 @@ export const PeriodeMedForeldrepengerSteg = ({ arbeidsforhold, mellomlagreSøkna
                                 onAvsluttOgSlett={avbrytSøknad}
                                 onFortsettSenere={navigator.fortsettSøknadSenere}
                                 goToPreviousDefaultStep={navigator.goToPreviousDefaultStep}
-                                goToNextDefaultStep={navigator.goToNextDefaultStep}
+                                goToNextDefaultStep={navigator.goToNextStep}
                                 fornavnAnnenForelder={annenForelder.fornavn}
                                 kjønnAnnenForelder={getKjønnFromFnr(annenForelder)}
                                 dekningsgrad={annenPartVedtak.dekningsgrad === 'HUNDRE' ? '100' : '80'}
@@ -81,7 +81,7 @@ export const PeriodeMedForeldrepengerSteg = ({ arbeidsforhold, mellomlagreSøkna
                         {!visAnnenPartsValg && (
                             <DekningsgradForm
                                 goToPreviousDefaultStep={navigator.goToPreviousDefaultStep}
-                                goToNextDefaultStep={navigator.goToNextDefaultStep}
+                                goToNextDefaultStep={navigator.goToNextStep}
                                 onAvsluttOgSlett={avbrytSøknad}
                                 onFortsettSenere={navigator.fortsettSøknadSenere}
                                 barn={barn}

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
@@ -57,12 +57,12 @@ export const SøkersituasjonSteg = ({ arbeidsforhold, kjønn, mellomlagreSøknad
 
         oppdaterSøkersituasjon(nySøkersituasjon);
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
@@ -62,7 +62,7 @@ export const SøkersituasjonSteg = ({ arbeidsforhold, kjønn, mellomlagreSøknad
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -36,6 +36,7 @@ export const SenereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadO
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -24,7 +24,7 @@ export const SenereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadO
     const save = (values: UtenlandsoppholdPeriode[]) => {
         oppdaterSenereUtenlandsopphold(values);
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     return (
@@ -36,7 +36,7 @@ export const SenereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadO
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -41,6 +41,7 @@ export const TidligereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøkn
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -29,7 +29,7 @@ export const TidligereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøkn
         const nesteSide = utenlandsopphold.skalBoUtenforNorgeNeste12Mnd
             ? SøknadRoutes.SENERE_UTENLANDSOPPHOLD
             : SøknadRoutes.ARBEID_OG_INNTEKT;
-        return navigator.goToNextStep(nesteSide);
+        return navigator.goToStep(nesteSide);
     };
 
     return (
@@ -41,7 +41,7 @@ export const TidligereUtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøkn
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
             />
         </SkjemaRotLayout>
     );

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -54,6 +54,7 @@ export const UtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadOgNavig
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
+                onStepChange={navigator.goToNextStep}
                 stønadstype="Foreldrepenger"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -42,7 +42,7 @@ export const UtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadOgNavig
             oppdaterSenereUtenlandsopphold(undefined);
         }
 
-        return navigator.goToNextStep(utledNesteSide(values));
+        return navigator.goToStep(utledNesteSide(values));
     };
 
     return (
@@ -54,7 +54,7 @@ export const UtenlandsoppholdSteg = ({ arbeidsforhold, mellomlagreSøknadOgNavig
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 stønadstype="Foreldrepenger"
             />
         </SkjemaRotLayout>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -135,7 +135,7 @@ export const UttaksplanForm = ({
             oppdaterUttaksplan(defaultUttaksperioder);
         }
 
-        return navigator.goToNextDefaultStep();
+        return navigator.goToNextStep();
     };
 
     const [gåTilbakeIsOpen, setGåTilbakeIsOpen] = useState(false);

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -2,6 +2,7 @@ import { BulletListIcon, CalendarIcon } from '@navikt/aksel-icons';
 import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
+import { useFpNavigator } from 'appData/useFpNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { ReactNode, useCallback, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -68,6 +69,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
     const erEndringssøknad = !!valgtEksisterendeSaksnr;
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
+    const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad, eksisterendeSak);
 
     const oppgittAnnenForelder = isAnnenForelderOppgitt(annenForelder) ? annenForelder : undefined;
     const erAleneOmOmsorg = oppgittAnnenForelder ? oppgittAnnenForelder.erAleneOmOmsorg : true;
@@ -139,7 +141,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig}>
+            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
                 {erDeltUttak && (
                     <Alert variant="info">
                         <BodyLong>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { SøknadRoutes } from 'appData/routes';
 import { useStepConfig } from 'appData/useStepConfig';
 import { ReactNode, useCallback, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -31,6 +32,7 @@ import {
 } from '@navikt/fp-uttaksplan';
 import { notEmpty } from '@navikt/fp-validation';
 
+import { GåTilbakeModal } from './GåTilbakeModal';
 import { UttaksplanForm } from './UttaksplanForm';
 import { useUttaksplanForEksisterendeSak } from './hooks/useUttaksplanForEksisterendeSak';
 import { useUttaksplanForslag } from './hooks/useUttaksplanForslag';
@@ -70,6 +72,32 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
     const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad, eksisterendeSak);
+    const [gåTilbakeIsOpen, setGåTilbakeIsOpen] = useState(false);
+    const [stegEtterBekreftelse, setStegEtterBekreftelse] = useState<SøknadRoutes | undefined>();
+
+    const onStepChange = useCallback(
+        (path: SøknadRoutes) => {
+            const currentIndex = stepConfig.findIndex((step) => step.isSelected);
+            const targetIndex = stepConfig.findIndex((step) => step.id === path);
+            const gårTilTidligereSteg = currentIndex !== -1 && targetIndex !== -1 && targetIndex < currentIndex;
+
+            if (uttaksplan && gårTilTidligereSteg) {
+                setStegEtterBekreftelse(path);
+                setGåTilbakeIsOpen(true);
+                return;
+            }
+
+            navigator.goToNextStep(path);
+        },
+        [navigator, stepConfig, uttaksplan],
+    );
+
+    const gåTilStegEtterBekreftelse = useCallback(() => {
+        if (!stegEtterBekreftelse) {
+            return;
+        }
+        navigator.goToNextStep(stegEtterBekreftelse);
+    }, [navigator, stegEtterBekreftelse]);
 
     const oppgittAnnenForelder = isAnnenForelderOppgitt(annenForelder) ? annenForelder : undefined;
     const erAleneOmOmsorg = oppgittAnnenForelder ? oppgittAnnenForelder.erAleneOmOmsorg : true;
@@ -141,7 +169,17 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={navigator.goToNextStep}>
+            <Step steps={stepConfig} onStepChange={onStepChange}>
+                <GåTilbakeModal
+                    isOpen={gåTilbakeIsOpen}
+                    setIsOpen={(isOpen) => {
+                        setGåTilbakeIsOpen(isOpen);
+                        if (!isOpen) {
+                            setStegEtterBekreftelse(undefined);
+                        }
+                    }}
+                    goToPreviousStep={gåTilStegEtterBekreftelse}
+                />
                 {erDeltUttak && (
                     <Alert variant="info">
                         <BodyLong>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -87,7 +87,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
                 return;
             }
 
-            navigator.goToNextStep(path);
+            navigator.goToStep(path);
         },
         [navigator, stepConfig, uttaksplan],
     );
@@ -96,7 +96,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
         if (!stegEtterBekreftelse) {
             return;
         }
-        navigator.goToNextStep(stegEtterBekreftelse);
+        navigator.goToStep(stegEtterBekreftelse);
     }, [navigator, stegEtterBekreftelse]);
 
     const oppgittAnnenForelder = isAnnenForelderOppgitt(annenForelder) ? annenForelder : undefined;

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
-import { SøknadRoutes } from 'appData/routes';
 import { useStepConfig } from 'appData/useStepConfig';
 import { ReactNode, useCallback, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -32,7 +31,6 @@ import {
 } from '@navikt/fp-uttaksplan';
 import { notEmpty } from '@navikt/fp-validation';
 
-import { GåTilbakeModal } from './GåTilbakeModal';
 import { UttaksplanForm } from './UttaksplanForm';
 import { useUttaksplanForEksisterendeSak } from './hooks/useUttaksplanForEksisterendeSak';
 import { useUttaksplanForslag } from './hooks/useUttaksplanForslag';
@@ -72,32 +70,6 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
     const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad, eksisterendeSak);
-    const [gåTilbakeIsOpen, setGåTilbakeIsOpen] = useState(false);
-    const [stegEtterBekreftelse, setStegEtterBekreftelse] = useState<SøknadRoutes | undefined>();
-
-    const onStepChange = useCallback(
-        (path: SøknadRoutes) => {
-            const currentIndex = stepConfig.findIndex((step) => step.isSelected);
-            const targetIndex = stepConfig.findIndex((step) => step.id === path);
-            const gårTilTidligereSteg = currentIndex !== -1 && targetIndex !== -1 && targetIndex < currentIndex;
-
-            if (uttaksplan && gårTilTidligereSteg) {
-                setStegEtterBekreftelse(path);
-                setGåTilbakeIsOpen(true);
-                return;
-            }
-
-            navigator.goToStep(path);
-        },
-        [navigator, stepConfig, uttaksplan],
-    );
-
-    const gåTilStegEtterBekreftelse = useCallback(() => {
-        if (!stegEtterBekreftelse) {
-            return;
-        }
-        navigator.goToStep(stegEtterBekreftelse);
-    }, [navigator, stegEtterBekreftelse]);
 
     const oppgittAnnenForelder = isAnnenForelderOppgitt(annenForelder) ? annenForelder : undefined;
     const erAleneOmOmsorg = oppgittAnnenForelder ? oppgittAnnenForelder.erAleneOmOmsorg : true;
@@ -169,17 +141,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'søknad.pageheading' })}>
-            <Step steps={stepConfig} onStepChange={onStepChange}>
-                <GåTilbakeModal
-                    isOpen={gåTilbakeIsOpen}
-                    setIsOpen={(isOpen) => {
-                        setGåTilbakeIsOpen(isOpen);
-                        if (!isOpen) {
-                            setStegEtterBekreftelse(undefined);
-                        }
-                    }}
-                    goToPreviousStep={gåTilStegEtterBekreftelse}
-                />
+            <Step steps={stepConfig} onStepChange={navigator.goToStep}>
                 {erDeltUttak && (
                     <Alert variant="info">
                         <BodyLong>


### PR DESCRIPTION
Legg til stegvelgar-navigering på alle 15 stegkomponentar i foreldrepengesøknaden slik at brukar kan navigere tilbake til tidlegare steg via stegvelgaren (Vis alle steg). Framovernavigasjon er framleis sperra – same mønster som i engangsstønad og planleggar.

I praksis er dette no kobla via `onStepChange={navigator.goToStep}` (tidlegare `goToNextStep(path)`), og standard framoversteg er omdøypt frå `goToNextDefaultStep()` til `goToNextStep()` i foreldrepengesøknad-appen for tydelegare semantikk.

Oppdaterer AppContainer-testen til å verifisere stegvelgar-navigasjon (Oppsummering → Bo i utlandet → Din situasjon → Velkommen).