### PR TITLE
fix: legg til transparent border på alle kalenderdagar for konsistent…

### DIFF
--- a/packages/ui/src/calendar/Day.tsx
+++ b/packages/ui/src/calendar/Day.tsx
@@ -12,7 +12,7 @@ import { CalendarPeriodColor } from './types/CalendarPeriodColor';
 export type DayShape = 'square' | 'rounded-right' | 'rounded-left';
 
 const DAY_STYLE: Record<CalendarPeriodColor, string> = {
-    ['NONE']: styles.none!,
+    ['NONE']: '',
     ['BLUE']: styles.blueDay!,
     ['DARKBLUE']: styles.darkblueDay!,
     ['LIGHTGREEN']: styles.lightgreenDay!,

--- a/packages/ui/src/calendar/day.module.css
+++ b/packages/ui/src/calendar/day.module.css
@@ -21,6 +21,7 @@
     letter-spacing: 0.06px;
     border-radius: 4px;
     user-select: none;
+    border: 2px solid transparent;
 }
 
 .roundedLeft {
@@ -49,7 +50,6 @@
 
 .cursorAndHoover {
     cursor: pointer;
-    border: 1px solid transparent;
 }
 
 .cursorAndHoover:hover,
@@ -329,8 +329,6 @@
 }
 
 .none {
-    padding-left: 2px;
-    padding-right: 2px;
 }
 
 .icon {

--- a/packages/ui/src/calendar/day.module.css
+++ b/packages/ui/src/calendar/day.module.css
@@ -328,9 +328,6 @@
     print-color-adjust: exact;
 }
 
-.none {
-}
-
 .icon {
     position: absolute;
     bottom: 2px;


### PR DESCRIPTION
… høgde

Periodar med synleg border (t.d. lightblue, greenStriped) gjorde at celler utan border vart mindre, og markering (DARKBLUE) utan border førte til eit visuelt hopp. Løyst ved å gi base-klassen .days ein 2px transparent border, slik at total-høgda er lik uansett farge.