### PR TITLE
ci: legg til knip-workflow

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -1,0 +1,21 @@
+name: Knip
+
+on:
+  pull_request:
+
+jobs:
+  knip-it:
+    name: Kjør Knip
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Kjør Knip
+        uses: navikt/fp-gha-workflows/.github/actions/knip-it@main
+        with:
+          npm-auth-token: ${{ secrets.READER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-manager: 'pnpm'
+          node-version: 26.1.0


### PR DESCRIPTION
## Sammendrag
- Legger til PR-workflow som kjører `knip-it` fra `navikt/fp-gha-workflows`.
- Bruker pnpm, Node 26.1.0 og job-scopede token-rettigheter for minimalt privilegium.


merges etter denne fixen: https://github.com/navikt/fp-gha-workflows/pull/418
