### PR TITLE
Chore: Legg til haproxy-redirect for oversikt

### DIFF
--- a/.deploy/foreldrepengeoversikt/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/foreldrepengeoversikt/prod-gcp-teamforeldrepenger.json
@@ -16,6 +16,10 @@
         "host": "foreldrepenger.nav.no",
         "ingressClassName": "nais-ingress-external"
     },
+    "haproxyredirect": {
+        "host": "foreldrepenger.nav.no",
+        "ingressClassName": "external-haproxy"
+    },
     "env": {
         "ENV": "prod",
         "PUBLIC_PATH": "/foreldrepenger/oversikt",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -92,7 +92,32 @@ metadata:
   labels:
     team: teamforeldrepenger
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: {{../ingress}}/$1
+    nginx.ingress.kubernetes.io/permanent-redirect: {{../ingress}}/$1
+spec:
+  ingressClassName: {{ingressClassName}}
+  rules:
+    - host: {{host}}
+      http:
+        paths:
+          - path: "/(.*)"
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{app}}
+                port:
+                  number: 80
+{{/with}}
+{{#with haproxyredirect}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{../app}}-haproxy-redirect
+  namespace: teamforeldrepenger
+  labels:
+    team: teamforeldrepenger
+  annotations:
+    haproxy.org/request-redirect: "code 301 location {{../ingress}}/$1"
 spec:
   ingressClassName: {{ingressClassName}}
   rules:


### PR DESCRIPTION
Oppsett er basert på det vi har prodsatt for iac/familie-redirect (k get ingresses | grep redirect)
Bruker også permanent redirect for mer snappy opplevelse.
Vi har fjernet alle redirects i dev og de 3 søknadene i prod. Gjenstår nå foreldrepenger her og familie i iac.

I mitt sinn ser jeg for meg en at foreldrepenger-subdomain går til en dynamisk landingsside for effektiv navigering videre med pålogging, søknad, mer om. Slik vi gjorde for mellomlandingssiden i søknad - sendinn går til mellomlanding som går videre til oversikt