### PR TITLE
feat(engangsstonad): bytt til zod-skjema for validering og innsending

### DIFF
--- a/apps/engangsstonad/package.json
+++ b/apps/engangsstonad/package.json
@@ -23,6 +23,7 @@
         "storybook": "storybook dev --quiet -p 7003"
     },
     "dependencies": {
+        "@hookform/resolvers": "5.2.2",
         "@navikt/ds-css": "8.10.5",
         "@navikt/ds-react": "8.10.5",
         "@navikt/ds-tailwind": "8.10.5",
@@ -48,7 +49,8 @@
         "react-dom": "19.2.6",
         "react-hook-form": "7.75.0",
         "react-intl": "10.1.6",
-        "react-router-dom": "7.15.0"
+        "react-router-dom": "7.15.0",
+        "zod": "4.4.3"
     },
     "devDependencies": {
         "@formatjs/cli-lib": "8.6.0",

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -5,6 +5,7 @@ import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
+import { engangsstønadDtoSchema } from 'schemas/engangsstønadDtoSchema';
 import { Dokumentasjon, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
 import { ApiError } from '@navikt/fp-observability';
@@ -48,6 +49,14 @@ export const useEsSendSøknad = (personinfo: EsPersonopplysningerDto_fpoversikt)
                     },
                 })) ?? [],
         } satisfies EngangsstønadDto;
+
+        // Sjekk søknad mot DTO-skjema før innsending — fangar mappingfeil og korrupt mellomlagra state
+        const parseResultat = engangsstønadDtoSchema.safeParse(søknad);
+        if (!parseResultat.success) {
+            throw new Error(
+                `Søknad bestod ikkje skjema-validering før innsending: ${parseResultat.error.message}`,
+            );
+        }
 
         const signal = initAbortSignal();
 

--- a/apps/engangsstonad/src/schemas/dokumentasjonSchema.ts
+++ b/apps/engangsstonad/src/schemas/dokumentasjonSchema.ts
@@ -1,0 +1,94 @@
+import dayjs from 'dayjs';
+import minMax from 'dayjs/plugin/minMax';
+import { IntlShape } from 'react-intl';
+import { z } from 'zod';
+
+import { isBeforeTodayOrToday, isValidDate } from '@navikt/fp-validation';
+
+import { Dokumentasjon } from 'types/Dokumentasjon';
+
+dayjs.extend(minMax);
+
+const ATTEN_UKER_OG_TRE_DAGAR = 18 * 7 + 3;
+
+const isUtstedtDatoIUke22 =
+    (termindato: string | undefined, message: string) =>
+    (terminBekreftelseDato: string): string | null => {
+        if (!termindato) {
+            return null;
+        }
+        const utstedt = dayjs(terminBekreftelseDato).startOf('day');
+        const uke22 = dayjs(termindato).startOf('day').subtract(ATTEN_UKER_OG_TRE_DAGAR, 'days');
+        return dayjs.max(uke22, utstedt).isSame(utstedt) ? null : message;
+    };
+
+const runPredicates = <T>(
+    value: T,
+    ctx: z.RefinementCtx,
+    path: Array<string | number>,
+    predicates: Array<(v: T) => string | null>,
+): void => {
+    for (const predicate of predicates) {
+        const message = predicate(value);
+        if (message) {
+            ctx.addIssue({ code: 'custom', message, path });
+            return;
+        }
+    }
+};
+
+const vedleggSchema = z.array(z.any()).default([]);
+
+interface Options {
+    erTermin: boolean;
+    termindato?: string;
+}
+
+export const lagDokumentasjonSchema = (
+    intl: IntlShape,
+    { erTermin, termindato }: Options,
+): z.ZodType<Dokumentasjon, Dokumentasjon> =>
+    z
+        .object({
+            vedlegg: vedleggSchema,
+            terminbekreftelsedato: z.string().optional(),
+        })
+        .superRefine((data, ctx) => {
+            if (data.vedlegg.length === 0) {
+                ctx.addIssue({
+                    code: 'custom',
+                    path: ['vedlegg'],
+                    message: erTermin
+                        ? intl.formatMessage({ id: 'DokumentasjonSteg.MinstEttDokumentTermin' })
+                        : intl.formatMessage({ id: 'DokumentasjonSteg.MinstEttDokumentAdopsjon' }),
+                });
+            }
+            if (erTermin) {
+                if (!data.terminbekreftelsedato) {
+                    ctx.addIssue({
+                        code: 'custom',
+                        path: ['terminbekreftelsedato'],
+                        message: intl.formatMessage({
+                            id: 'TerminDokPanel.Validering.TerminbekreftelseDato.DuMåOppgi',
+                        }),
+                    });
+                } else {
+                    runPredicates(data.terminbekreftelsedato, ctx, ['terminbekreftelsedato'], [
+                        isValidDate(
+                            intl.formatMessage({ id: 'TerminDokPanel.Validering.TerminBekreftelsedato' }),
+                        ),
+                        isBeforeTodayOrToday(
+                            intl.formatMessage({
+                                id: 'TerminDokPanel.Validering.TerminBekreftelsedato.MåVæreIdagEllerTidligere',
+                            }),
+                        ),
+                        isUtstedtDatoIUke22(
+                            termindato,
+                            intl.formatMessage({
+                                id: 'TerminDokPanel.Validering.TerminBekreftelsedato.DuMåVæreIUke22',
+                            }),
+                        ),
+                    ]);
+                }
+            }
+        }) as unknown as z.ZodType<Dokumentasjon, Dokumentasjon>;

--- a/apps/engangsstonad/src/schemas/engangsstønadDtoSchema.ts
+++ b/apps/engangsstonad/src/schemas/engangsstønadDtoSchema.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+import { ISO_DATE_REGEX } from '@navikt/fp-constants';
+import { EngangsstønadDto } from '@navikt/fp-types';
+
+const isoDateString = z.string().regex(ISO_DATE_REGEX, 'Forventa ISO-dato (YYYY-MM-DD)');
+
+const navnSchema = z.object({
+    fornavn: z.string().min(1),
+    etternavn: z.string().min(1),
+    mellomnavn: z.string().optional(),
+});
+
+const søkerinfoSchema = z.object({
+    fnr: z.string().min(1),
+    navn: navnSchema,
+    arbeidsforhold: z.array(z.any()).optional(),
+});
+
+const målformSchema = z.enum(['NB', 'NN', 'EN', 'E']);
+
+const baseBarnFelt = {
+    antallBarn: z.number().int().positive().optional(),
+};
+
+const fødselDtoSchema = z.object({
+    type: z.literal('fødsel'),
+    ...baseBarnFelt,
+    fødselsdato: isoDateString,
+    termindato: isoDateString.optional(),
+});
+
+const terminDtoSchema = z.object({
+    type: z.literal('termin'),
+    ...baseBarnFelt,
+    termindato: isoDateString,
+    terminbekreftelseDato: isoDateString.optional(),
+});
+
+const adopsjonDtoSchema = z.object({
+    type: z.literal('adopsjon'),
+    ...baseBarnFelt,
+    adopsjonAvEktefellesBarn: z.boolean(),
+    adopsjonsdato: isoDateString,
+    ankomstdato: isoDateString.optional(),
+    søkerAdopsjonAlene: z.boolean().optional(),
+    fødselsdatoer: z.array(isoDateString).optional(),
+});
+
+const omsorgsovertakelseDtoSchema = z.object({
+    type: z.literal('omsorgsovertakelse'),
+    ...baseBarnFelt,
+    foreldreansvarsdato: isoDateString,
+    fødselsdatoer: z.array(isoDateString).optional(),
+});
+
+const barnDtoSchema = z.discriminatedUnion('type', [
+    fødselDtoSchema,
+    terminDtoSchema,
+    adopsjonDtoSchema,
+    omsorgsovertakelseDtoSchema,
+]);
+
+const utenlandsoppholdsperiodeSchema = z.object({
+    fom: isoDateString,
+    tom: isoDateString,
+    landkode: z.string().min(2),
+});
+
+const vedleggDtoSchema = z.object({
+    skjemanummer: z.string().min(1),
+    innsendingsType: z.enum(['LASTET_OPP', 'SEND_SENERE', 'AUTOMATISK']),
+    uuid: z.string().optional(),
+    beskrivelse: z.string().optional(),
+    dokumenterer: z
+        .object({
+            type: z.enum(['BARN', 'OPPTJENING', 'UTTAK', 'TILRETTELEGGING']),
+        })
+        .passthrough()
+        .optional(),
+});
+
+export const engangsstønadDtoSchema: z.ZodType<EngangsstønadDto> = z.object({
+    barn: barnDtoSchema,
+    mottattdato: isoDateString.optional(),
+    språkkode: målformSchema,
+    søkerinfo: søkerinfoSchema,
+    utenlandsopphold: z.array(utenlandsoppholdsperiodeSchema).optional(),
+    vedlegg: z.array(vedleggDtoSchema).optional(),
+}) as unknown as z.ZodType<EngangsstønadDto>;

--- a/apps/engangsstonad/src/schemas/omBarnetSchema.ts
+++ b/apps/engangsstonad/src/schemas/omBarnetSchema.ts
@@ -1,0 +1,212 @@
+import { IntlShape } from 'react-intl';
+import { z } from 'zod';
+
+import {
+    erI22SvangerskapsukeEllerSenere,
+    isAfterOrSameAsSixMonthsAgo,
+    isBeforeTodayOrToday,
+    isMaxOneYearIntoTheFuture,
+    isValidDate,
+} from '@navikt/fp-validation';
+import { isLessThanThreeWeeksBeforeFødsel } from '@navikt/fp-validation/src/form/dateFormValidation';
+
+import { Adopsjon, Fødsel } from 'types/OmBarnet';
+
+/**
+ * Køyr ein liste med fp-validation-predikat på ein verdi og legg til zod-issue
+ * for første feilen som blir funnen, slik at meldinga endar opp på rett felt-path.
+ */
+const runPredicates = <T>(
+    value: T,
+    ctx: z.RefinementCtx,
+    path: Array<string | number>,
+    predicates: Array<(v: T) => string | null>,
+): void => {
+    for (const predicate of predicates) {
+        const message = predicate(value);
+        if (message) {
+            ctx.addIssue({ code: 'custom', message, path });
+            return;
+        }
+    }
+};
+
+export type FødselFormValues = Fødsel & { antallBarnDropDown?: string };
+export type AdopsjonFormValues = Adopsjon & { antallBarnDropDown?: string };
+export type OmBarnetFormValues = FødselFormValues & AdopsjonFormValues;
+
+/**
+ * Felles "rå" struktur som dekkjer både fødsel- og adopsjonsfelt — bygd som
+ * eit ope, optional-skjema slik at output passar inn i RHF sine eksisterande
+ * `FormValues`-typar. All forretningslogikk skjer i `superRefine`.
+ */
+const baseFelt = z.object({
+    erBarnetFødt: z.boolean().optional(),
+    antallBarn: z.number().optional(),
+    antallBarnDropDown: z.string().optional(),
+    fødselsdato: z.string().optional(),
+    termindato: z.string().optional(),
+    adopsjonAvEktefellesBarn: z.boolean().optional(),
+    adopsjonsdato: z.string().optional(),
+    søkerAdopsjonAlene: z.boolean().optional(),
+    fødselsdatoer: z.array(z.object({ dato: z.string().optional() })).optional(),
+});
+
+const refineAntallBarn = (
+    data: z.infer<typeof baseFelt>,
+    ctx: z.RefinementCtx,
+    krevMsg: string,
+    dropdownMsg: string,
+) => {
+    if (data.antallBarn === undefined) {
+        ctx.addIssue({ code: 'custom', path: ['antallBarn'], message: krevMsg });
+    } else if (data.antallBarn === 3 && !data.antallBarnDropDown) {
+        ctx.addIssue({ code: 'custom', path: ['antallBarnDropDown'], message: dropdownMsg });
+    }
+};
+
+export const lagFødselSchema = (
+    intl: IntlShape,
+): z.ZodType<OmBarnetFormValues, OmBarnetFormValues> =>
+    baseFelt.superRefine((data, ctx) => {
+        const antallBarnFødtMsg = intl.formatMessage({ id: 'FødselPanel.AntallBarn.Født.Required' });
+        const antallBarnTerminMsg = intl.formatMessage({ id: 'FødselPanel.AntallBarn.Venter.Required' });
+
+        if (data.erBarnetFødt === undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['erBarnetFødt'],
+                message: intl.formatMessage({ id: 'FødselPanel.Spørsmål.ErBarnetFødt.Required' }),
+            });
+        }
+
+        // termindato
+        if (!data.termindato) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['termindato'],
+                message: intl.formatMessage({ id: 'FødselPanel.Termindato.DuMåOppgi' }),
+            });
+        } else {
+            runPredicates(data.termindato, ctx, ['termindato'], [
+                isValidDate(intl.formatMessage({ id: 'FødselPanel.Termindato.Gyldig' })),
+                erI22SvangerskapsukeEllerSenere(
+                    intl.formatMessage({ id: 'FødselPanel.Termindato.DuMåVæreIUke22' }),
+                ),
+                ...(data.fødselsdato
+                    ? [
+                          isLessThanThreeWeeksBeforeFødsel(
+                              intl.formatMessage({
+                                  id: 'FødselPanel.Termindato.TermindatoKanIkkeVære3UkerFørFødsel',
+                              }),
+                              data.fødselsdato,
+                          ),
+                      ]
+                    : []),
+            ]);
+        }
+
+        // fødselsdato berre når barnet er fødd
+        if (data.erBarnetFødt) {
+            if (!data.fødselsdato) {
+                ctx.addIssue({
+                    code: 'custom',
+                    path: ['fødselsdato'],
+                    message: intl.formatMessage({ id: 'FødselPanel.Fødselsdato.DuMåOppgi' }),
+                });
+            } else {
+                runPredicates(data.fødselsdato, ctx, ['fødselsdato'], [
+                    isValidDate(intl.formatMessage({ id: 'FødselPanel.Fødselsdato.Gyldig' })),
+                    isBeforeTodayOrToday(
+                        intl.formatMessage({ id: 'FødselPanel.Fodselsdato.MåVæreIdagEllerTidligere' }),
+                    ),
+                    isAfterOrSameAsSixMonthsAgo(
+                        intl.formatMessage({ id: 'FødselPanel.Fodselsdato.IkkeMerEnn6MånederTilbake' }),
+                    ),
+                ]);
+            }
+        }
+
+        refineAntallBarn(
+            data,
+            ctx,
+            data.erBarnetFødt ? antallBarnFødtMsg : antallBarnTerminMsg,
+            data.erBarnetFødt ? antallBarnFødtMsg : antallBarnTerminMsg,
+        );
+    }) as unknown as z.ZodType<OmBarnetFormValues, OmBarnetFormValues>;
+
+export const lagAdopsjonSchema = (
+    intl: IntlShape,
+    kjønn?: string,
+): z.ZodType<OmBarnetFormValues, OmBarnetFormValues> =>
+    baseFelt.superRefine((data, ctx) => {
+        if (data.adopsjonAvEktefellesBarn === undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['adopsjonAvEktefellesBarn'],
+                message: intl.formatMessage({ id: 'AdopsjonPanel.Spørsmål.Required' }),
+            });
+        }
+
+        if (kjønn === 'M' && data.adopsjonAvEktefellesBarn === false && data.søkerAdopsjonAlene === undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['søkerAdopsjonAlene'],
+                message: intl.formatMessage({ id: 'AdopsjonPanel.AdoptererDuAlene.Required' }),
+            });
+        }
+
+        // adopsjonsdato
+        const adopsjonsdatoKrevMsg = data.adopsjonAvEktefellesBarn
+            ? intl.formatMessage({ id: 'AdopsjonPanel.EktefellensBarn.DuMåOppgi' })
+            : intl.formatMessage({ id: 'AdopsjonPanel.OvertaOmsorg.DuMåOppgi' });
+        const adopsjonsdatoUgyldigMsg = data.adopsjonAvEktefellesBarn
+            ? intl.formatMessage({ id: 'AdopsjonPanel.Adopsjonsdato.GyldigFormat' })
+            : intl.formatMessage({ id: 'AdopsjonPanel.Omsorgsovertakelsen.GyldigFormat' });
+
+        if (!data.adopsjonsdato) {
+            ctx.addIssue({ code: 'custom', path: ['adopsjonsdato'], message: adopsjonsdatoKrevMsg });
+        } else {
+            runPredicates(data.adopsjonsdato, ctx, ['adopsjonsdato'], [
+                isValidDate(adopsjonsdatoUgyldigMsg),
+                isMaxOneYearIntoTheFuture(
+                    intl.formatMessage({ id: 'AdopsjonPanel.AdopsjonDato.ForLangtFremITid' }),
+                ),
+            ]);
+        }
+
+        const antallBarnMsg = intl.formatMessage({ id: 'AdopsjonPanel.Antallbarn.Required' });
+        refineAntallBarn(
+            data,
+            ctx,
+            antallBarnMsg,
+            intl.formatMessage({ id: 'AdopsjonPanel.Antallbarndropdown.Required' }),
+        );
+
+        // fødselsdatoer
+        (data.fødselsdatoer ?? []).forEach((entry, index) => {
+            const path = ['fødselsdatoer', index, 'dato'] as Array<string | number>;
+            if (!entry.dato) {
+                ctx.addIssue({
+                    code: 'custom',
+                    path,
+                    message: intl.formatMessage({ id: 'AdopsjonFodselFieldArray.Fodselsdato.DuMåOppgi' }),
+                });
+                return;
+            }
+            runPredicates(entry.dato, ctx, path, [
+                isValidDate(
+                    intl.formatMessage({ id: 'AdopsjonFodselFieldArray.Fødselsdato.Gyldig' }),
+                ),
+                ...(data.adopsjonsdato
+                    ? [
+                          isBeforeTodayOrToday(
+                              intl.formatMessage({
+                                  id: 'AdopsjonFodselFieldArray.fodselsdato.MåVæreIdagEllerTidligere',
+                              }),
+                          ),
+                      ]
+                    : []),
+            ]);
+        });
+    }) as unknown as z.ZodType<OmBarnetFormValues, OmBarnetFormValues>;

--- a/apps/engangsstonad/src/schemas/refinements.ts
+++ b/apps/engangsstonad/src/schemas/refinements.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import {
+    erI22SvangerskapsukeEllerSenere,
+    isAfterOrSameAsSixMonthsAgo,
+    isBeforeTodayOrToday,
+    isMaxOneYearIntoTheFuture,
+    isValidDate,
+} from '@navikt/fp-validation';
+
+/**
+ * Lar oss reuse predikat-funksjonar frå @navikt/fp-validation (som returnerer
+ * `string | null`) inne i zod-refinements utan å duplisera dato-logikken.
+ */
+export const refineWithPredicate =
+    <T>(predicate: (value: T) => string | null) =>
+    (value: T, ctx: z.RefinementCtx) => {
+        const message = predicate(value);
+        if (message) {
+            ctx.addIssue({ code: 'custom', message });
+        }
+    };
+
+export const isValidIsoDate = (message: string) => refineWithPredicate(isValidDate(message));
+export const isBeforeOrToday = (message: string) => refineWithPredicate(isBeforeTodayOrToday(message));
+export const isAtMostOneYearAhead = (message: string) => refineWithPredicate(isMaxOneYearIntoTheFuture(message));
+export const isWithinLastSixMonths = (message: string) => refineWithPredicate(isAfterOrSameAsSixMonthsAgo(message));
+export const isAtUke22EllerSenere = (message: string) =>
+    refineWithPredicate(erI22SvangerskapsukeEllerSenere(message));

--- a/apps/engangsstonad/src/schemas/søkersituasjonSchema.ts
+++ b/apps/engangsstonad/src/schemas/søkersituasjonSchema.ts
@@ -1,0 +1,19 @@
+import { IntlShape } from 'react-intl';
+import { z } from 'zod';
+
+import { Søkersituasjon } from '@navikt/fp-types';
+
+export const lagSøkersituasjonSchema = (
+    intl: IntlShape,
+): z.ZodType<Søkersituasjon, Søkersituasjon> =>
+    z.object({
+        situasjon: z
+            .enum(['fødsel', 'adopsjon'])
+            .optional()
+            .refine((v): v is 'fødsel' | 'adopsjon' => v !== undefined, {
+                message: intl.formatMessage({
+                    id: 'SøkersituasjonSteg.Validering.OppgiFodselEllerAdopsjon',
+                }),
+            }),
+    });
+

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
@@ -1,6 +1,8 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
+import { lagDokumentasjonSchema } from 'schemas/dokumentasjonSchema';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
@@ -33,23 +35,18 @@ export const DokumentasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
 
     const erBarnetAdoptert = barn.type === 'adopsjon';
     const harTermindato = barn.type === 'termin';
+    const termindato = barn.type === 'termin' ? barn.termindato : undefined;
 
     const formMethods = useForm<Dokumentasjon>({
         defaultValues: dokumentasjon,
+        resolver: zodResolver(
+            lagDokumentasjonSchema(intl, { erTermin: harTermindato, termindato }),
+        ),
     });
 
     const lagre = (formValues: Dokumentasjon) => {
-        if (formValues.vedlegg.length === 0) {
-            formMethods.setError('vedlegg', {
-                message: erBarnetAdoptert
-                    ? intl.formatMessage({ id: 'DokumentasjonSteg.MinstEttDokumentAdopsjon' })
-                    : intl.formatMessage({ id: 'DokumentasjonSteg.MinstEttDokumentTermin' }),
-            });
-            return Promise.resolve();
-        } else {
-            oppdaterDokumentasjon(formValues);
-            return navigator.goToNextDefaultStep();
-        }
+        oppdaterDokumentasjon(formValues);
+        return navigator.goToNextDefaultStep();
     };
 
     const updateAttachments = (attachments: Attachment[], hasPendingUploads: boolean) => {
@@ -74,7 +71,7 @@ export const DokumentasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
                             <TerminDokPanel
                                 attachments={dokumentasjon?.vedlegg}
                                 updateAttachments={updateAttachments}
-                                termindato={barn.type === 'termin' ? barn.termindato : ''}
+                                termindato={termindato ?? ''}
                             />
                         )}
                         <ScanDocumentInfo />

--- a/apps/engangsstonad/src/steg/dokumentasjon/TerminDokPanel.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/TerminDokPanel.tsx
@@ -2,31 +2,15 @@ import { API_URLS } from 'appData/queries';
 import dayjs from 'dayjs';
 import minMax from 'dayjs/plugin/minMax';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Dokumentasjon } from 'types/Dokumentasjon';
 
 import { AttachmentType, Skjemanummer } from '@navikt/fp-constants';
 import { FileUploader } from '@navikt/fp-filopplaster';
 import { RhfDatepicker } from '@navikt/fp-form-hooks';
 import { Attachment } from '@navikt/fp-types';
-import { isBeforeTodayOrToday, isRequired, isValidDate } from '@navikt/fp-validation';
 
 dayjs.extend(minMax);
-
-const ukerAaTrekkeFraTerminDato = 18;
-const ekstraDagerAaTrekkeFraTerminDato = 3;
-const dagerForTerminbekreftelse = ukerAaTrekkeFraTerminDato * 7 + ekstraDagerAaTrekkeFraTerminDato;
-
-const isUtstedtDatoIUke22 = (termindato: string, intl: IntlShape) => (terminBekreftelseDato: string) => {
-    const utstedtDato = dayjs(terminBekreftelseDato).startOf('day');
-    const terminDato = dayjs(termindato).startOf('day');
-    const uke22 = terminDato.subtract(dagerForTerminbekreftelse, 'days');
-    const erUtstedtDataIUke22 = dayjs.max(uke22, utstedtDato).isSame(utstedtDato);
-
-    return erUtstedtDataIUke22
-        ? null
-        : intl.formatMessage({ id: 'TerminDokPanel.Validering.TerminBekreftelsedato.DuMåVæreIUke22' });
-};
 
 interface Props {
     attachments?: Attachment[];
@@ -47,16 +31,6 @@ export const TerminDokPanel = ({ attachments, updateAttachments, termindato }: P
                 label={<FormattedMessage id="TerminDokPanel.Terminbekreftelsesdato" />}
                 minDate={dayjs(termindato).subtract(18, 'week').subtract(3, 'day')}
                 maxDate={dayjs()}
-                validate={[
-                    isRequired(intl.formatMessage({ id: 'TerminDokPanel.Validering.TerminbekreftelseDato.DuMåOppgi' })),
-                    isValidDate(intl.formatMessage({ id: 'TerminDokPanel.Validering.TerminBekreftelsedato' })),
-                    isBeforeTodayOrToday(
-                        intl.formatMessage({
-                            id: 'TerminDokPanel.Validering.TerminBekreftelsedato.MåVæreIdagEllerTidligere',
-                        }),
-                    ),
-                    isUtstedtDatoIUke22(termindato, intl),
-                ]}
             />
             <FileUploader
                 label={intl.formatMessage({ id: 'TerminDokPanel.Vedlegg.Terminbekreftelse' })}

--- a/apps/engangsstonad/src/steg/om-barnet/AdopsjonFodselFieldArray.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/AdopsjonFodselFieldArray.tsx
@@ -6,7 +6,6 @@ import { IntlShape, useIntl } from 'react-intl';
 import { VStack } from '@navikt/ds-react';
 
 import { RhfDatepicker } from '@navikt/fp-form-hooks';
-import { isBeforeTodayOrToday, isRequired, isValidDate } from '@navikt/fp-validation';
 
 type FormValues = {
     fødselsdatoer?: Array<{
@@ -20,7 +19,7 @@ interface Props {
     adopsjonsdato?: string;
 }
 
-export const AdopsjonFodselFieldArray = ({ adopsjonsdato, antallBarn, antallBarnDropDown }: Props) => {
+export const AdopsjonFodselFieldArray = ({ antallBarn, antallBarnDropDown }: Props) => {
     const intl = useIntl();
     const { control } = useFormContext<FormValues>();
     const { fields, remove, append } = useFieldArray({
@@ -61,19 +60,6 @@ export const AdopsjonFodselFieldArray = ({ adopsjonsdato, antallBarn, antallBarn
                             ? intl.formatMessage({ id: 'AdopsjonFodselFieldArray.Fødselsdato' })
                             : getFødselsdatoLabel(intl, index + 1)
                     }
-                    validate={[
-                        isRequired(intl.formatMessage({ id: 'AdopsjonFodselFieldArray.Fodselsdato.DuMåOppgi' })),
-                        isValidDate(intl.formatMessage({ id: 'AdopsjonFodselFieldArray.Fødselsdato.Gyldig' })),
-                        (fødselsdato) => {
-                            return !fødselsdato || !adopsjonsdato
-                                ? null
-                                : isBeforeTodayOrToday(
-                                      intl.formatMessage({
-                                          id: 'AdopsjonFodselFieldArray.fodselsdato.MåVæreIdagEllerTidligere',
-                                      }),
-                                  )(fødselsdato);
-                        },
-                    ]}
                 />
             ))}
         </VStack>

--- a/apps/engangsstonad/src/steg/om-barnet/AdopsjonPanel.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/AdopsjonPanel.tsx
@@ -1,19 +1,16 @@
 import dayjs from 'dayjs';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Adopsjon } from 'types/OmBarnet';
+import { AdopsjonFormValues } from 'schemas/omBarnetSchema';
 
 import { Radio } from '@navikt/ds-react';
 
 import { RhfDatepicker, RhfRadioGroup, RhfSelect } from '@navikt/fp-form-hooks';
 import { Kjønn_fpoversikt } from '@navikt/fp-types';
-import { isMaxOneYearIntoTheFuture, isRequired, isValidDate } from '@navikt/fp-validation';
 
 import { AdopsjonFodselFieldArray } from './AdopsjonFodselFieldArray';
 
-export type FormValues = {
-    antallBarnDropDown?: string;
-} & Adopsjon;
+export type FormValues = AdopsjonFormValues;
 
 interface Props {
     kjønn: Kjønn_fpoversikt;
@@ -32,7 +29,6 @@ export const AdopsjonPanel = ({ kjønn }: Props) => {
                 name="adopsjonAvEktefellesBarn"
                 control={control}
                 label={<FormattedMessage id="AdopsjonPanel.Spørsmål.Stebarnsadopsjon" />}
-                validate={[isRequired(intl.formatMessage({ id: 'AdopsjonPanel.Spørsmål.Required' }))]}
             >
                 <Radio value={true}>
                     <FormattedMessage id="AdopsjonPanel.Ja" />
@@ -50,28 +46,12 @@ export const AdopsjonPanel = ({ kjønn }: Props) => {
                         : intl.formatMessage({ id: 'AdopsjonPanel.Spørsmål.Overtaomsorgdato' })
                 }
                 minDate={dayjs().subtract(6, 'month')}
-                validate={[
-                    isRequired(
-                        adopsjonAvEktefellesBarn
-                            ? intl.formatMessage({ id: 'AdopsjonPanel.EktefellensBarn.DuMåOppgi' })
-                            : intl.formatMessage({ id: 'AdopsjonPanel.OvertaOmsorg.DuMåOppgi' }),
-                    ),
-                    isValidDate(
-                        adopsjonAvEktefellesBarn
-                            ? intl.formatMessage({ id: 'AdopsjonPanel.Adopsjonsdato.GyldigFormat' })
-                            : intl.formatMessage({ id: 'AdopsjonPanel.Omsorgsovertakelsen.GyldigFormat' }),
-                    ),
-                    isMaxOneYearIntoTheFuture(
-                        intl.formatMessage({ id: 'AdopsjonPanel.AdopsjonDato.ForLangtFremITid' }),
-                    ),
-                ]}
             />
             <RhfRadioGroup
                 name="antallBarn"
                 control={control}
                 label={<FormattedMessage id="AdopsjonPanel.Spørsmål.AntallBarnAdoptert" />}
                 description={<FormattedMessage id="AdopsjonPanel.Spørsmål.AntallBarnAdoptert.Beskrivelse" />}
-                validate={[isRequired(intl.formatMessage({ id: 'AdopsjonPanel.Antallbarn.Required' }))]}
             >
                 <Radio value={1}>
                     <FormattedMessage id="AdopsjonPanel.Radiobutton.Ettbarn" />
@@ -83,12 +63,11 @@ export const AdopsjonPanel = ({ kjønn }: Props) => {
                     <FormattedMessage id="AdopsjonPanel.Radiobutton.Flere" />
                 </Radio>
             </RhfRadioGroup>
-            {antallBarn && antallBarn >= 3 && (
+            {antallBarn !== undefined && antallBarn >= 3 && (
                 <RhfSelect
                     name="antallBarnDropDown"
                     control={control}
                     label={<FormattedMessage id="AdopsjonPanel.AntallBarn.Omsorgsovertakelse" />}
-                    validate={[isRequired(intl.formatMessage({ id: 'AdopsjonPanel.Antallbarndropdown.Required' }))]}
                 >
                     <option value="3">3</option>
                     <option value="4">4</option>
@@ -109,7 +88,6 @@ export const AdopsjonPanel = ({ kjønn }: Props) => {
                     name="søkerAdopsjonAlene"
                     control={control}
                     label={<FormattedMessage id="AdopsjonPanel.Spørsmål.AdoptererDuAlene" />}
-                    validate={[isRequired(intl.formatMessage({ id: 'AdopsjonPanel.AdoptererDuAlene.Required' }))]}
                 >
                     <Radio value={true}>
                         <FormattedMessage id="AdopsjonPanel.Ja" />

--- a/apps/engangsstonad/src/steg/om-barnet/FødselPanel.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/FødselPanel.tsx
@@ -1,23 +1,13 @@
 import dayjs from 'dayjs';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Fødsel } from 'types/OmBarnet';
+import { FødselFormValues } from 'schemas/omBarnetSchema';
 
 import { Radio } from '@navikt/ds-react';
 
 import { RhfDatepicker, RhfRadioGroup, RhfSelect } from '@navikt/fp-form-hooks';
-import {
-    erI22SvangerskapsukeEllerSenere,
-    isAfterOrSameAsSixMonthsAgo,
-    isBeforeTodayOrToday,
-    isRequired,
-    isValidDate,
-} from '@navikt/fp-validation';
-import { isLessThanThreeWeeksBeforeFødsel } from '@navikt/fp-validation/src/form/dateFormValidation';
 
-export type FormValues = {
-    antallBarnDropDown?: string;
-} & Fødsel;
+export type FormValues = FødselFormValues;
 
 export const FødselPanel = () => {
     const intl = useIntl();
@@ -34,7 +24,6 @@ export const FødselPanel = () => {
                 name="erBarnetFødt"
                 control={control}
                 label={<FormattedMessage id="FødselPanel.Spørsmål.ErBarnetFødt" />}
-                validate={[isRequired(intl.formatMessage({ id: 'FødselPanel.Spørsmål.ErBarnetFødt.Required' }))]}
             >
                 <Radio value={true}>
                     <FormattedMessage id="FødselPanel.Radiobutton.Ja" />
@@ -50,17 +39,6 @@ export const FødselPanel = () => {
                 description={intl.formatMessage({ id: 'FødselPanel.TermindatoFodselsdato.beskrivelse' })}
                 minDate={dayjs(fødselsdato).subtract(3, 'week')}
                 maxDate={dayjs().add(18, 'weeks').add(3, 'days')}
-                validate={[
-                    isRequired(intl.formatMessage({ id: 'FødselPanel.Termindato.DuMåOppgi' })),
-                    isValidDate(intl.formatMessage({ id: 'FødselPanel.Termindato.Gyldig' })),
-                    isLessThanThreeWeeksBeforeFødsel(
-                        intl.formatMessage({ id: 'FødselPanel.Termindato.TermindatoKanIkkeVære3UkerFørFødsel' }),
-                        fødselsdato,
-                    ),
-                    erI22SvangerskapsukeEllerSenere(
-                        intl.formatMessage({ id: 'FødselPanel.Termindato.DuMåVæreIUke22' }),
-                    ),
-                ]}
             />
             {erBarnetFødt && (
                 <RhfDatepicker
@@ -69,16 +47,6 @@ export const FødselPanel = () => {
                     label={<FormattedMessage id="FødselPanel.Fødselsdato" />}
                     minDate={dayjs().subtract(6, 'month')}
                     maxDate={dayjs()}
-                    validate={[
-                        isRequired(intl.formatMessage({ id: 'FødselPanel.Fødselsdato.DuMåOppgi' })),
-                        isValidDate(intl.formatMessage({ id: 'FødselPanel.Fødselsdato.Gyldig' })),
-                        isBeforeTodayOrToday(
-                            intl.formatMessage({ id: 'FødselPanel.Fodselsdato.MåVæreIdagEllerTidligere' }),
-                        ),
-                        isAfterOrSameAsSixMonthsAgo(
-                            intl.formatMessage({ id: 'FødselPanel.Fodselsdato.IkkeMerEnn6MånederTilbake' }),
-                        ),
-                    ]}
                 />
             )}
             <RhfRadioGroup
@@ -90,13 +58,6 @@ export const FødselPanel = () => {
                         : intl.formatMessage({ id: 'FødselPanel.AntallBarn.Termin' })
                 }
                 description={intl.formatMessage({ id: 'FødselPanel.AntallBarn.TerminBeskrivelse' })}
-                validate={[
-                    isRequired(
-                        erBarnetFødt
-                            ? intl.formatMessage({ id: 'FødselPanel.AntallBarn.Født.Required' })
-                            : intl.formatMessage({ id: 'FødselPanel.AntallBarn.Venter.Required' }),
-                    ),
-                ]}
             >
                 <Radio value={1}>
                     <FormattedMessage id="FødselPanel.Radiobutton.Ettbarn" />
@@ -108,7 +69,7 @@ export const FødselPanel = () => {
                     <FormattedMessage id="FødselPanel.Radiobutton.Flere" />
                 </Radio>
             </RhfRadioGroup>
-            {antallBarn >= 3 && (
+            {antallBarn !== undefined && antallBarn >= 3 && (
                 <RhfSelect
                     name="antallBarnDropDown"
                     control={control}
@@ -117,13 +78,6 @@ export const FødselPanel = () => {
                             ? intl.formatMessage({ id: 'FødselPanel.AntallBarn.Født' })
                             : intl.formatMessage({ id: 'FødselPanel.AntallBarn.Termin' })
                     }
-                    validate={[
-                        isRequired(
-                            erBarnetFødt
-                                ? intl.formatMessage({ id: 'FødselPanel.AntallBarn.Født.Required' })
-                                : intl.formatMessage({ id: 'FødselPanel.AntallBarn.Venter.Required' }),
-                        ),
-                    ]}
                 >
                     <option value="3">3</option>
                     <option value="4">4</option>

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -1,7 +1,9 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
+import { lagAdopsjonSchema, lagFødselSchema, OmBarnetFormValues } from 'schemas/omBarnetSchema';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 import { Adopsjon, Fødsel } from 'types/OmBarnet';
@@ -13,10 +15,10 @@ import { BarnDto, Kjønn_fpoversikt, Søkersituasjon } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
-import { FormValues as AdopsjonFormValues, AdopsjonPanel } from './AdopsjonPanel';
-import { FødselPanel, FormValues as FødtFormValues } from './FødselPanel';
+import { AdopsjonPanel } from './AdopsjonPanel';
+import { FødselPanel } from './FødselPanel';
 
-type FormValues = FødtFormValues & AdopsjonFormValues;
+type FormValues = OmBarnetFormValues;
 
 interface Props {
     kjønn: Kjønn_fpoversikt;
@@ -47,6 +49,11 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
 
     const formMethods = useForm<FormValues>({
         defaultValues: barn ? mapBarnFraDtoTilForm(barn) : {},
+        resolver: zodResolver(
+            søkersituasjon.situasjon === 'adopsjon'
+                ? lagAdopsjonSchema(intl, kjønn)
+                : lagFødselSchema(intl),
+        ),
     });
 
     return (

--- a/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.tsx
@@ -1,4 +1,6 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
+import { lagSøkersituasjonSchema } from 'schemas/søkersituasjonSchema';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
@@ -9,7 +11,6 @@ import { Radio, VStack } from '@navikt/ds-react';
 import { ErrorSummaryHookForm, RhfForm, RhfRadioGroup, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { Søkersituasjon } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
-import { isRequired } from '@navikt/fp-validation';
 
 type Props = {
     mellomlagreOgNaviger: () => Promise<void>;
@@ -27,6 +28,7 @@ export const SøkersituasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
 
     const formMethods = useForm<Søkersituasjon>({
         defaultValues: søkersituasjon,
+        resolver: zodResolver(lagSøkersituasjonSchema(intl)),
     });
 
     const lagre = (formValues: Søkersituasjon) => {
@@ -47,13 +49,6 @@ export const SøkersituasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
                             name="situasjon"
                             control={formMethods.control}
                             label={<FormattedMessage id="SøkersituasjonSteg.Situasjon" />}
-                            validate={[
-                                isRequired(
-                                    intl.formatMessage({
-                                        id: 'SøkersituasjonSteg.Validering.OppgiFodselEllerAdopsjon',
-                                    }),
-                                ),
-                            ]}
                         >
                             <Radio value="fødsel">
                                 <FormattedMessage id="SøkersituasjonSteg.Fødsel" />

--- a/apps/engangsstonad/tsconfig.json
+++ b/apps/engangsstonad/tsconfig.json
@@ -5,7 +5,8 @@
         "paths": {
             "styles/*": ["./src/styles/*"],
             "types/*": ["./src/types/*"],
-            "appData/*": ["./src/app-data/*"]
+            "appData/*": ["./src/app-data/*"],
+            "schemas/*": ["./src/schemas/*"]
         },
         "types": ["@testing-library/jest-dom", "vitest/globals", "vite/client"]
     },

--- a/apps/engangsstonad/vite.config.ts
+++ b/apps/engangsstonad/vite.config.ts
@@ -31,6 +31,7 @@ export default mergeConfig(createSharedConfigWithCrossorgin(setupFileDirName), {
             styles: path.resolve(__dirname, './src/styles'),
             types: path.resolve(__dirname, './src/types/'),
             appData: path.resolve(__dirname, './src/app-data/'),
+            schemas: path.resolve(__dirname, './src/schemas/'),
         },
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
 
   apps/engangsstonad:
     dependencies:
+      '@hookform/resolvers':
+        specifier: 5.2.2
+        version: 5.2.2(react-hook-form@7.75.0(react@19.2.6))
       '@navikt/ds-css':
         specifier: 8.10.5
         version: 8.10.5
@@ -120,6 +123,9 @@ importers:
       react-router-dom:
         specifier: 7.15.0
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@formatjs/cli-lib':
         specifier: 8.6.0
@@ -3355,6 +3361,11 @@ packages:
       react-dom: '>=16.8.0'
       react-hook-form: ^7.0.0
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -4130,6 +4141,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-links@10.3.6':
     resolution: {integrity: sha512-tv9Xd68qRGBAvEubaxNo3FuFq4GwuMiBriD+gLGuFK0+/u3cnkuA264aoR1v6YCH3sT3er3+MBimuyKM3jLDxg==}
@@ -8100,6 +8114,11 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-hook-form: 7.75.0(react@19.2.6)
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.6))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.75.0(react@19.2.6)
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -8690,6 +8709,8 @@ snapshots:
       text-hex: 1.0.0
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-links@10.3.6(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:


### PR DESCRIPTION
Erstattar per-felt validate-prop frå @navikt/fp-validation med zod-skjema via @hookform/resolvers i app-eigde steg (søkersituasjon, om-barnet, dokumentasjon). Same skjema-laget gjenbrukar dato-predikat frå fp-validation gjennom superRefine.

Legg til engangsstønadDtoSchema som ekstra runtime-sjekk i useEsSendSøknad rett før POST — fangar mappingfeil og korrupt mellomlagra state. Flyttar òg minst-eitt-vedlegg-sjekken frå imperativ setError til skjemaet i DokumentasjonSteg.