### PR TITLE
TFP-6920: korriger til-dato i fordelingsslider ved fødsel før termin

### DIFF
--- a/apps/planlegger/src/utils/uttakUtils.test.ts
+++ b/apps/planlegger/src/utils/uttakUtils.test.ts
@@ -1,0 +1,121 @@
+import { KontoBeregningDto, KontoDto } from '@navikt/fp-types';
+import { Uttaksdagen } from '@navikt/fp-utils';
+import { deltUttak } from '@navikt/fp-uttaksplan';
+
+import { HvemPlanlegger, HvemPlanleggerType } from '../types/HvemPlanlegger';
+import { finnUttaksdata } from './uttakUtils';
+
+const lagStønadskvote = (kontoer: KontoDto[]): KontoBeregningDto => ({
+    kontoer,
+    minsteretter: { farRundtFødsel: 0, toTette: 0 },
+});
+
+const KONTOER: KontoDto[] = [
+    { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+    { konto: 'MØDREKVOTE', dager: 75 },
+    { konto: 'FELLESPERIODE', dager: 80 },
+    { konto: 'FEDREKVOTE', dager: 75 },
+];
+
+const morOgFar: HvemPlanlegger = {
+    type: HvemPlanleggerType.MOR_OG_FAR,
+    navnPåMor: 'Klara',
+    navnPåFar: 'Espen',
+};
+
+const FELLESPERIODE_DAGER_MOR = 40;
+
+describe('finnUttaksdata - delt uttak, fødsel', () => {
+    it('skal gi samme datoer i fordelingssliderens visning som i uttaksplanen (deltUttak) når barnet er født før termin', () => {
+        const fødselsdato = '2026-04-01';
+        const barnet = {
+            erFødsel: true,
+            erBarnetFødt: true,
+            antallBarn: '1',
+            fødselsdato,
+            termindato: '2026-04-23',
+        };
+
+        const uttaksdata = finnUttaksdata(
+            'beggeHarRett',
+            morOgFar,
+            lagStønadskvote(KONTOER),
+            barnet,
+            FELLESPERIODE_DAGER_MOR,
+        );
+
+        const uttaksplan = deltUttak({
+            famDato: fødselsdato,
+            tilgjengeligeStønadskvoter: KONTOER,
+            fellesperiodeDagerMor: FELLESPERIODE_DAGER_MOR,
+        });
+
+        const morsPerioder = uttaksplan.filter((p) => p.forelder === 'MOR');
+        const farsPerioder = uttaksplan.filter((p) => p.forelder === 'FAR_MEDMOR');
+
+        const morFørstePeriode = morsPerioder[0]!;
+        const morSistePeriode = morsPerioder[morsPerioder.length - 1]!;
+        const farFørstePeriode = farsPerioder[0]!;
+        const farSistePeriode = farsPerioder[farsPerioder.length - 1]!;
+
+        expect(uttaksdata.startdatoPeriode1).toEqual(morFørstePeriode.fom);
+        expect(uttaksdata.sluttdatoPeriode1).toEqual(morSistePeriode.tom);
+        expect(uttaksdata.startdatoPeriode2).toEqual(farFørstePeriode.fom);
+        expect(uttaksdata.sluttdatoPeriode2).toEqual(farSistePeriode.tom);
+    });
+
+    it('skal legge foreldrepenger før fødsel 3 uker før fødsel selv om barnet er født mer enn 3 uker før termin', () => {
+        const fødselsdato = '2026-04-01';
+        const barnet = {
+            erFødsel: true,
+            erBarnetFødt: true,
+            antallBarn: '1',
+            fødselsdato,
+            termindato: '2026-04-23',
+        };
+
+        const uttaksdata = finnUttaksdata(
+            'beggeHarRett',
+            morOgFar,
+            lagStønadskvote(KONTOER),
+            barnet,
+            FELLESPERIODE_DAGER_MOR,
+        );
+
+        const forventetStart = Uttaksdagen.denne(fødselsdato).getDatoAntallUttaksdagerTidligere(15);
+        expect(uttaksdata.startdatoPeriode1).toEqual(forventetStart);
+    });
+
+    it('skal gi samme datoer som uttaksplanen når fødsel og termin er samme dato', () => {
+        const fødselsdato = '2026-04-23';
+        const barnet = {
+            erFødsel: true,
+            erBarnetFødt: true,
+            antallBarn: '1',
+            fødselsdato,
+            termindato: '2026-04-23',
+        };
+
+        const uttaksdata = finnUttaksdata(
+            'beggeHarRett',
+            morOgFar,
+            lagStønadskvote(KONTOER),
+            barnet,
+            FELLESPERIODE_DAGER_MOR,
+        );
+
+        const uttaksplan = deltUttak({
+            famDato: fødselsdato,
+            tilgjengeligeStønadskvoter: KONTOER,
+            fellesperiodeDagerMor: FELLESPERIODE_DAGER_MOR,
+        });
+
+        const morsPerioder = uttaksplan.filter((p) => p.forelder === 'MOR');
+        const farsPerioder = uttaksplan.filter((p) => p.forelder === 'FAR_MEDMOR');
+
+        expect(uttaksdata.startdatoPeriode1).toEqual(morsPerioder[0]!.fom);
+        expect(uttaksdata.sluttdatoPeriode1).toEqual(morsPerioder[morsPerioder.length - 1]!.tom);
+        expect(uttaksdata.startdatoPeriode2).toEqual(farsPerioder[0]!.fom);
+        expect(uttaksdata.sluttdatoPeriode2).toEqual(farsPerioder[farsPerioder.length - 1]!.tom);
+    });
+});

--- a/apps/planlegger/src/utils/uttakUtils.test.ts
+++ b/apps/planlegger/src/utils/uttakUtils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { KontoBeregningDto, KontoDto } from '@navikt/fp-types';
 import { Uttaksdagen } from '@navikt/fp-utils';
 import { deltUttak } from '@navikt/fp-uttaksplan';

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -126,13 +126,13 @@ const getFørsteUttaksdagForeldrepengerFørFødsel = (barnet: OmBarnetPlanlegger
 };
 
 /**
- * Første uttaksdag med foreldrepenger før fødsel for delt uttak, lagt 3 uker (15 uttaksdager)
- * før familiehendelsedatoen. I motsetning til {@link getFørsteUttaksdagForeldrepengerFørFødsel}
- * har denne ingen spesialhåndtering når barnet er født mer enn 3 uker før termin. Dette samsvarer
- * med hvordan selve uttaksplanen (`deltUttak`) plasserer foreldrepenger-før-fødsel-perioden, slik
- * at fordelingssliderens datoer blir like kalender- og listevisningen.
+ * Første uttaksdag med foreldrepenger før fødsel, lagt 3 uker (15 uttaksdager) før
+ * familiehendelsedatoen. I motsetning til {@link getFørsteUttaksdagForeldrepengerFørFødsel} har
+ * denne ingen spesialhåndtering når barnet er født mer enn 3 uker før termin. Dette samsvarer med
+ * hvordan selve uttaksplanen (`deltUttak`) plasserer foreldrepenger-før-fødsel-perioden, slik at
+ * fordelingssliderens datoer blir like kalender- og listevisningen.
  */
-const getFørsteUttaksdagForeldrepengerFørFødselDeltUttak = (familiehendelsedato: string): string => {
+const getStartdatoForeldrepengerFørFødsel = (familiehendelsedato: string): string => {
     return trekkUttaksdagerFraDato(
         getUttaksdagFraOgMedDato(familiehendelsedato),
         ANTALL_UKER_FORELDREPENGER_FØR_FØDSEL * 5,
@@ -168,7 +168,7 @@ const finnDeltUttaksdata = (
     const startdatoPeriode1 =
         erBarnetAdoptert(barnet) || hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR
             ? getUttaksdagFraOgMedDato(getUttaksdagFraOgMedDato(familiehendelsedato))
-            : getFørsteUttaksdagForeldrepengerFørFødselDeltUttak(familiehendelsedato);
+            : getStartdatoForeldrepengerFørFødsel(familiehendelsedato);
 
     const sluttdatoPeriode1 =
         hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -125,6 +125,20 @@ const getFørsteUttaksdagForeldrepengerFørFødsel = (barnet: OmBarnetPlanlegger
     );
 };
 
+/**
+ * Første uttaksdag med foreldrepenger før fødsel for delt uttak, lagt 3 uker (15 uttaksdager)
+ * før familiehendelsedatoen. I motsetning til {@link getFørsteUttaksdagForeldrepengerFørFødsel}
+ * har denne ingen spesialhåndtering når barnet er født mer enn 3 uker før termin. Dette samsvarer
+ * med hvordan selve uttaksplanen (`deltUttak`) plasserer foreldrepenger-før-fødsel-perioden, slik
+ * at fordelingssliderens datoer blir like kalender- og listevisningen.
+ */
+const getFørsteUttaksdagForeldrepengerFørFødselDeltUttak = (familiehendelsedato: string): string => {
+    return trekkUttaksdagerFraDato(
+        getUttaksdagFraOgMedDato(familiehendelsedato),
+        ANTALL_UKER_FORELDREPENGER_FØR_FØDSEL * 5,
+    );
+};
+
 export type Uttaksdata = {
     familiehendelsedato: string;
     startdatoPeriode1: string;
@@ -154,7 +168,7 @@ const finnDeltUttaksdata = (
     const startdatoPeriode1 =
         erBarnetAdoptert(barnet) || hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR
             ? getUttaksdagFraOgMedDato(getUttaksdagFraOgMedDato(familiehendelsedato))
-            : getFørsteUttaksdagForeldrepengerFørFødsel(barnet);
+            : getFørsteUttaksdagForeldrepengerFørFødselDeltUttak(familiehendelsedato);
 
     const sluttdatoPeriode1 =
         hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6920

## Problem
I fordelingssteget (planlegger) viste sliderens datovisning feil til-dato for mor – og dermed feil fra-dato for far – når barnet var født mer enn 3 uker før termin. Kalender- og listevisning var korrekte.

Eksempel som ga feil: barn født 01.04.2026, termin 23.04.2026. Når fødsel og termin er samme dato ble resultatet korrekt.

## Årsak
Sliderens datoer beregnes av `finnDeltUttaksdata` i `uttakUtils.ts`, mens kalender/liste bygges av `deltUttak`. `deltUttak` legger alltid foreldrepenger-før-fødsel (FPFF) 15 uttaksdager før fødsel. Men `finnDeltUttaksdata` brukte et spesialtilfelle som satte startdatoen til selve fødselsdatoen ved tidlig fødsel, samtidig som sluttdatoberegningen likevel alltid la til 15 FPFF-dager. Dermed ble mors periode 15 uttaksdager for lang.

## Løsning
Legger FPFF alltid 3 uker før familiehendelsedatoen i delt uttak (ny hjelpefunksjon `getFørsteUttaksdagForeldrepengerFørFødselDeltUttak`), slik at sliderens datoer samsvarer med kalender- og listevisning. Enslig-beregningen er uendret.

## Test
- Ny `uttakUtils.test.ts` som verifiserer at sliderens datoer (`finnUttaksdata`) er identiske med uttaksplanens (`deltUttak`) ved tidlig fødsel og ved fødsel = termin.
- Alle 158 planlegger-tester, `tsc` og eslint kjører grønt.