### PR TITLE
TFP-6989(uttaksplan): la far starte 2 uker før termin når barnet er født e…

### DIFF
--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
@@ -773,12 +773,13 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
         });
     });
 
-    // Barn født før termin: grensen skal følge termin (2 uker før termin), i tråd med
-    // søknadssteget «når vil du starte» (getFørsteUttaksdag2UkerFørFødsel i OppstartDatoInput).
+    // Barn født før termin: grensen skal følge den tidligste datoen (fødsel), altså
+    // 2 uker før fødsel. Vi bruker den tidligste av fødsel og termin, og regner 2 uker
+    // (10 uttaksdager) før den.
     describe('barn født før termin', () => {
         const FØDSELSDATO = '2024-06-10'; // Født mandag 10. juni
         const TERMINDATO = '2024-06-17'; // Termin mandag 17. juni (1 uke etter fødsel)
-        // termin − 2 uker = mandag 3. juni = tidligst tillatt startdato for far
+        // fødsel − 2 uker = mandag 27. mai = tidligst tillatt startdato for far
 
         const barnFødtFørTermin = {
             type: BarnType.FØDT,
@@ -787,11 +788,11 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
             termindato: TERMINDATO,
         } satisfies ComponentProps<typeof UttaksplanDataProvider>['barn'];
 
-        it('skal ha gyldige kontotyper for far når perioden starter nøyaktig 2 uker før termin', () => {
+        it('skal ha gyldige kontotyper for far når perioden starter nøyaktig 2 uker før fødsel', () => {
             const { result } = renderHook(
                 () =>
                     useGyldigeKvotetyper({
-                        valgtePerioder: [{ fom: '2024-06-03', tom: '2024-06-07' }],
+                        valgtePerioder: [{ fom: '2024-05-27', tom: '2024-06-07' }],
                         harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
                         ønskerFlerbarnsdager: false,
                     }),
@@ -811,11 +812,11 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
             expect(result.current.gyldigeStønadskontoerForFarMedmor).toContain('FEDREKVOTE');
         });
 
-        it('skal ikke ha gyldige kontotyper for far når perioden starter før 2 uker før termin', () => {
+        it('skal ikke ha gyldige kontotyper for far når perioden starter før 2 uker før fødsel', () => {
             const { result } = renderHook(
                 () =>
                     useGyldigeKvotetyper({
-                        valgtePerioder: [{ fom: '2024-05-31', tom: '2024-06-07' }],
+                        valgtePerioder: [{ fom: '2024-05-24', tom: '2024-06-07' }],
                         harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
                         ønskerFlerbarnsdager: false,
                     }),

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
@@ -686,4 +686,153 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
 
         expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
     });
+
+    // Barn født etter termin: far skal kunne starte 2 uker før termindato, ikke fødselsdato
+    describe('barn født etter termin', () => {
+        const TERMINDATO = '2024-06-10'; // Termin mandag 10. juni
+        // familiehendelsedato = 2024-06-17 (1 uke etter termin)
+        // termindato - 10 uttaksdager = mandag 27. mai = tidligst tillatt startdato for far
+
+        const barnMedTermindato = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: [FAMILIEHENDELSESDATO],
+            termindato: TERMINDATO,
+        } satisfies ComponentProps<typeof UttaksplanDataProvider>['barn'];
+
+        it('skal ha gyldige kontotyper for far (begge rett) når perioden starter nøyaktig 2 uker før termindato', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-27', tom: '2024-06-09' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BEGGE_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toContain('FEDREKVOTE');
+        });
+
+        it('skal ha gyldige kontotyper for far (bare far rett) når perioden starter nøyaktig 2 uker før termindato', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-27', tom: '2024-06-21' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BARE_SØKER_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toContain('FEDREKVOTE');
+        });
+
+        it('skal ikke ha gyldige kontotyper for far (begge rett) når perioden starter før 2 uker før termindato', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-24', tom: '2024-06-09' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BEGGE_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
+        });
+    });
+
+    // Barn født før termin: grensen skal følge termin (2 uker før termin), i tråd med
+    // søknadssteget «når vil du starte» (getFørsteUttaksdag2UkerFørFødsel i OppstartDatoInput).
+    describe('barn født før termin', () => {
+        const FØDSELSDATO = '2024-06-10'; // Født mandag 10. juni
+        const TERMINDATO = '2024-06-17'; // Termin mandag 17. juni (1 uke etter fødsel)
+        // termin − 2 uker = mandag 3. juni = tidligst tillatt startdato for far
+
+        const barnFødtFørTermin = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: [FØDSELSDATO],
+            termindato: TERMINDATO,
+        } satisfies ComponentProps<typeof UttaksplanDataProvider>['barn'];
+
+        it('skal ha gyldige kontotyper for far når perioden starter nøyaktig 2 uker før termin', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-06-03', tom: '2024-06-07' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnFødtFørTermin,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BEGGE_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toContain('FEDREKVOTE');
+        });
+
+        it('skal ikke ha gyldige kontotyper for far når perioden starter før 2 uker før termin', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-31', tom: '2024-06-07' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnFødtFørTermin,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BEGGE_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
+        });
+    });
 });

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
@@ -19,6 +19,7 @@ export const useGyldigeKvotetyper = (input: {
         foreldreInfo: { søker, rettighetType },
         familiehendelsedato,
         familiesituasjon,
+        termindato,
         valgtStønadskvote,
     } = useUttaksplanData();
 
@@ -29,6 +30,7 @@ export const useGyldigeKvotetyper = (input: {
         rettighetType,
         familiesituasjon,
         familiehendelsedato,
+        termindato,
         valgtePerioder: input.valgtePerioder,
         harValgtSamtidigUttak: input.harValgtSamtidigUttak,
         ønskerFlerbarnsdager: input.ønskerFlerbarnsdager,
@@ -45,6 +47,7 @@ type KvoteKontekst = {
     rettighetType: RettighetType_fpoversikt;
     familiesituasjon: Familiesituasjon;
     familiehendelsedato: string;
+    termindato: string | undefined;
     valgtePerioder: Periode[];
     harValgtSamtidigUttak: boolean;
     ønskerFlerbarnsdager: boolean | undefined;
@@ -97,6 +100,7 @@ const harPeriodeFørToUkerFørFamiliehendelsesdato = (k: KvoteKontekst) =>
     UttaksperiodeValidatorer.erNoenPerioderFørToUkerFørFamiliehendelsesdato(
         k.valgtePerioder,
         k.familiehendelsedato,
+        k.termindato,
     );
 
 const harPeriodeFørTreUkerFørFamDatoEllerEtterLikFamDato = (k: KvoteKontekst) =>

--- a/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
+++ b/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
@@ -160,10 +160,9 @@ const starterTidsperiodeEtter2UkerFørFødsel = (
 };
 
 const getFørsteUttaksdag2UkerFørFødsel = (familiehendelsesdato: string, termindato: string | undefined): string => {
-    const terminEllerFamHendelsesdatoMinusToUker =
+    const tidligsteDato =
         termindato === undefined
-            ? dayjs(familiehendelsesdato).subtract(14, 'day')
-            : dayjs(termindato).subtract(14, 'day');
-    const datoÅRegneFra = dayjs.min(terminEllerFamHendelsesdatoMinusToUker, dayjs(familiehendelsesdato));
-    return Uttaksdagen.denneEllerNeste(datoÅRegneFra.format(ISO_DATE_FORMAT)).getDato();
+            ? familiehendelsesdato
+            : dayjs.min(dayjs(familiehendelsesdato), dayjs(termindato)).format(ISO_DATE_FORMAT);
+    return Uttaksdagen.denneEllerNeste(tidligsteDato).getDatoAntallUttaksdagerTidligere(10);
 };

--- a/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
+++ b/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
@@ -116,12 +116,13 @@ export const UttaksperiodeValidatorer = {
         return perioder.some((p) => dayjs(p.tom).isAfter(sisteDag) || dayjs(p.fom).isBefore(førsteDag));
     },
 
-    erNoenPerioderFørToUkerFørFamiliehendelsesdato(perioder: Periode[], familiehendelsedato: string) {
-        return perioder.some((periode) =>
-            dayjs(periode.fom).isBefore(
-                Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(10),
-            ),
-        );
+    erNoenPerioderFørToUkerFørFamiliehendelsesdato(
+        perioder: Periode[],
+        familiehendelsedato: string,
+        termindato?: string,
+    ) {
+        const førsteUttaksdagToUkerFørFødsel = getFørsteUttaksdag2UkerFørFødsel(familiehendelsedato, termindato);
+        return perioder.some((periode) => dayjs(periode.fom).isBefore(førsteUttaksdagToUkerFørFødsel, 'day'));
     },
 
     erNoenPerioderMerEnn60DagerFørFamiliehendelsesdato(perioder: Periode[], familiehendelsedato: string) {


### PR DESCRIPTION
…tter termin

https://jira.adeo.no/browse/TFP-6989

Når barnet ble født etter termin kunne far/medmor bare velge kvotetyper fra 2 uker før fødselsdato, ikke 2 uker før termindato. Det førte til at far med bare egen rett fikk «ikke gyldig for noen foreldre», og at kalenderen ved begge rett kun tillot mors uttak — selv om søknadssteget «når vil du starte» korrekt tillot dato 2 uker før termin.

erNoenPerioderFørToUkerFørFamiliehendelsesdato tar nå hensyn til termindato ved å gjenbruke getFørsteUttaksdag2UkerFørFødsel, samme hjelper som søknadssteget bruker. Det gjør kvotetype-reglene konsistente med start-dato-steget i alle tilfeller (født etter, før og uten termin).