### PR TITLE
feat(planlegger): komprimer URL-data med lz-string

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
+++ b/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
@@ -14,7 +14,7 @@ import {
     SøkersituasjonFp,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { decodeBase64 } from '@navikt/fp-utils';
+import { decompressFromUrl } from '@navikt/fp-utils';
 
 import { ContextDataMap, ContextDataType } from './FpDataContext';
 
@@ -108,7 +108,7 @@ export const usePlanleggerDataFromUrl = (kjønn: Kjønn_fpoversikt | undefined):
             return null;
         }
         try {
-            const data = JSON.parse(decodeBase64(encoded)) as PlanleggerDataFromUrl;
+            const data = JSON.parse(decompressFromUrl(encoded)) as PlanleggerDataFromUrl;
             return mapPlanleggerDataToSøknadState(data, kjønn);
         } catch {
             return null;

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -18,7 +18,7 @@ import { HvemHarRett, harMorRett, utledHvemSomHarRett } from 'utils/hvemHarRettU
 import { DEFAULT_SATSER } from '@navikt/fp-constants';
 import { KontoBeregningResultatDto, OmBarnetPlanlegger } from '@navikt/fp-types';
 import { SimpleErrorPage } from '@navikt/fp-ui';
-import { decodeBase64 } from '@navikt/fp-utils';
+import { decompressFromUrl } from '@navikt/fp-utils';
 
 import { PlanleggerRouter } from './PlanleggerRouter';
 
@@ -90,7 +90,7 @@ export const PlanleggerDataInit = () => {
     const intl = useIntl();
 
     const dataParam = new URLSearchParams(locations.search).get('data');
-    const data = dataParam ? (JSON.parse(decodeBase64(dataParam)) as ContextDataMap) : undefined;
+    const data = dataParam ? (JSON.parse(decompressFromUrl(dataParam)) as ContextDataMap) : undefined;
 
     // Denne useEffecten kjøres for at skyra-undersøkelsen skal trigges inline på oppsummering-siden
     useEffect(() => {

--- a/apps/planlegger/src/app-data/usePlanleggerNavigator.ts
+++ b/apps/planlegger/src/app-data/usePlanleggerNavigator.ts
@@ -2,7 +2,7 @@ import { PlanleggerRoutes } from 'appData/routes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { encodeToBase64 } from '@navikt/fp-utils';
+import { compressToUrl } from '@navikt/fp-utils';
 
 import { useContextComplete } from './PlanleggerDataContext';
 import { useStepData } from './useStepData';
@@ -16,7 +16,7 @@ export const usePlanleggerNavigator = () => {
 
     useEffect(() => {
         if (path) {
-            void navigate(`${path}?data=${encodeToBase64(JSON.stringify(context))}`);
+            void navigate(`${path}?data=${compressToUrl(JSON.stringify(context))}`);
         }
     }, [path]);
 

--- a/apps/planlegger/src/steps/oppsummering/SøkOmForeldrepenger.tsx
+++ b/apps/planlegger/src/steps/oppsummering/SøkOmForeldrepenger.tsx
@@ -8,7 +8,7 @@ import { BodyShort, LinkCard, VStack } from '@navikt/ds-react';
 import { links } from '@navikt/fp-constants';
 import { OmBarnetPlanlegger } from '@navikt/fp-types';
 import { Infobox } from '@navikt/fp-ui';
-import { encodeToBase64 } from '@navikt/fp-utils';
+import { compressToUrl } from '@navikt/fp-utils';
 
 interface Props {
     erAlenesøker: boolean;
@@ -17,8 +17,8 @@ interface Props {
 
 export const SøkOmForeldrepenger = ({ erAlenesøker, barnet }: Props) => {
     const planleggerState = useContextComplete();
-    const søknadHref = `${links.foreldrepengesoknad}/?planleggerData=${encodeURIComponent(
-        encodeToBase64(JSON.stringify(sanitizePlanleggerState(planleggerState))),
+    const søknadHref = `${links.foreldrepengesoknad}/?planleggerData=${compressToUrl(
+        JSON.stringify(sanitizePlanleggerState(planleggerState)),
     )}`;
 
     return (

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
@@ -36,7 +36,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { BluePanel, Infobox, StepButtons } from '@navikt/fp-ui';
-import { Uttaksperioden, encodeToBase64, useMedia } from '@navikt/fp-utils';
+import { Uttaksperioden, compressToUrl, useMedia } from '@navikt/fp-utils';
 import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
 import {
     FjernAltIUttaksplanModal,
@@ -100,7 +100,7 @@ export const PlanenDeresSteg = ({ stønadskvoter }: Props) => {
             [ContextDataType.UTTAKSPLAN]: oppdatertUttaksplan,
         };
 
-        const encodedData = encodeToBase64(JSON.stringify(contextData));
+        const encodedData = compressToUrl(JSON.stringify(contextData));
         const currentPath = globalThis.location.pathname;
         const newUrl = `${currentPath}?data=${encodedData}`;
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -34,7 +34,7 @@ export {
 } from './src/stringUtils';
 export { getFamiliehendelsedato, getFamiliesituasjon, sorterPersonEtterEldstOgNavn } from './src/barnUtils';
 export { formatCurrencyWithKr, formatCurrency } from './src/currencyUtils';
-export { encodeToBase64, decodeBase64 } from './src/urlEncodingUtils';
+export { encodeToBase64, decodeBase64, compressToUrl, decompressFromUrl } from './src/urlEncodingUtils';
 export { erLokaltEllerDev } from './src/miljoUtils';
 export {
     getBokmålLocale,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,7 @@
         "@navikt/fp-types": "workspace:*",
         "dayjs": "1.11.20",
         "i18n-iso-countries": "7.14.0",
+        "lz-string": "1.5.0",
         "react": "19.2.6",
         "react-intl": "10.1.6"
     },

--- a/packages/utils/src/urlEncodingUtils.test.ts
+++ b/packages/utils/src/urlEncodingUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { compressToUrl, decodeBase64, decompressFromUrl, encodeToBase64 } from './urlEncodingUtils';
+
+describe('urlEncodingUtils', () => {
+    const json = JSON.stringify({
+        OM_BARNET: { erFødsel: true, antallBarn: '1', termindato: '2025-07-24' },
+        UTTAKSPLAN: [
+            { forelder: 'MOR', kontoType: 'MØDREKVOTE', fom: '2025-07-24', tom: '2025-11-05', flerbarnsdager: false },
+            { forelder: 'FAR_MEDMOR', kontoType: 'FEDREKVOTE', fom: '2025-11-06', tom: '2026-02-25', flerbarnsdager: false },
+        ],
+    });
+
+    it('round-trips komprimert data', () => {
+        expect(decompressFromUrl(compressToUrl(json))).toBe(json);
+    });
+
+    it('gir kortere streng enn base64 for typiske data', () => {
+        expect(compressToUrl(json).length).toBeLessThan(encodeToBase64(json).length);
+    });
+
+    it('produserer URL-trygg output (ingen tegn som endres av URLSearchParams)', () => {
+        const compressed = compressToUrl(json);
+        const params = new URLSearchParams(`data=${compressed}`);
+        // Selv om "+" tolkes som mellomrom av URLSearchParams, skal dekomprimeringen håndtere det
+        expect(decompressFromUrl(params.get('data') ?? '')).toBe(json);
+    });
+
+    it('faller tilbake til base64 for gamle lenker (bakoverkompatibilitet)', () => {
+        const gammelBase64 = encodeToBase64(json);
+        expect(decompressFromUrl(gammelBase64)).toBe(json);
+    });
+
+    it('tolker ikke gammelt base64 feilaktig som komprimert', () => {
+        const gammelBase64 = encodeToBase64(json);
+        expect(decompressFromUrl(gammelBase64)).toBe(decodeBase64(gammelBase64));
+    });
+});

--- a/packages/utils/src/urlEncodingUtils.ts
+++ b/packages/utils/src/urlEncodingUtils.ts
@@ -1,3 +1,5 @@
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+
 // From https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem.
 function base64ToBytes(base64: string) {
     const binString = atob(base64);
@@ -39,4 +41,41 @@ export const decodeBase64 = (stringToBeDecoded: string) => {
         return new TextDecoder().decode(base64ToBytes(stringToBeDecoded));
     }
     throw new Error('Error in base64 decoding');
+};
+
+/**
+ * Komprimerer en streng (typisk JSON) til en URL-trygg verdi for bruk i query-parametere.
+ * Gir vesentlig kortere URL-er enn ren base64-koding fordi gjentakende JSON-struktur komprimeres.
+ *
+ * Output er trygt å legge rett inn i en query-streng uten ekstra `encodeURIComponent`.
+ */
+export const compressToUrl = (stringToBeCompressed: string) => {
+    return compressToEncodedURIComponent(stringToBeCompressed);
+};
+
+const isParsableJson = (value: string | null): value is string => {
+    if (!value) {
+        return false;
+    }
+    try {
+        JSON.parse(value);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Dekoder en verdi som ble lagt på URL-en av {@link compressToUrl}.
+ *
+ * Faller tilbake til {@link decodeBase64} dersom verdien ikke er lz-komprimert. Det gjør at gamle
+ * delte lenker (base64-format) fortsatt fungerer i en overgangsperiode. Returnerer en JSON-streng
+ * som kaller-koden selv må `JSON.parse`-e.
+ */
+export const decompressFromUrl = (valueFromUrl: string) => {
+    const decompressed = decompressFromEncodedURIComponent(valueFromUrl);
+    if (isParsableJson(decompressed)) {
+        return decompressed;
+    }
+    return decodeBase64(valueFromUrl);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2298,6 +2298,9 @@ importers:
       i18n-iso-countries:
         specifier: 7.14.0
         version: 7.14.0
+      lz-string:
+        specifier: 1.5.0
+        version: 1.5.0
       react:
         specifier: 19.2.6
         version: 19.2.6


### PR DESCRIPTION
Planleggeren lagrer hele tilstanden i URL-en som base64-kodet JSON, og samme mekanisme brukes når data sendes videre til foreldrepengesøknaden. For lange uttaksplaner ble URL-ene unødvendig store.

Erstatter base64-koding med lz-string-komprimering på alle fire encode/decode- steder. Dette gir 37-61 % kortere URL-er avhengig av datamengde. Dekoderne faller tilbake til base64 slik at gamle delte lenker fortsatt fungerer.