### PR TITLE
TFP-6170(uttaksplan): unngå at kalendermånader blir delt over PDF-sider

### DIFF
--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -28,11 +28,12 @@
         "@navikt/fp-utils": "workspace:*",
         "@navikt/fp-validation": "workspace:*",
         "dayjs": "1.11.20",
+        "html2canvas": "1.4.1",
+        "jspdf": "4.2.1",
         "lodash": "4.18.1",
         "react": "19.2.6",
         "react-hook-form": "7.75.0",
-        "react-intl": "10.1.6",
-        "react-to-pdf": "3.2.2"
+        "react-intl": "10.1.6"
     },
     "devDependencies": {
         "@navikt/ds-tailwind": "8.10.5",

--- a/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
+++ b/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
@@ -1,13 +1,13 @@
 import { DownloadIcon } from '@navikt/aksel-icons';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Margin, Options, Resolution, usePDF } from 'react-to-pdf';
 
 import { Button, Dialog, HStack, Radio, RadioGroup, VStack } from '@navikt/ds-react';
 
 import { Calendar, CalendarPeriod } from '@navikt/fp-ui';
 
 import { UttaksplanLegend } from '../legend/UttaksplanLegend';
+import { genererKalenderPdf } from './genererKalenderPdf';
 
 interface Props {
     perioderForKalendervisning: CalendarPeriod[];
@@ -27,25 +27,32 @@ export const KalenderPdf = ({
     const [isCreatingPdf, setIsCreatingPdf] = useState(false);
     const [antallKolonner, setAntallKolonner] = useState<1 | 2 | 3>(2);
 
-    const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const legendRef = useRef<HTMLDivElement>(null);
+    const kalenderRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        return () => clearTimeout(timeoutRef.current);
-    }, []);
+    const lastNedPdf = async () => {
+        const legendElement = legendRef.current;
+        const kalenderElement = kalenderRef.current;
+        if (!legendElement || !kalenderElement) {
+            return;
+        }
 
-    const pdfOptions = {
-        filename: 'Min foreldrepengeplan.pdf',
-        resolution: Resolution.NORMAL,
-        page: {
-            margin: Margin.MEDIUM,
-        },
-        overrides: {
-            canvas: {
-                windowWidth: 1200,
-            },
-        },
-    } satisfies Options;
-    const { toPDF, targetRef } = usePDF(pdfOptions);
+        setIsCreatingPdf(true);
+        try {
+            const månedElementer = Array.from(
+                kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'),
+            );
+
+            await genererKalenderPdf({
+                legendElement,
+                månedElementer,
+                antallKolonner,
+                filename: 'Min foreldrepengeplan.pdf',
+            });
+        } finally {
+            setIsCreatingPdf(false);
+        }
+    };
 
     return (
         <Dialog>
@@ -80,16 +87,7 @@ export const KalenderPdf = ({
                                     variant="primary"
                                     icon={<DownloadIcon aria-hidden />}
                                     loading={isCreatingPdf}
-                                    onClick={() => {
-                                        setIsCreatingPdf(true);
-
-                                        toPDF();
-
-                                        // Kun for visuell feedback til bruker
-                                        timeoutRef.current = setTimeout(() => {
-                                            setIsCreatingPdf(false);
-                                        }, 500);
-                                    }}
+                                    onClick={() => void lastNedPdf()}
                                     type="button"
                                 >
                                     <FormattedMessage id="kalender.lastNed" />
@@ -101,18 +99,22 @@ export const KalenderPdf = ({
                                 </Dialog.CloseTrigger>
                             </HStack>
                         </VStack>
-                        <VStack gap="space-24" ref={targetRef}>
-                            <UttaksplanLegend
-                                perioderForKalendervisning={perioderForKalendervisning}
-                                readOnly
-                                barnehagestartdato={barnehagestartdato}
-                            />
-                            <Calendar
-                                periods={perioderForKalendervisning}
-                                nrOfColumns={antallKolonner}
-                                firstDateInCalendar={førsteDatoIKalender}
-                                lastDateInCalendar={sisteDatoIKalender}
-                            />
+                        <VStack gap="space-24">
+                            <div ref={legendRef}>
+                                <UttaksplanLegend
+                                    perioderForKalendervisning={perioderForKalendervisning}
+                                    readOnly
+                                    barnehagestartdato={barnehagestartdato}
+                                />
+                            </div>
+                            <div ref={kalenderRef}>
+                                <Calendar
+                                    periods={perioderForKalendervisning}
+                                    nrOfColumns={antallKolonner}
+                                    firstDateInCalendar={førsteDatoIKalender}
+                                    lastDateInCalendar={sisteDatoIKalender}
+                                />
+                            </div>
                         </VStack>
                     </VStack>
                 </Dialog.Body>

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -13,6 +13,11 @@ const RAD_GAP_MM = 4;
 const SKALA = 1.5;
 const JPEG_KVALITET = 0.7;
 
+// Tvinga «desktop»-breidde slik at PDF-en blir deterministisk og uavhengig av
+// brukarens viewport. Utan dette ville Calendar sin responsive breakpoint
+// (columns={{ sm: 1, md: ... }}) gitt ulik layout på små skjermar.
+const RENDER_BREDDE_PX = 1200;
+
 interface GenererKalenderPdfParams {
     legendElement: HTMLElement;
     månedElementer: HTMLElement[];
@@ -26,6 +31,7 @@ const fangElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
         useCORS: true,
         logging: false,
         backgroundColor: '#ffffff',
+        windowWidth: RENDER_BREDDE_PX,
     });
 
 const høgdeForBredde = (canvas: HTMLCanvasElement, bredde: number): number =>
@@ -70,13 +76,17 @@ export const genererKalenderPdf = async ({
     leggTilBilete(legendCanvas, MARGIN_MM, y, tilgjengeligBredde);
     y += høgdeForBredde(legendCanvas, tilgjengeligBredde) + RAD_GAP_MM;
 
-    const månedCanvaser = await Promise.all(månedElementer.map(fangElement));
-
     const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
 
-    for (let i = 0; i < månedCanvaser.length; i += antallKolonner) {
-        const rad = månedCanvaser.slice(i, i + antallKolonner);
-        const radHøgde = Math.max(...rad.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
+    // Fang ein rad (maks `antallKolonner` månadar) om gongen i staden for alle
+    // samtidig. Kalenderen kan vere opptil 3 år (≈36 månadar), så å halde alle
+    // canvasane i minnet samstundes ville gitt unødvendig høgt minnebruk. Når vi
+    // går vidare til neste rad kan dei føregåande canvasane bli GC-a.
+    for (let i = 0; i < månedElementer.length; i += antallKolonner) {
+        const radElementer = månedElementer.slice(i, i + antallKolonner);
+        const radCanvaser = await Promise.all(radElementer.map(fangElement));
+
+        const radHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
 
         // Start ny side dersom heile raden ikkje får plass på resten av sida.
         if (y + radHøgde > sideBunn) {
@@ -84,7 +94,7 @@ export const genererKalenderPdf = async ({
             y = MARGIN_MM;
         }
 
-        rad.forEach((canvas, kolonne) => {
+        radCanvaser.forEach((canvas, kolonne) => {
             const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
             leggTilBilete(canvas, x, y, kolonneBredde);
         });

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -25,7 +25,7 @@ interface GenererKalenderPdfParams {
     filename: string;
 }
 
-const fangElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
+const lagBildeAvElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
     html2canvas(element, {
         scale: SKALA,
         useCORS: true,
@@ -72,7 +72,7 @@ export const genererKalenderPdf = async ({
     };
 
     // Forklaringa (legend) øvst på første side.
-    const legendCanvas = await fangElement(legendElement);
+    const legendCanvas = await lagBildeAvElement(legendElement);
     leggTilBilete(legendCanvas, MARGIN_MM, y, tilgjengeligBredde);
     y += høgdeForBredde(legendCanvas, tilgjengeligBredde) + RAD_GAP_MM;
 
@@ -84,7 +84,7 @@ export const genererKalenderPdf = async ({
     // går vidare til neste rad kan dei føregåande canvasane bli GC-a.
     for (let i = 0; i < månedElementer.length; i += antallKolonner) {
         const radElementer = månedElementer.slice(i, i + antallKolonner);
-        const radCanvaser = await Promise.all(radElementer.map(fangElement));
+        const radCanvaser = await Promise.all(radElementer.map(lagBildeAvElement));
 
         const radHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
 

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -1,0 +1,96 @@
+import html2canvas from 'html2canvas';
+import { jsPDF } from 'jspdf';
+
+const A4_BREDDE_MM = 210;
+const A4_HØGDE_MM = 297;
+const MARGIN_MM = 10;
+const KOLONNE_GAP_MM = 4;
+const RAD_GAP_MM = 4;
+
+// Lågare skala + JPEG-komprimering held filstorleik og genereringstid nede.
+// Kalenderen er reint vektor-/tekstinnhald på kvit botn, så ein moderat skala og
+// JPEG-kvalitet gjev framleis skarp nok tekst.
+const SKALA = 1.5;
+const JPEG_KVALITET = 0.7;
+
+interface GenererKalenderPdfParams {
+    legendElement: HTMLElement;
+    månedElementer: HTMLElement[];
+    antallKolonner: 1 | 2 | 3;
+    filename: string;
+}
+
+const fangElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
+    html2canvas(element, {
+        scale: SKALA,
+        useCORS: true,
+        logging: false,
+        backgroundColor: '#ffffff',
+    });
+
+const høgdeForBredde = (canvas: HTMLCanvasElement, bredde: number): number =>
+    (bredde * canvas.height) / canvas.width;
+
+/**
+ * Genererer ein PDF av uttaksplan-kalenderen der kvar månad blir teikna som eit
+ * eige bilete og plassert slik at ein månad aldri blir delt over to sider.
+ *
+ * react-to-pdf (og liknande verktøy) rasteriserer heile kalenderen til eitt høgt
+ * lerret og klypper det opp i faste sidehøgder utan å ta omsyn til kvar månadane
+ * startar og sluttar. Då kan ein månad bli kutta i to over eit sideskift. Her
+ * fangar vi difor kvar månad for seg og paginerer manuelt slik at ein heil månad
+ * alltid hamnar på éi side.
+ */
+export const genererKalenderPdf = async ({
+    legendElement,
+    månedElementer,
+    antallKolonner,
+    filename,
+}: GenererKalenderPdfParams): Promise<void> => {
+    const pdf = new jsPDF({ unit: 'mm', format: 'a4', orientation: 'portrait' });
+
+    const tilgjengeligBredde = A4_BREDDE_MM - 2 * MARGIN_MM;
+    const sideBunn = A4_HØGDE_MM - MARGIN_MM;
+
+    let y = MARGIN_MM;
+
+    const leggTilBilete = (canvas: HTMLCanvasElement, x: number, øvst: number, bredde: number): void => {
+        pdf.addImage(
+            canvas.toDataURL('image/jpeg', JPEG_KVALITET),
+            'JPEG',
+            x,
+            øvst,
+            bredde,
+            høgdeForBredde(canvas, bredde),
+        );
+    };
+
+    // Forklaringa (legend) øvst på første side.
+    const legendCanvas = await fangElement(legendElement);
+    leggTilBilete(legendCanvas, MARGIN_MM, y, tilgjengeligBredde);
+    y += høgdeForBredde(legendCanvas, tilgjengeligBredde) + RAD_GAP_MM;
+
+    const månedCanvaser = await Promise.all(månedElementer.map(fangElement));
+
+    const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
+
+    for (let i = 0; i < månedCanvaser.length; i += antallKolonner) {
+        const rad = månedCanvaser.slice(i, i + antallKolonner);
+        const radHøgde = Math.max(...rad.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
+
+        // Start ny side dersom heile raden ikkje får plass på resten av sida.
+        if (y + radHøgde > sideBunn) {
+            pdf.addPage('a4', 'portrait');
+            y = MARGIN_MM;
+        }
+
+        rad.forEach((canvas, kolonne) => {
+            const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
+            leggTilBilete(canvas, x, y, kolonneBredde);
+        });
+
+        y += radHøgde + RAD_GAP_MM;
+    }
+
+    await pdf.save(filename, { returnPromise: true });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2447,6 +2447,12 @@ importers:
       dayjs:
         specifier: 1.11.20
         version: 1.11.20
+      html2canvas:
+        specifier: 1.4.1
+        version: 1.4.1
+      jspdf:
+        specifier: 4.2.1
+        version: 4.2.1
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -2459,9 +2465,6 @@ importers:
       react-intl:
         specifier: 10.1.6
         version: 10.1.6(@types/react@19.2.14)(react@19.2.6)
-      react-to-pdf:
-        specifier: 3.2.2
-        version: 3.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@navikt/ds-tailwind':
         specifier: 8.10.5
@@ -6641,12 +6644,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-to-pdf@3.2.2:
-    resolution: {integrity: sha512-luw/VFzctbJrQ9XvUtOSM2DyMFGPsnrhnivV5Heq5TISNQwf7dqjoQp8/k+XLBlYm/AVak8HDYJfX6OejBMH6g==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -11438,13 +11435,6 @@ snapshots:
       react: 19.2.6
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.6(react@19.2.6)
-
-  react-to-pdf@3.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      html2canvas: 1.4.1
-      jspdf: 4.2.1
-      react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
   react@19.2.6: {}


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6170

Erstatta react-to-pdf med eigen pagineringslogikk basert på html2canvas og jspdf. react-to-pdf rasteriserte heile kalenderen til eitt høgt lerret og klypte det opp i faste sidehøgder utan omsyn til kvar månadane startar og sluttar, slik at ein månad kunne bli kutta i to over eit sideskift. No blir kvar månad fanga som eit eige bilete og lagt ut med manuell sidebrekking slik at ein heil månad alltid hamnar på éi side.

Bruker JPEG-komprimering og lågare render-skala for å halde filstorleik og genereringstid nede.