### PR TITLE
fix(security): tett fire medium-alvorlege funn i autentisert proxy og CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,8 @@ name: 'CodeQL'
 on:
   push:
     branches: ['master']
-    paths-ignore:
-      - 'server/**'
   pull_request:
     branches: ['master']
-    paths-ignore:
-      - 'server/**'
   schedule:
     - cron: '0 0 * * 0,4'
 

--- a/server/src/reverseProxy.test.ts
+++ b/server/src/reverseProxy.test.ts
@@ -92,3 +92,33 @@ test('does not proxy requests outside configured paths', async () => {
     const res = await supertest(app).get('/internal/health').set('Authorization', 'Bearer t');
     expect(res.status).toBe(404);
 });
+
+test('strips cookie header on fpgrunndata proxy', async () => {
+    await supertest(app).get('/fpgrunndata/api/konto').set('Cookie', 'session=abc').expect(200);
+    expect(lastRequest.headers.cookie).toBeUndefined();
+});
+
+test('rejects cross-site API calls (Sec-Fetch-Site=cross-site)', async () => {
+    const res = await supertest(app)
+        .get('/fpsoknad/api/storage/FORELDREPENGER')
+        .set('Authorization', 'Bearer t')
+        .set('Sec-Fetch-Site', 'cross-site');
+    expect(res.status).toBe(403);
+});
+
+test('allows same-origin API calls (Sec-Fetch-Site=same-origin)', async () => {
+    await supertest(app)
+        .get('/fpsoknad/api/storage/FORELDREPENGER')
+        .set('Authorization', 'Bearer t')
+        .set('Sec-Fetch-Site', 'same-origin')
+        .expect(200);
+});
+
+test('allows requests without Sec-Fetch-Site header (eldre nettlesarar / ikkje-nettlesar-klientar)', async () => {
+    await supertest(app).get('/fpsoknad/api/storage/FORELDREPENGER').set('Authorization', 'Bearer t').expect(200);
+});
+
+test('rejects cross-site API calls on fpgrunndata proxy', async () => {
+    const res = await supertest(app).get('/fpgrunndata/api/konto').set('Sec-Fetch-Site', 'cross-site');
+    expect(res.status).toBe(403);
+});

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -18,6 +18,27 @@ const proxy = {
     FPGRUNNDATA_API_URL: serverConfig.påkrevMiljøVariabel('FPGRUNNDATA_API_URL'),
 } as const;
 
+const TILLATTE_SEC_FETCH_SITE = new Set(['same-origin', 'same-site']);
+
+/**
+ * CSRF-djupforsvar: avviser API-kall som nettlesaren har markert som kryss-opphav.
+ * Sec-Fetch-Site sendast av alle moderne nettlesarar. Når headeren manglar (eldre
+ * nettlesarar eller ikkje-nettlesar-klientar) lèt vi requesten passere for å unngå
+ * å bryte legitim trafikk.
+ */
+const avvisKryssOpphavsKall = (request: Request, response: Response, next: NextFunction) => {
+    const secFetchSite = request.headers['sec-fetch-site'];
+    if (secFetchSite === undefined || TILLATTE_SEC_FETCH_SITE.has(String(secFetchSite))) {
+        return next();
+    }
+    logger.warning(`Avviste API-kall med Sec-Fetch-Site=${secFetchSite}`);
+    response.status(403).send();
+};
+
+const fjernSesjonsHeadere = (proxyRequest: { removeHeader: (name: string) => void }) => {
+    proxyRequest.removeHeader('cookie');
+};
+
 export function configureReverseProxyApi(router: Router) {
     addProxyHandler(router, {
         ingoingUrl: '/fpsoknad/api',
@@ -33,10 +54,19 @@ export function configureReverseProxyApi(router: Router) {
 
     router.use(
         '/fpgrunndata/api',
+        avvisKryssOpphavsKall,
         createProxyMiddleware({
             target: proxy.FPGRUNNDATA_API_URL,
             changeOrigin: true,
             logger: console,
+            on: {
+                proxyReq: (proxyRequest) => {
+                    // Strip sesjons-cookien slik at IDporten-sidecar-cookien ikkje lek
+                    // ut til fpgrunndata. Tenesta krev ikkje autentisering og skal
+                    // ikkje sjå brukar-sesjonen vår.
+                    fjernSesjonsHeadere(proxyRequest);
+                },
+            },
         }),
     );
 }
@@ -44,6 +74,7 @@ export function configureReverseProxyApi(router: Router) {
 function addProxyHandler(router: Router, { ingoingUrl, outgoingUrl, scope }: ProxyOptions) {
     router.use(
         ingoingUrl,
+        avvisKryssOpphavsKall,
         async (request: Request, response: Response, next: NextFunction) => {
             const token = getToken(request);
             if (!token) {

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -32,7 +32,7 @@ const avvisKryssOpphavsKall = (request: Request, response: Response, next: NextF
         return next();
     }
     logger.warning(`Avviste API-kall med Sec-Fetch-Site=${secFetchSite}`);
-    response.status(403).send();
+    return response.status(403).send();
 };
 
 const fjernSesjonsHeadere = (proxyRequest: { removeHeader: (name: string) => void }) => {

--- a/server/src/tokenValidation.ts
+++ b/server/src/tokenValidation.ts
@@ -12,7 +12,9 @@ export const validerInnkommendeIdportenToken = async (request: Request, response
 
     const validation = await validateIdportenToken(token);
     if (!validation.ok) {
-        logger.error('Ugyldig IDporten token', validation);
+        // Logg berre feiltype/-melding, ikkje heile valideringsobjektet — det kan
+        // innehalde dekoda claims (sub/pid m.m.) som er personopplysningar.
+        logger.error('Ugyldig IDporten token', validation.error?.message ?? 'ukjend feil');
         response.status(403).send();
         return;
     }


### PR DESCRIPTION
Human note: Eg spurte om ein revurdering av dette og da var det berre punkt 4 som vart påpeika som medium alvorleg, resten kan i praksis ikkje skje. Så mogleg dei berre bør rullast tilbake?
-----
Denne endringa adresserer fire uavhengige funn frå sikkerheitsgjennomgangen av server- og infrastrukturkoden. Alle ligg i den autentiserte BFF-en (server/) og CI-oppsettet.

1) Strip cookie-header på /fpgrunndata/api-proxyen
   Tidlegare blei IDporten-sidecar-cookien vidaresendt til fpgrunndata fordi
   /fpgrunndata/api gjekk rett gjennom createProxyMiddleware utan ein
   proxyReq-handler. Sjølv om tenesta ikkje krev autentisering, lakk vi
   ein bearer-ekvivalent sesjons-cookie ut av tillitssona vår. /fpsoknad/api
   og /fpoversikt/api gjorde dette riktig frå før. No har grunndata-proxyen
   ein eigen proxyReq-handler som kallar removeHeader('cookie') før requesten
   sendast vidare. Hjelparen fjernSesjonsHeadere er ekstrahert for å unngå
   duplisering og halde intensjonen tydeleg.

2) CSRF-djupforsvar via Sec-Fetch-Site-sjekk
   Sidan @navikt/oasis getToken hentar IDporten-tokenet frå sidecar-cookien
   som nettlesaren automatisk legg ved, vil ein cross-site POST frå ein
   ondsinna nettstad i prinsippet kunne trigge ein OBO-veksling og eit
   state-endrande proxy-kall. SameSite på sidecar-cookien gir noko vern, men
   vi hadde inga eksplisitt CSRF-beskytting i appen sjølv. Ny middleware
   avvisKryssOpphavsKall sjekkar Sec-Fetch-Site og avviser kall markert som
   "cross-site" med 403. "same-origin" og "same-site" er tillate, og kall
   utan headeren passerer (eldre nettlesarar og ikkje-nettlesar-klientar)
   slik at vi ikkje bryt legitim trafikk. Middlewaren er montert på alle
   tre proxy-stiane - også fpgrunndata - for å avgrense kva som kan
   kryss-opphavs-trigge requestar frå tenarane våre. Sjekken køyrer før
   OBO-vekslinga slik at vi sparar tokenutsteding på avviste kall.

3) Logg ikkje heile token-valideringsobjektet ved feil
   tokenValidation.ts logga tidlegare heile validation-objektet frå oasis
   ved ugyldig token. Objektet kan innehalde dekoda claims (sub/pid og
   liknande), som er personopplysningar og ikkje skal i loggar. Vi loggar
   no berre validation.error?.message med "ukjend feil" som fallback, slik
   at feilen framleis er diagnoserbar utan å eksponere PII.

4) Inkluder server/** i CodeQL-skanninga
   .github/workflows/codeql.yml hadde paths-ignore: ['server/**'] for både
   push og pull_request. Det betydde at akkurat den mest sikkerheits-
   sensitive koden (token-handsaming, proxy, inngåande HTTP) ikkje fekk
   statisk analyse på endringar. paths-ignore-blokkene er fjerna, slik at
   CodeQL no også køyrer på server-endringar.

Testar
- Lagt til testar for cookie-stripping på fpgrunndata, avvising av cross-site-kall (på både OBO- og grunndata-proxy), passering av same-origin, og bakoverkompatibilitet for requestar utan Sec-Fetch-Site-header.
- Heile testsuiten kan ikkje køyrast i dette CLI-sandboxa miljøet pga blokkert TCP-loopback (alle 12 testar feilar likt med EPERM, også dei uendra), men esbuild-bygget av server går reint og tsc-feilen som framleis ligg i src/reverseProxy.ts:96 er pre-eksisterande (gjeld logger-typen til http-proxy-middleware) og ikkje innført her.