### PR TITLE
docs: endre Storybook-dokumentasjon fra nynorsk til bokmål

### DIFF
--- a/packages/uttaksplan/src/kalender/Fargekatalog.stories.tsx
+++ b/packages/uttaksplan/src/kalender/Fargekatalog.stories.tsx
@@ -27,7 +27,7 @@ import { getLegendLabelFromPeriode } from './legend/uttaksplanLegendUtils';
 import { getKalenderFargeForPeriode } from './utils/usePerioderForKalendervisning';
 
 // ---------------------------------------------------------------------------
-// Mock-fabrikkar — minimale periodar som triggar dei ulike kodebanane
+// Mock-fabrikker — minimale perioder som trigger de ulike kodebanene
 // ---------------------------------------------------------------------------
 
 const FOM = '2025-06-01';
@@ -70,7 +70,7 @@ const PLEIEPENGE_AVSLAG: UttakPeriodeResultat_fpoversikt = {
 };
 
 // ---------------------------------------------------------------------------
-// Spesifikasjon — kvar rad definerer mock-input, resten blir utleia
+// Spesifikasjon — hver rad definerer mock-input, resten blir utledet
 // ---------------------------------------------------------------------------
 
 type FargeSpec = {
@@ -80,9 +80,9 @@ type FargeSpec = {
     /** Mock-periode for kalender (getKalenderFargeForPeriode + getLegendLabelFromPeriode) */
     kalenderPeriode?: UttaksplanperiodeMedKunTapteDager;
     kalenderErFarEllerMedmor?: boolean;
-    /** Statisk kalender-verdi for ting som ikkje kan avleiast (ikon-markørar, interaksjonsfargar) */
+    /** Statisk kalender-verdi for ting som ikke kan utledes (ikon-markører, interaksjonsfarger) */
     kalenderStatisk?: { fargekode: CalendarPeriodColor | null; ikon?: ReactNode; legendLabel: string };
-    /** Mock-periodar for liste (finnBakgrunnsfarge + getBorderFarge + getIkon) */
+    /** Mock-perioder for liste (finnBakgrunnsfarge + getBorderFarge + getIkon) */
     listePerioder?: Uttaksplanperiode[];
     listeErFamiliehendelse?: boolean;
     listeFamiliehendelsedato?: string;
@@ -90,7 +90,7 @@ type FargeSpec = {
 };
 
 // ---------------------------------------------------------------------------
-// Avleiing — slår opp i produksjonskoden for å finne fargar
+// Utledning — slår opp i produksjonskoden for å finne farger
 // ---------------------------------------------------------------------------
 
 type FargeEntry = {
@@ -132,37 +132,37 @@ const beregnEntry = (s: FargeSpec): FargeEntry => ({
 type FargeOmråde = { id: string; område: string; beskrivelse: string; regler: FargeEntry[] };
 
 // ---------------------------------------------------------------------------
-// Alle fargar, gruppert etter periodekategori
-// Fargane er *dynamisk utleia* frå produksjonskoden via beregnEntry().
-// Berre interaksjonsfargar og spesialdagar (barnehage, helg) er statiske.
+// Alle farger, gruppert etter periodekategori
+// Fargene er *dynamisk utledet* fra produksjonskoden via beregnEntry().
+// Bare interaksjonsfarger og spesialdager (barnehage, helg) er statiske.
 // ---------------------------------------------------------------------------
 
 const OMRÅDER: FargeOmråde[] = [
     {
         id: 'mor',
-        område: 'Mors periodar (blå)',
+        område: 'Mors perioder (blå)',
         beskrivelse:
-            'Blå fargar representerer periodar som tilhøyrer mor — mødrekvote, fellesperiode ' +
-            'teken av mor, eller foreldrepengar før fødsel.',
+            'Blå farger representerer perioder som tilhører mor — mødrekvote, fellesperiode ' +
+            'tatt av mor, eller foreldrepenger før fødsel.',
         regler: [
             beregnEntry({
-                id: 'mor-vanleg',
+                id: 'mor-vanlig',
                 periodetype: 'Mors uttak',
-                beskrivelse: 'Vanleg uttak — mødrekvote, fellesperiode eller foreldrepengar før fødsel.',
+                beskrivelse: 'Vanlig uttak — mødrekvote, fellesperiode eller foreldrepenger før fødsel.',
                 kalenderPeriode: lagPeriode({ kontoType: 'MØDREKVOTE' }),
                 listePerioder: [lagPeriode({ kontoType: 'MØDREKVOTE' })],
             }),
             beregnEntry({
                 id: 'mor-gradert',
                 periodetype: 'Mors uttak (gradert)',
-                beskrivelse: 'Gradert uttak — mor jobbar deltid og tek ut foreldrepengar samtidig.',
+                beskrivelse: 'Gradert uttak — mor jobber deltid og tar ut foreldrepenger samtidig.',
                 kalenderPeriode: lagPeriode({ kontoType: 'MØDREKVOTE', gradering: { arbeidstidprosent: 50 } }),
                 listePerioder: [lagPeriode({ kontoType: 'MØDREKVOTE', gradering: { arbeidstidprosent: 50 } })],
             }),
             beregnEntry({
                 id: 'mor-før-fødsel',
                 periodetype: 'Før fødsel / termin',
-                beskrivelse: 'Foreldrepengar før fødsel — perioden med FORELDREPENGER_FØR_FØDSEL-konto.',
+                beskrivelse: 'Foreldrepenger før fødsel — perioden med FORELDREPENGER_FØR_FØDSEL-konto.',
                 kalenderPeriode: lagPeriode({ kontoType: 'FORELDREPENGER_FØR_FØDSEL' }),
                 listePerioder: [lagPeriode({ kontoType: 'FORELDREPENGER_FØR_FØDSEL' })],
                 listeFamiliehendelsedato: '2025-12-01',
@@ -171,15 +171,15 @@ const OMRÅDER: FargeOmråde[] = [
     },
     {
         id: 'far',
-        område: 'Fars / medmors periodar (grøn)',
+        område: 'Fars / medmors perioder (grønn)',
         beskrivelse:
-            'Grøne fargar representerer periodar som tilhøyrer far eller medmor — fedrekvote ' +
+            'Grønne farger representerer perioder som tilhører far eller medmor — fedrekvote ' +
             'eller fellesperiode. Stripete = gradert, omriss = aktivitetsfri.',
         regler: [
             beregnEntry({
-                id: 'far-vanleg',
+                id: 'far-vanlig',
                 periodetype: 'Fars uttak',
-                beskrivelse: 'Vanleg uttak — fedrekvote eller fellesperiode.',
+                beskrivelse: 'Vanlig uttak — fedrekvote eller fellesperiode.',
                 kalenderPeriode: lagPeriode({ forelder: 'FAR_MEDMOR', kontoType: 'FEDREKVOTE' }),
                 kalenderErFarEllerMedmor: true,
                 listePerioder: [lagPeriode({ forelder: 'FAR_MEDMOR', kontoType: 'FEDREKVOTE' })],
@@ -188,8 +188,8 @@ const OMRÅDER: FargeOmråde[] = [
                 id: 'far-gradert',
                 periodetype: 'Fars uttak (gradert)',
                 beskrivelse:
-                    'Gradert uttak — far jobbar deltid. Gjeld også aktivitetsfri kvote med gradering ' +
-                    '(FARS_DEL_AKTIVITETSFRI_GRADERT — same kalenderfarge, men labelen skil dei).',
+                    'Gradert uttak — far jobber deltid. Gjelder også aktivitetsfri kvote med gradering ' +
+                    '(FARS_DEL_AKTIVITETSFRI_GRADERT — samme kalenderfarge, men labelen skiller dem).',
                 kalenderPeriode: lagPeriode({
                     forelder: 'FAR_MEDMOR',
                     kontoType: 'FEDREKVOTE',
@@ -208,8 +208,8 @@ const OMRÅDER: FargeOmråde[] = [
                 id: 'far-aktivitetsfri',
                 periodetype: 'Aktivitetsfri kvote',
                 beskrivelse:
-                    'Aktivitetsfri kvote — inga krav til mors aktivitet. ' +
-                    'Berre for FORELDREPENGER-kontoen med morsAktivitet = IKKE_OPPGITT.',
+                    'Aktivitetsfri kvote — ingen krav til mors aktivitet. ' +
+                    'Bare for FORELDREPENGER-kontoen med morsAktivitet = IKKE_OPPGITT.',
                 kalenderPeriode: lagPeriode({
                     forelder: 'FAR_MEDMOR',
                     kontoType: 'FORELDREPENGER',
@@ -228,10 +228,10 @@ const OMRÅDER: FargeOmråde[] = [
     },
     {
         id: 'samtidig',
-        område: 'Samtidig uttak (splitta farge)',
+        område: 'Samtidig uttak (splittet farge)',
         beskrivelse:
-            'Når begge foreldra tek ut foreldrepengar i same periode. Kalenderen viser splitta ' +
-            'farge (retning avheng av innlogga brukar), lista viser diagonal gradient.',
+            'Når begge foreldrene tar ut foreldrepenger i samme periode. Kalenderen viser splittet ' +
+            'farge (retning avhenger av innlogget bruker), listen viser diagonal gradient.',
         regler: (() => {
             const morSamtidig = lagPeriode({ kontoType: 'FELLESPERIODE', samtidigUttak: 50 });
             const farSamtidig = lagPeriode({
@@ -243,17 +243,17 @@ const OMRÅDER: FargeOmråde[] = [
             return [
                 beregnEntry({
                     id: 'samtidig-mor',
-                    periodetype: 'Samtidig uttak (sett frå mor)',
-                    beskrivelse: 'Kalender: grøn topp, blå botn. Liste: diagonal gradient grøn → blå.',
+                    periodetype: 'Samtidig uttak (sett fra mor)',
+                    beskrivelse: 'Kalender: grønn topp, blå bunn. Liste: diagonal gradient grønn → blå.',
                     kalenderPeriode: morSamtidig,
                     kalenderErFarEllerMedmor: false,
                     listePerioder,
                 }),
                 beregnEntry({
                     id: 'samtidig-far',
-                    periodetype: 'Samtidig uttak (sett frå far)',
+                    periodetype: 'Samtidig uttak (sett fra far)',
                     beskrivelse:
-                        'Kalender: blå topp, grøn botn. Liste: same gradient (ikkje perspektivavhengig).',
+                        'Kalender: blå topp, grønn bunn. Liste: samme gradient (ikke perspektivavhengig).',
                     kalenderPeriode: farSamtidig,
                     kalenderErFarEllerMedmor: true,
                     listePerioder,
@@ -265,28 +265,28 @@ const OMRÅDER: FargeOmråde[] = [
         id: 'utsettelse',
         område: 'Utsettelse (omriss / pause)',
         beskrivelse:
-            'Utsetjingsperiodar «pausar» uttaket. Kalenderen skil ferie (blå omriss) frå ' +
-            'andre årsaker (beige omriss). Lista brukar same bakgrunn for alle utsetjingar, ' +
-            'men ulike ikon per årsak.',
+            'Utsettelsesperioder «pauser» uttaket. Kalenderen skiller ferie (blå omriss) fra ' +
+            'andre årsaker (beige omriss). Listen bruker samme bakgrunn for alle utsettelser, ' +
+            'men ulike ikoner per årsak.',
         regler: [
             beregnEntry({
                 id: 'utsettelse-ferie',
                 periodetype: 'Ferie',
-                beskrivelse: 'Lovbestemt ferie — uttaket er pausa medan familien har ferie.',
+                beskrivelse: 'Lovbestemt ferie — uttaket er pauset mens familien har ferie.',
                 kalenderPeriode: lagPeriode({ utsettelseÅrsak: 'LOVBESTEMT_FERIE' }),
                 listePerioder: [lagPeriode({ utsettelseÅrsak: 'LOVBESTEMT_FERIE' })],
             }),
             beregnEntry({
                 id: 'utsettelse-arbeid',
                 periodetype: 'Utsettelse (arbeid/fri)',
-                beskrivelse: 'Utsettelse grunna arbeid eller fri — søkar jobbar i perioden.',
+                beskrivelse: 'Utsettelse grunnet arbeid eller fri — søker jobber i perioden.',
                 kalenderPeriode: lagPeriode({ utsettelseÅrsak: 'ARBEID' }),
                 listePerioder: [lagPeriode({ utsettelseÅrsak: 'ARBEID' })],
             }),
             beregnEntry({
-                id: 'utsettelse-sjukdom',
-                periodetype: 'Utsettelse (sjukdom/innlegging)',
-                beskrivelse: 'Utsettelse grunna sjukdom, innlegging, HV-øving eller NAV-tiltak.',
+                id: 'utsettelse-sykdom',
+                periodetype: 'Utsettelse (sykdom/innlegging)',
+                beskrivelse: 'Utsettelse grunnet sykdom, innlegging, HV-øvelse eller NAV-tiltak.',
                 kalenderPeriode: lagPeriode({ utsettelseÅrsak: 'SØKER_SYKDOM' }),
                 listePerioder: [lagPeriode({ utsettelseÅrsak: 'SØKER_SYKDOM' })],
             }),
@@ -294,17 +294,17 @@ const OMRÅDER: FargeOmråde[] = [
     },
     {
         id: 'eøs',
-        område: 'EØS-periodar (fylt med svart omriss)',
+        område: 'EØS-perioder (fylt med svart omriss)',
         beskrivelse:
-            'Periodar der den eine forelderen har foreldrepengar frå eit anna EØS-land. ' +
-            'Kalenderen viser hovudfarge + svart omriss. Lista brukar blå bakgrunn (accent-400) for begge.',
+            'Perioder der den ene forelderen har foreldrepenger fra et annet EØS-land. ' +
+            'Kalenderen viser hovedfarge + svart omriss. Listen bruker blå bakgrunn (accent-400) for begge.',
         regler: [
             beregnEntry({
                 id: 'eøs-mor',
                 periodetype: 'Mors EØS-periode',
                 beskrivelse:
-                    'Visast for far/medmor som er innlogga (mora har EØS-foreldrepengar). ' +
-                    'Merk: Lista brukar same blå bakgrunn uavhengig av forelder.',
+                    'Vises for far/medmor som er innlogget (mor har EØS-foreldrepenger). ' +
+                    'Merk: Listen bruker samme blå bakgrunn uavhengig av forelder.',
                 kalenderPeriode: lagEøs(),
                 kalenderErFarEllerMedmor: true,
                 listePerioder: [lagEøs()],
@@ -313,8 +313,8 @@ const OMRÅDER: FargeOmråde[] = [
                 id: 'eøs-far',
                 periodetype: 'Fars EØS-periode',
                 beskrivelse:
-                    'Visast for mor som er innlogga (far/medmor har EØS-foreldrepengar). ' +
-                    'Merk: Lista brukar same blå bakgrunn uavhengig av forelder.',
+                    'Vises for mor som er innlogget (far/medmor har EØS-foreldrepenger). ' +
+                    'Merk: Listen bruker samme blå bakgrunn uavhengig av forelder.',
                 kalenderPeriode: lagEøs(),
                 kalenderErFarEllerMedmor: false,
                 listePerioder: [lagEøs()],
@@ -323,15 +323,15 @@ const OMRÅDER: FargeOmråde[] = [
     },
     {
         id: 'tapte-og-avslag',
-        område: 'Tapte dagar, avslag og uten uttak',
+        område: 'Tapte dager, avslag og uten uttak',
         beskrivelse:
-            'Mørke og åtvaringsfargar signaliserer problem — tapte dagar (hull), ' +
-            'avslåtte periodar, pleiepengefratrekk, eller periodar utan uttak.',
+            'Mørke og advarselsfarger signaliserer problemer — tapte dager (hull), ' +
+            'avslåtte perioder, pleiepengefratrekk, eller perioder uten uttak.',
         regler: [
             beregnEntry({
-                id: 'tapte-dagar',
-                periodetype: 'Tapte dagar',
-                beskrivelse: 'Hull i uttaksplanen der dagar kan gå tapt om ikkje planen blir endra.',
+                id: 'tapte-dager',
+                periodetype: 'Tapte dager',
+                beskrivelse: 'Hull i uttaksplanen der dager kan gå tapt om ikke planen blir endret.',
                 kalenderPeriode: TAPTE,
                 listePerioder: [TAPTE],
             }),
@@ -345,26 +345,26 @@ const OMRÅDER: FargeOmråde[] = [
             beregnEntry({
                 id: 'pleiepenger',
                 periodetype: 'Pleiepenger-fratrekk',
-                beskrivelse: 'Avslag fordi barnet mottek pleiepenger — foreldrepengar er trekte frå.',
+                beskrivelse: 'Avslag fordi barnet mottar pleiepenger — foreldrepenger er trukket fra.',
                 kalenderPeriode: lagPeriode({ kontoType: 'MØDREKVOTE', resultat: PLEIEPENGE_AVSLAG }),
                 listePerioder: [lagPeriode({ kontoType: 'MØDREKVOTE', resultat: PLEIEPENGE_AVSLAG })],
             }),
             beregnEntry({
                 id: 'uten-uttak',
-                periodetype: 'Periode utan uttak',
+                periodetype: 'Periode uten uttak',
                 beskrivelse:
-                    'Periode der ingen forelder tek ut foreldrepengar. ' +
-                    'Finst berre i listevisninga — kalenderen viser ikkje denne periodetypen.',
-                kalenderStatisk: { fargekode: null, legendLabel: '(berre liste)' },
+                    'Periode der ingen forelder tar ut foreldrepenger. ' +
+                    'Finnes bare i listevisningen — kalenderen viser ikke denne periodetypen.',
+                kalenderStatisk: { fargekode: null, legendLabel: '(bare liste)' },
                 listePerioder: [UTEN_UTTAK],
             }),
             beregnEntry({
                 id: 'mors-aktivitet-mangler',
-                periodetype: 'Mors aktivitet ikkje vald',
+                periodetype: 'Mors aktivitet ikke valgt',
                 beskrivelse:
-                    'Berre liste: far/medmors fellesperiode der mors aktivitet ikkje er oppgjeve. ' +
-                    'Raud bakgrunn (danger-200) signaliserer at perioden treng redigering.',
-                kalenderStatisk: { fargekode: null, legendLabel: '(berre liste)' },
+                    'Bare liste: far/medmors fellesperiode der mors aktivitet ikke er oppgitt. ' +
+                    'Rød bakgrunn (danger-200) signaliserer at perioden trenger redigering.',
+                kalenderStatisk: { fargekode: null, legendLabel: '(bare liste)' },
                 listePerioder: [
                     lagPeriode({ forelder: 'FAR_MEDMOR', kontoType: 'FELLESPERIODE' }),
                 ],
@@ -374,17 +374,17 @@ const OMRÅDER: FargeOmråde[] = [
     },
     {
         id: 'spesial',
-        område: 'Spesialdagar (familiehendelse, barnehage, helg)',
+        område: 'Spesialdager (familiehendelse, barnehage, helg)',
         beskrivelse:
-            'Desse er ikkje knytte til uttak, men visast som landemerke. ' +
-            'Familiehendelse og barnehagestart finst i begge visningar, helg berre i kalenderen.',
+            'Disse er ikke knyttet til uttak, men vises som landemerker. ' +
+            'Familiehendelse og barnehagestart finnes i begge visninger, helg bare i kalenderen.',
         regler: [
             beregnEntry({
                 id: 'familiehendelse',
                 periodetype: 'Fødsel / termin / adopsjon',
                 beskrivelse:
-                    'Familiehendelsesdato — fødselsdato, termindato eller omsorgsovertaking. ' +
-                    'Hjarteikon i begge visningar.',
+                    'Familiehendelsesdato — fødselsdato, termindato eller omsorgsovertakelse. ' +
+                    'Hjerteikon i begge visninger.',
                 kalenderStatisk: {
                     fargekode: null,
                     ikon: (
@@ -421,50 +421,50 @@ const OMRÅDER: FargeOmråde[] = [
                 id: 'helg',
                 periodetype: 'Helg',
                 beskrivelse:
-                    'Laurdag og søndag — det blir ikkje telt uttaksdagar i helgene. Berre i kalenderen.',
+                    'Lørdag og søndag — det telles ikke uttaksdager i helgene. Bare i kalenderen.',
                 kalenderStatisk: { fargekode: 'GRAY', legendLabel: 'HELG' },
             }),
         ],
     },
     {
         id: 'interaksjon',
-        område: 'Interaksjonsfargar (berre kalender)',
+        område: 'Interaksjonsfarger (bare kalender)',
         beskrivelse:
-            'Desse fargane representerer ikkje ein periodetype, men ein visuell tilstand — ' +
-            'valde periodar, dagar utan uttaksdata, eller outline-stilar for fokus/seleksjon. ' +
-            'Ingen av desse finst i listevisninga.',
+            'Disse fargene representerer ikke en periodetype, men en visuell tilstand — ' +
+            'valgte perioder, dager uten uttaksdata, eller outline-stiler for fokus/seleksjon. ' +
+            'Ingen av disse finnes i listevisningen.',
         regler: [
             beregnEntry({
                 id: 'none',
                 periodetype: 'Ingen periode',
                 beskrivelse:
-                    'Dagar utan periode — standard for dagar som ikkje er del av nokon uttaksperiode.',
+                    'Dager uten periode — standard for dager som ikke er del av noen uttaksperiode.',
                 kalenderStatisk: { fargekode: 'NONE', legendLabel: '(ingen)' },
             }),
             beregnEntry({
                 id: 'darkblue',
                 periodetype: 'Vald periode (redigering)',
                 beskrivelse:
-                    'Markerer valde periodar i redigeringsmodus — ' +
-                    'når brukaren klikkar på ein legend-farge, blir dei aktuelle dagane framheva. ' +
-                    'NB: CalendarLabel rendrar ikkje denne fargen (returnerer null) — ' +
-                    'fargen (--ax-bg-accent-strong-pressed) visast berre på kalenderdagar.',
+                    'Markerer valgte perioder i redigeringsmodus — ' +
+                    'når brukeren klikker på en legend-farge, blir de aktuelle dagene framhevet. ' +
+                    'NB: CalendarLabel rendrer ikke denne fargen (returnerer null) — ' +
+                    'fargen (--ax-bg-accent-strong-pressed) vises bare på kalenderdager.',
                 kalenderStatisk: { fargekode: 'DARKBLUE', legendLabel: '(ingen)' },
             }),
             beregnEntry({
                 id: 'lightblue',
                 periodetype: 'Fokus/seleksjon (blå)',
                 beskrivelse:
-                    'Brukt i outline-/fokusstil for blå periodar — ' +
-                    'ikkje ein eigen periodetype, men del av seleksjonslogikken.',
+                    'Brukt i outline-/fokusstil for blå perioder — ' +
+                    'ikke en egen periodetype, men del av seleksjonslogikken.',
                 kalenderStatisk: { fargekode: 'LIGHTBLUE', legendLabel: '(ingen)' },
             }),
             beregnEntry({
                 id: 'lightgreen',
                 periodetype: 'Fokus/seleksjon (grøn)',
                 beskrivelse:
-                    'Brukt i outline-/fokusstil for grøne periodar — ' +
-                    'ikkje ein eigen periodetype, men del av seleksjonslogikken.',
+                    'Brukt i outline-/fokusstil for grønne perioder — ' +
+                    'ikke en egen periodetype, men del av seleksjonslogikken.',
                 kalenderStatisk: { fargekode: 'LIGHTGREEN', legendLabel: '(ingen)' },
             }),
         ],
@@ -472,11 +472,11 @@ const OMRÅDER: FargeOmråde[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Hovudkomponent
+// Hovedkomponent
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Swatchar
+// Swatcher
 // ---------------------------------------------------------------------------
 
 const KalenderSwatch = ({ entry }: { entry: FargeEntry }) => {
@@ -507,16 +507,16 @@ const ListeSwatch = ({ entry }: { entry: FargeEntry }) => {
 };
 
 // ---------------------------------------------------------------------------
-// Hovudkomponent
+// Hovedkomponent
 // ---------------------------------------------------------------------------
 
 /**
- * Sjølvdokumenterande Storybook-side: viser fargesystemet i uttaksplanen
- * side om side for kalender- og listevisninga.
+ * Selvdokumenterende Storybook-side: viser fargesystemet i uttaksplanen
+ * side om side for kalender- og listevisningen.
  *
- * Fargane er **dynamisk utleia** frå produksjonskoden — same funksjonar
- * som appen brukar (getKalenderFargeForPeriode, finnBakgrunnsfarge, getIkon
- * osv.) blir kalla med mock-periodar. Endringar i produksjonskoden blir
+ * Fargene er **dynamisk utledet** fra produksjonskoden — samme funksjoner
+ * som appen bruker (getKalenderFargeForPeriode, finnBakgrunnsfarge, getIkon
+ * osv.) blir kalt med mock-perioder. Endringer i produksjonskoden blir
  * automatisk reflektert her.
  */
 const Fargekatalog = () => {
@@ -553,7 +553,7 @@ const Fargekatalog = () => {
             render: (entry) => <ListeSwatch entry={entry} />,
         },
         {
-            overskrift: 'Skildring',
+            overskrift: 'Beskrivelse',
             render: (entry) => <BodyShort size="small">{entry.beskrivelse}</BodyShort>,
         },
     ];
@@ -563,23 +563,23 @@ const Fargekatalog = () => {
             tittel="Fargekatalog for uttaksplanen"
             intro={
                 <>
-                    Uttaksplanen har to visningar — <strong>kalender</strong> og <strong>liste</strong> — som brukar{' '}
-                    <em>ulike fargesystem</em>. Kalenderen brukar{' '}
-                    <code className="font-mono">CalendarPeriodColor</code> (enum → CSS-modul), medan lista brukar
-                    Tailwind-klassar direkte. Denne katalogen viser begge side om side, slik at du kan sjå om same
-                    periodetype ser likt ut i begge visningar.
+                    Uttaksplanen har to visninger — <strong>kalender</strong> og <strong>liste</strong> — som bruker{' '}
+                    <em>ulike fargesystemer</em>. Kalenderen bruker{' '}
+                    <code className="font-mono">CalendarPeriodColor</code> (enum → CSS-modul), mens listen bruker
+                    Tailwind-klasser direkte. Denne katalogen viser begge side om side, slik at du kan se om samme
+                    periodetype ser likt ut i begge visninger.
                     <br />
                     <br />
-                    <strong>NB:</strong> Fargane i denne oversikta er <em>dynamisk utleia</em> frå produksjonskoden
-                    (same funksjonar som appen brukar). Endringar i{' '}
+                    <strong>NB:</strong> Fargene i denne oversikten er <em>dynamisk utledet</em> fra produksjonskoden
+                    (samme funksjoner som appen bruker). Endringer i{' '}
                     <code className="font-mono">getKalenderFargeForPeriode</code>,{' '}
                     <code className="font-mono">finnBakgrunnsfarge</code>,{' '}
                     <code className="font-mono">getIkon</code> osv. blir automatisk reflektert her.
                     <br />
                     <br />
-                    Hovudmønster: <strong>blå = mor</strong>, <strong>grøn = far / medmor</strong>,{' '}
+                    Hovedmønster: <strong>blå = mor</strong>, <strong>grønn = far / medmor</strong>,{' '}
                     <strong>stripete = gradert</strong>, <strong>omriss = utsettelse / aktivitetsfri</strong>,{' '}
-                    <strong>svart/grå = avslag / tapte dagar</strong>.
+                    <strong>svart/grå = avslag / tapte dager</strong>.
                 </>
             }
             kildesti="kalender/…/usePerioderForKalendervisning.tsx · liste/…/PeriodeListeHeaderUtils.tsx"
@@ -606,4 +606,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const AlleFargar: Story = {};
+export const AlleFarger: Story = {};

--- a/packages/uttaksplan/src/regler/Alertregler.stories.tsx
+++ b/packages/uttaksplan/src/regler/Alertregler.stories.tsx
@@ -120,8 +120,8 @@ const KONTEKSTUELL_ALERT_OMRÅDE: Alertområde = {
 };
 
 /**
- * Informasjonsalert-reglane lever som `Alertregel<TKontekst>` for runtime, men har eit
- * konsistent supersett (`AlertregelDoc`) — så vi kan liste dei direkte utan cast.
+ * Informasjonsalert-reglene lever som `Alertregel<TKontekst>` for runtime, men har et
+ * konsistent supersett (`AlertregelDoc`) — så vi kan liste dem direkte uten cast.
  */
 const ALLE_INFORMASJONS_ALERTS: readonly AlertregelDoc[] = [
     MANGLER_MORS_AKTIVITET_LISTE,


### PR DESCRIPTION
Fargekatalog.stories.tsx var skrevet på nynorsk. Endret all tekst (kommentarer, beskrivelser, IDer, eksportnavnet) til bokmål for konsistens med de andre regelkatalog-storiene.

Fikset også én nynorsk-kommentar i Alertregler.stories.tsx.