### PR TITLE
fix(foreldrepengesoknad): unngå Step-krasj «Ingen valgte steg funnet» ved betinget stegsynlighet

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -38,52 +38,37 @@ const getPathToLabelMap = (intl: IntlShape) =>
         [SøknadRoutes.IKKE_MYNDIG]: '',
     }) satisfies Record<SøknadRoutes, string>;
 
-const isAfterStep = (previousStepPath: SøknadRoutes, currentStepPath: SøknadRoutes): boolean => {
-    return ROUTES_ORDER.indexOf(currentStepPath) > ROUTES_ORDER.indexOf(previousStepPath);
-};
-
 const showUtenlandsoppholdStep = (
     path: SøknadRoutes,
-    currentPath: SøknadRoutes,
     getData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
 ) => {
     if (path === SøknadRoutes.TIDLIGERE_UTENLANDSOPPHOLD) {
-        const erValgtOgEtterSteg =
-            getData(ContextDataType.UTENLANDSOPPHOLD)?.harBoddUtenforNorgeSiste12Mnd === true &&
-            isAfterStep(SøknadRoutes.UTENLANDSOPPHOLD, currentPath);
-        return erValgtOgEtterSteg || !!getData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
+        const erValgt = getData(ContextDataType.UTENLANDSOPPHOLD)?.harBoddUtenforNorgeSiste12Mnd === true;
+        return erValgt || !!getData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     }
     if (path === SøknadRoutes.SENERE_UTENLANDSOPPHOLD) {
-        const erValgtOgEtterSteg =
-            getData(ContextDataType.UTENLANDSOPPHOLD)?.skalBoUtenforNorgeNeste12Mnd === true &&
-            isAfterStep(SøknadRoutes.UTENLANDSOPPHOLD, currentPath);
-        return erValgtOgEtterSteg || !!getData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
+        const erValgt = getData(ContextDataType.UTENLANDSOPPHOLD)?.skalBoUtenforNorgeNeste12Mnd === true;
+        return erValgt || !!getData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
     }
     return false;
 };
 
 const showFrilansOgEgenNæringOgAndreInntekter = (
     path: SøknadRoutes,
-    currentPath: SøknadRoutes,
     getData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
 ) => {
     if (path === SøknadRoutes.FRILANS) {
-        const erValgtOgEtterSteg =
-            getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harJobbetSomFrilans === true &&
-            isAfterStep(SøknadRoutes.ARBEID_OG_INNTEKT, currentPath);
-        return erValgtOgEtterSteg || !!getData(ContextDataType.FRILANS);
+        const erValgt = getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harJobbetSomFrilans === true;
+        return erValgt || !!getData(ContextDataType.FRILANS);
     }
     if (path === SøknadRoutes.EGEN_NÆRING) {
-        const erValgtOgEtterSteg =
-            getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harJobbetSomSelvstendigNæringsdrivende === true &&
-            isAfterStep(SøknadRoutes.ARBEID_OG_INNTEKT, currentPath);
-        return erValgtOgEtterSteg || !!getData(ContextDataType.EGEN_NÆRING);
+        const erValgt =
+            getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harJobbetSomSelvstendigNæringsdrivende === true;
+        return erValgt || !!getData(ContextDataType.EGEN_NÆRING);
     }
     if (path === SøknadRoutes.ANDRE_INNTEKTER) {
-        const erValgtOgEtterSteg =
-            getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harHattAndreInntektskilder === true &&
-            isAfterStep(SøknadRoutes.ARBEID_OG_INNTEKT, currentPath);
-        return erValgtOgEtterSteg || !!getData(ContextDataType.ANDRE_INNTEKTSKILDER);
+        const erValgt = getData(ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT)?.harHattAndreInntektskilder === true;
+        return erValgt || !!getData(ContextDataType.ANDRE_INNTEKTSKILDER);
     }
     return false;
 };
@@ -194,13 +179,13 @@ export const useStepConfig = (
         () =>
             ROUTES_ORDER.flatMap((path) =>
                 (requiredSteps.includes(path) && skalViseFordelingSteg(path, getStateData)) ||
-                showUtenlandsoppholdStep(path, currentPath, getStateData) ||
+                showUtenlandsoppholdStep(path, getStateData) ||
                 showManglendeDokumentasjonSteg(path, getStateData, arbeidsforhold, eksisterendeSak) ||
-                showFrilansOgEgenNæringOgAndreInntekter(path, currentPath, getStateData)
+                showFrilansOgEgenNæringOgAndreInntekter(path, getStateData)
                     ? [path]
                     : [],
             ),
-        [requiredSteps, currentPath, getStateData, arbeidsforhold, erEndringssøknad, eksisterendeSak],
+        [requiredSteps, getStateData, arbeidsforhold, erEndringssøknad, eksisterendeSak],
     );
 
     return useMemo(


### PR DESCRIPTION
Forklaring for en 5-åring 🧸

Tenk deg en sti med hoppesteiner du hopper på, én etter én. 🪨🪨🪨
Én av steinene er en magisk stein. Den er bare der hvis du har sagt «ja, jeg vil ha den!»
Den gamle, dumme regelen 🙈
Før hadde den magiske steinen en rar regel:
 «Jeg er bare her hvis du har sagt ja OG du allerede har gått forbi meg.»
Men tenk om du snur deg og går tilbake og vil stå oppå den steinen igjen?
Da sier steinen: «Du har jo ikke gått forbi meg nå… så jeg forsvinner!» 💨
Og PLOPP — steinen blir borte mens du står på den, og du datt i vannet! 💦😱 (Det er det appen gjør når den «krasjer».)
Den nye, snille regelen ☀️
Nå sier steinen bare:
 «Har du sagt ja? Da er jeg her. Ferdig snakka!» 🪨💛
Den bryr seg ikke lenger om hvor du går. Den blir værende så lenge du har sagt ja.
Så nå kan du hoppe fram og tilbake så mye du vil — steinen forsvinner aldri under føttene dine. Du datt aldri i vannet igjen! 🎉

Aller kortest
Før: steinen gjemte seg når du kom tilbake → du datt. 💦 Nå: steinen står stille → du står trygt. 🧍✨



## Problem

`Step` kasta `Error: Ingen valgte steg funnet` (`packages/ui/src/step/page-step/Step.tsx`) når den aktive ruta var eit betinga steg som `useStepConfig` ekskluderte. Då blei ingen steg `isSelected`, og søknaden krasja — typisk ved bakovernavigasjon via stegvelgaren eller nettlesarens tilbakeknapp.

## Rotårsak

Synlegheita for betinga steg (frilans, egen næring, andre inntekter, tidlegare/seinare utenlandsopphald) avhang av `isAfterStep(..., currentPath)`. Det gjorde steglista **ikke-monoton**: eit steg kunne vere valt (`currentPath`) men samstundes filtrert bort fordi `isAfterStep` evaluerte ulikt avhengig av kva side ein stod på. Sidan kvar stegovergang er ein history-`push`, kunne ein lande på ein URL som ikkje lenger fanst i `stepConfig`.

## Endring

Fjernar `isAfterStep`-leddet. Eit betinga steg er no synleg dersom **svaret er valt** eller **det finst lagra data** for steget — uavhengig av gjeldande steg. Steglista blir då monoton, så eit steg ein står på finst alltid i lista.

## Sideeffektar

- Faktisk rutenavigasjon (Neste/Forrige) er **uendra** — portstega navigerer eksplisitt via `goToStep(...)`, ikkje via `stepConfig`-indeksering.
- Einaste synlege endring: betinga steg visast konsistent i stegteljaren/«Vis alle steg» så snart svaret er gitt (t.d. ved retur eller gjenoppteke søknad), i staden for å poppe inn/ut.
- Framoverhopp er framleis sperra (`index < currentStepIndex`).

## Test

- `pnpm tsc` ✅
- `eslint` på endra fil ✅
- `pnpm test` ✅ — 39 testfiler / 379 testar (inkl. `AppContainer.test.tsx`, `FrilansSteg.test.tsx`)

## Merk

Same mønster finst i `apps/engangsstonad/src/app-data/useStepConfig.ts` og har same latente feil — utanfor scope her.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>