### PR TITLE
TFP-6323(uttaksplan): blokker 200 % samtidig uttak ved adopsjon med ett barn

### DIFF
--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
@@ -467,4 +467,40 @@ describe('useFormSubmitValidator', () => {
 
         expect(feilmelding).toBeNull();
     });
+
+    it('skal returnere feilmelding ved 200 % samtidig uttak ved adopsjon med kun ett barn', () => {
+        const { result } = renderHook(() => useFormSubmitValidator(), {
+            wrapper: getWrapper({
+                barn: {
+                    type: BarnType.ADOPTERT_STEBARN,
+                    antallBarn: 1,
+                    adopsjonsdato: FAMILIEHENDELSESDATO,
+                    fødselsdatoer: [FAMILIEHENDELSESDATO],
+                },
+            }),
+        });
+
+        const perioder = [
+            {
+                fom: FAMILIEHENDELSESDATO,
+                tom: Uttaksdagen.denne(FAMILIEHENDELSESDATO).getDatoAntallUttaksdagerSenere(10),
+            },
+        ];
+
+        const formValues = {
+            forelder: 'BEGGE',
+            kontoTypeMor: 'FELLESPERIODE',
+            kontoTypeFarMedmor: 'FELLESPERIODE',
+            ønskerFlerbarnsdager: false,
+            samtidigUttaksprosentMor: '100',
+            samtidigUttaksprosentFarMedmor: '100',
+            skalDuKombinereArbeidOgUttakMor: false,
+            skalDuKombinereArbeidOgUttakFarMedmor: false,
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const valider = result.current;
+        const feilmelding = valider(perioder, formValues);
+
+        expect(feilmelding).toBe('Dere kan ikke ha mer enn 150 % foreldrepenger til sammen');
+    });
 });

--- a/packages/uttaksplan/src/regler/validering/farMedmorRundtFødsel.ts
+++ b/packages/uttaksplan/src/regler/validering/farMedmorRundtFødsel.ts
@@ -11,7 +11,8 @@ export const lagFarMedmorRundtFødselOmråde = (intl: IntlShape): Valideringsomr
     område: 'Far/medmor sitt samtidige uttak rundt fødsel',
     beskrivelse:
         'Regler for samtidig uttak når minst én av periodene ligger i verneperioden rundt fødsel ' +
-        '(fra 2 uker før til 6 uker etter fødsel/termin). Her er kravene strengere enn ellers.',
+        '(fra 2 uker før til 6 uker etter fødsel/termin). Her er kravene strengere enn ellers. ' +
+        'Gjelder ikke ved adopsjon, som ikke har en verneperiode rundt fødsel.',
     byggKontekst: byggKontekst,
     regler: lagRegler(intl),
 });
@@ -83,9 +84,13 @@ const lagRegler = (intl: IntlShape): ReadonlyArray<Valideringsregel<FarMedmorRun
 ];
 
 const byggKontekst = (input: ValideringInput): FarMedmorRundtFødselKontekst | null => {
-    const { formValues, perioder, familiehendelsedato, termindato } = input;
+    const { formValues, perioder, familiehendelsedato, termindato, familiesituasjon } = input;
 
     if (!erUtfyltForSamtidigUttak(formValues)) {
+        return null;
+    }
+
+    if (familiesituasjon === 'adopsjon') {
         return null;
     }
 

--- a/packages/uttaksplan/src/regler/validering/samtidigUttak.ts
+++ b/packages/uttaksplan/src/regler/validering/samtidigUttak.ts
@@ -118,13 +118,14 @@ const lagRegler = (intl: IntlShape): ReadonlyArray<Valideringsregel<SamtidigUtta
 ];
 
 const byggSamtidigUttakKontekst = (input: ValideringInput): SamtidigUttakKontekst | null => {
-    const { formValues, perioder, familiehendelsedato, termindato } = input;
+    const { formValues, perioder, familiehendelsedato, termindato, familiesituasjon } = input;
 
     if (!erUtfyltForSamtidigUttak(formValues)) {
         return null;
     }
 
     const inneholderPerioderRundtFødsel =
+        familiesituasjon !== 'adopsjon' &&
         UttaksperiodeValidatorer.erNoenPerioderIMellomToUkerFørFamiliehendelsesdatoEllerEtterSeksUkerFamiliehendelsedato(
             perioder,
             familiehendelsedato,


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6323

Ved adopsjon finnes ingen verneperiode rundt fødsel, men valideringen behandlet perioder ved omsorgsovertakelse som om de lå i verneperioden. Det førte til at 200 % samtidig uttak (begge 100 %) slapp gjennom uten flerbarnsdager, i strid med reglene i ftrl. kap. 14 der 200 % kun er tillatt ved flere barn.

- samtidigUttak: behandler inneholderPerioderRundtFødsel som false ved adopsjon, slik at 150 %-taket (med flerbarnsdager-unntak) alltid gjelder
- farMedmorRundtFødsel: returnerer null ved adopsjon (ingen verneperiode)