### PR TITLE
fix(foreldrepengesoknad): hald URL og APP_ROUTE synkronisert

### DIFF
--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -7,7 +7,6 @@ import {
     useAnnenPartVedtakOptions,
 } from 'api/queries';
 import { ContextDataMap, ContextDataType, FpDataContext } from 'appData/FpDataContext';
-import { SøknadRoutes } from 'appData/routes';
 import { FpMellomlagretData } from 'appData/useMellomlagreSøknad';
 import { usePlanleggerDataFromUrl } from 'appData/usePlanleggerDataFromUrl';
 import ky from 'ky';
@@ -19,7 +18,6 @@ import { shouldApplyStorage } from 'utils/mellomlagringUtils';
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { ErrorBoundary, RegisterdataUtdatert, Spinner } from '@navikt/fp-ui';
 import { useDocumentTitle } from '@navikt/fp-utils';
-import { notEmpty } from '@navikt/fp-validation';
 
 import { ForeldrepengesøknadRoutes } from './ForeldrepengesøknadRoutes';
 
@@ -76,11 +74,6 @@ export const Foreldrepengesøknad = () => {
                     <ForeldrepengesøknadRoutes
                         søkerInfo={søkerinfoQuery.data}
                         foreldrepengerSaker={sakerQuery.data.foreldrepenger}
-                        currentRoute={
-                            skalBrukeMellomlagretData
-                                ? notEmpty(mellomlagretData?.[ContextDataType.APP_ROUTE])
-                                : SøknadRoutes.VELKOMMEN
-                        }
                         lagretErEndringssøknad={mellomlagretData?.erEndringssøknad ?? false}
                         lagretHarGodkjentVilkår={!!mellomlagretData?.[ContextDataType.APP_ROUTE]}
                         lagretSøknadGjelderNyttBarn={mellomlagretData?.søknadGjelderEtNyttBarn ?? false}

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -320,7 +320,8 @@ export const ForeldrepengesøknadRoutes = ({
 
         const currentPath = decodeURIComponent(routerLocation.pathname);
 
-        if (currentPath === SøknadRoutes.KVITTERING || currentPath === SøknadRoutes.IKKE_MYNDIG) {
+        const ignoredPaths = [SøknadRoutes.KVITTERING, SøknadRoutes.IKKE_MYNDIG].map((path) => path.toString());
+        if (ignoredPaths.includes(currentPath)) {
             return;
         }
 

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -319,9 +319,8 @@ export const ForeldrepengesøknadRoutes = ({
         }
 
         const currentPath = decodeURIComponent(routerLocation.pathname);
-        const alltidTillatne: string[] = [SøknadRoutes.KVITTERING, SøknadRoutes.IKKE_MYNDIG];
 
-        if (alltidTillatne.includes(currentPath)) {
+        if (currentPath === SøknadRoutes.KVITTERING || currentPath === SøknadRoutes.IKKE_MYNDIG) {
             return;
         }
 

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions } from 'api/queries';
-import { SøknadRoutes, isRouteAvailable } from 'appData/routes';
+import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
+import { SøknadRoutes } from 'appData/routes';
 import { useAvbrytSøknad } from 'appData/useAvbrytSøknad';
 import { useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
 import { useSendSøknad } from 'appData/useSendSøknad';
 import { Forside } from 'pages/forside/Forside';
 import { KvitteringPage } from 'pages/kvittering/KvitteringPage';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AndreInntektskilderSteg } from 'steps/andre-inntektskilder/AndreInntektskilderSteg';
 import { AnnenForelderSteg } from 'steps/annen-forelder/AnnenForelderSteg';
@@ -267,7 +268,6 @@ const renderSøknadRoutes = ({
 };
 
 interface Props {
-    currentRoute: SøknadRoutes;
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     foreldrepengerSaker: FpSak_fpoversikt[];
     lagretErEndringssøknad?: boolean;
@@ -276,7 +276,6 @@ interface Props {
 }
 
 export const ForeldrepengesøknadRoutes = ({
-    currentRoute,
     søkerInfo,
     foreldrepengerSaker,
     lagretErEndringssøknad,
@@ -285,7 +284,6 @@ export const ForeldrepengesøknadRoutes = ({
 }: Props) => {
     const navigate = useNavigate();
     const routerLocation = useLocation();
-    const isFirstTimeLoadingAppRef = useRef(true);
 
     const [harGodkjentVilkår, setHarGodkjentVilkår] = useState(lagretHarGodkjentVilkår || false);
     const [erEndringssøknad, setErEndringssøknad] = useState(lagretErEndringssøknad || false);
@@ -307,21 +305,30 @@ export const ForeldrepengesøknadRoutes = ({
     const annenPartVedtakOptions = useAnnenPartVedtakOptions();
     useQuery(annenPartVedtakOptions);
 
+    // APP_ROUTE er einaste sanning for kva steg brukaren er på, og blir alltid
+    // halden gyldig av stegnavigasjonen (data for steget finst når APP_ROUTE peikar
+    // dit). Endrar nettlesarens tilbake/fram-knapp URL-en til eit anna steg,
+    // snappar vi tilbake til APP_ROUTE slik at vi aldri monterer eit steg utan dei
+    // påkravde dataene. Stegvelgar og «Tilbake»-knappar navigerer via APP_ROUTE og
+    // held difor URL-en i synk.
+    const appRoute = useContextGetData(ContextDataType.APP_ROUTE);
+
     useEffect(() => {
-        if (
-            currentRoute &&
-            erMyndig(søkerInfo.fødselsdato) &&
-            lagretHarGodkjentVilkår &&
-            isFirstTimeLoadingAppRef.current
-        ) {
-            isFirstTimeLoadingAppRef.current = false;
-            if (isRouteAvailable(currentRoute, lagretHarGodkjentVilkår)) {
-                void navigate(currentRoute);
-            } else if (routerLocation.pathname === SøknadRoutes.OPPSUMMERING.toString()) {
-                void navigate(SøknadRoutes.UTTAKSPLAN);
-            }
+        if (!appRoute || !harGodkjentVilkår || !erMyndig(søkerInfo.fødselsdato)) {
+            return;
         }
-    }, [currentRoute, søkerInfo.fødselsdato, lagretHarGodkjentVilkår, navigate, routerLocation.pathname]);
+
+        const currentPath = decodeURIComponent(routerLocation.pathname);
+        const alltidTillatne: string[] = [SøknadRoutes.KVITTERING, SøknadRoutes.IKKE_MYNDIG];
+
+        if (alltidTillatne.includes(currentPath)) {
+            return;
+        }
+
+        if (currentPath !== appRoute.toString()) {
+            void navigate(appRoute, { replace: true });
+        }
+    }, [appRoute, harGodkjentVilkår, søkerInfo.fødselsdato, routerLocation.pathname, navigate]);
 
     if (errorSendSøknad) {
         return (


### PR DESCRIPTION
----
Tor sin kommentar: Dette er eit forsøk på å fiksa "Data er ikke oppgitt"-feila i Sentry. Etter analyse så ser det ut til at dette skjer via bruk av knapp fram/tilbake i nettlesaren, og ikkje via navigering i app. Derfor er det lagt til ein sjekk som stoppar navigering via browser-knappane
----

## Problem

Steg vart monterte ut frå **URL-en** (React Router), mens dei påkravde dataene ligg i ein in-memory-kontekst (`FpDataContext`). Nettlesarens tilbake/fram-knapp endrar URL-en uavhengig av `APP_ROUTE`, så ein kunne lande på eit forelda, djupt steg utan dataene det krev — t.d. etter at `resetUttaksplanData` har nullstilt `UTTAKSPLAN` når brukaren går tilbake og endrar eit tidlegare steg. Resultatet var krasj på `notEmpty(...)` → `Error: Data er ikke oppgitt` (Sentry).

Dette vart meir eksponert etter #5565 (bakovernavigasjon via stegvelgaren).

## Løysing

`APP_ROUTE` er einaste sanning for kva steg brukaren er på, og blir alltid halden gyldig av stegnavigasjonen. Eingongs-restaureringa (`isFirstTimeLoadingAppRef`) er bytt ut med ein **kontinuerleg vakt** som held URL-en i synk med `APP_ROUTE`:

- Stegvelgar og «Tilbake»-knappar går via `goToStep`/`goToNextStep` → oppdaterer `APP_ROUTE` → URL følgjer. Uendra oppførsel.
- Nettlesarens tilbake/fram-knapp endrar berre URL → vakta snappar tilbake til gjeldande steg (`APP_ROUTE`), så eit steg aldri monterast på ein forelda URL utan dataene.
- `KVITTERING` og `IKKE_MYNDIG` er unntatt; `replace: true` hindrar redirect-loop.

## Endringar

- `ForeldrepengesøknadRoutes.tsx`: kontinuerleg synk-vakt som les levande `APP_ROUTE` frå konteksten.
- `Foreldrepengesøknad.tsx`: fjerna `currentRoute`-propen (+ ubrukte importar).

## Testing

- `tsc` ✓
- `eslint` ✓ (0 errors)
- jsdom-testsuiten: 379 testar ✓, inkl. navigasjonstestane i `AppContainer.test.tsx`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>