### PR TITLE
Chore: fjerne utgåtte redirects av søknader

### DIFF
--- a/.deploy/engangsstonad/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/engangsstonad/prod-gcp-teamforeldrepenger.json
@@ -12,10 +12,6 @@
         "cpu": "20m",
         "mem": "160Mi"
     },
-    "redirect": {
-        "host": "engangsstonad.nav.no",
-        "ingressClassName": "nais-ingress-external"
-    },
     "env": {
         "PUBLIC_PATH": "/engangsstonad/soknad",
         "INNSYN": "https://www.nav.no/foreldrepenger/oversikt",

--- a/.deploy/foreldrepengesoknad/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/foreldrepengesoknad/prod-gcp-teamforeldrepenger.json
@@ -12,10 +12,6 @@
         "cpu": "20m",
         "mem": "200Mi"
     },
-    "redirect": {
-        "host": "foreldrepengesoknad.nav.no",
-        "ingressClassName": "nais-ingress-external"
-    },
     "env": {
         "PUBLIC_PATH": "/foreldrepenger/soknad",
         "INNSYN": "https://www.nav.no/foreldrepenger/oversikt",

--- a/.deploy/svangerskapspengesoknad/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/svangerskapspengesoknad/prod-gcp-teamforeldrepenger.json
@@ -12,10 +12,6 @@
         "cpu": "20m",
         "mem": "160Mi"
     },
-    "redirect": {
-        "host": "svangerskapspengesoknad.nav.no",
-        "ingressClassName": "nais-ingress-external"
-    },
     "env": {
         "PUBLIC_PATH": "/svangerskapspenger/soknad",
         "INNSYN": "https://www.nav.no/foreldrepenger/oversikt",


### PR DESCRIPTION
Fjerner disse 3 nå - så fjerner jeg de eksisterende med k delete ingress ....
Beholder redirect for foreldrepenger.nav.no siden den har vært i utstrakt bruk i brev mv. Finnes bare i prod.
Kommer med en annen PR for nytt redirect-oppsett med haproxy.org i senere PR