### PR TITLE
TFP-6528(uttaksplan): strekk panelbakgrunn til bunnen på iOS 26

### DIFF
--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.tsx
@@ -250,8 +250,9 @@ export const UttaksplanKalender = ({ readOnly, barnehagestartdato, scrollToKvote
                         <div
                             className={[
                                 'fixed right-0 bottom-0 left-0 z-40 w-full',
+                                'bg-ax-bg-default ax-md:bg-transparent',
                                 'ax-md:sticky ax-md:top-24 ax-md:ml-4 ax-md:max-w-82 ax-md:self-start',
-                                'pb-[env(safe-area-inset-bottom,1rem)]',
+                                'pb-[env(safe-area-inset-bottom,1rem)] ax-md:pb-0',
                             ].join(' ')}
                         >
                             <RedigerKalenderIndex


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6528

Det sticky panelet nedst i kalenderen hadde bakgrunnsfargen på den indre Box-en, mens den fixed wrapperen var transparent. Padding-bottom for safe-area-inset gjorde at kalenderen synte gjennom Safari sin gjennomsiktige adresselinje på iOS 26. Gir wrapperen ugjennomsiktig bakgrunn på mobil slik at safe-area-sona blir fylt.