### PR TITLE
fix: rett opp Sonar-feil

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/util.ts
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/util.ts
@@ -252,113 +252,91 @@ const isMorStuderer = (periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartE
 };
 
 export const getOmsorgsovertakelseVedlegg = (vedlegg: VedleggDataType) => {
-    const omsorgsovertakelseVedlegg = vedlegg[Skjemanummer.OMSORGSOVERTAKELSE]
-        ? vedlegg[Skjemanummer.OMSORGSOVERTAKELSE]
-        : [];
+    const omsorgsovertakelseVedlegg = vedlegg[Skjemanummer.OMSORGSOVERTAKELSE] ?? [];
 
     return fjernSendSenereVedlegg(omsorgsovertakelseVedlegg);
 };
 
 export const getAleneOmOmsorgVedlegg = (vedlegg: VedleggDataType) => {
-    const aleneOmOmsorgVedlegg = vedlegg[Skjemanummer.DOK_AV_ALENEOMSORG]
-        ? vedlegg[Skjemanummer.DOK_AV_ALENEOMSORG]
-        : [];
+    const aleneOmOmsorgVedlegg = vedlegg[Skjemanummer.DOK_AV_ALENEOMSORG] ?? [];
 
     return fjernSendSenereVedlegg(aleneOmOmsorgVedlegg);
 };
 
 export const getTerminbekreftelseVedlegg = (vedlegg: VedleggDataType) => {
-    const terminbekreftelseVedlegg = vedlegg[Skjemanummer.TERMINBEKREFTELSE]
-        ? vedlegg[Skjemanummer.TERMINBEKREFTELSE]
-        : [];
+    const terminbekreftelseVedlegg = vedlegg[Skjemanummer.TERMINBEKREFTELSE] ?? [];
 
     return fjernSendSenereVedlegg(terminbekreftelseVedlegg);
 };
 
 export const getMilitærEllerSiviltjenesteVedlegg = (vedlegg: VedleggDataType) => {
-    const militærEllerSiviltjenesteVedlegg = vedlegg[Skjemanummer.DOK_MILITÆR_SILVIL_TJENESTE]
-        ? vedlegg[Skjemanummer.DOK_MILITÆR_SILVIL_TJENESTE]
-        : [];
+    const militærEllerSiviltjenesteVedlegg = vedlegg[Skjemanummer.DOK_MILITÆR_SILVIL_TJENESTE] ?? [];
 
     return fjernSendSenereVedlegg(militærEllerSiviltjenesteVedlegg);
 };
 
 export const getEtterlønnEllerSluttvederlagVedlegg = (vedlegg: VedleggDataType) => {
-    const etterlønnEllerSluttvederlagVedlegg = vedlegg[Skjemanummer.ETTERLØNN_ELLER_SLUTTVEDERLAG]
-        ? vedlegg[Skjemanummer.ETTERLØNN_ELLER_SLUTTVEDERLAG]
-        : [];
+    const etterlønnEllerSluttvederlagVedlegg = vedlegg[Skjemanummer.ETTERLØNN_ELLER_SLUTTVEDERLAG] ?? [];
 
     return fjernSendSenereVedlegg(etterlønnEllerSluttvederlagVedlegg);
 };
 
 export const getMorInnlagtVedlegg = (vedlegg: VedleggDataType) => {
-    const morInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_MOR]
-        ? vedlegg[Skjemanummer.DOK_INNLEGGELSE_MOR]
-        : [];
+    const morInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_MOR] ?? [];
 
     return fjernSendSenereVedlegg(morInnlagtVedlegg);
 };
 
 export const getMorForSykVedlegg = (vedlegg: VedleggDataType) => {
-    const morForSykVedlegg = vedlegg[Skjemanummer.DOK_SYKDOM_MOR] ? vedlegg[Skjemanummer.DOK_SYKDOM_MOR] : [];
+    const morForSykVedlegg = vedlegg[Skjemanummer.DOK_SYKDOM_MOR] ?? [];
 
     return fjernSendSenereVedlegg(morForSykVedlegg);
 };
 
 export const getFarInnlagtVedlegg = (vedlegg: VedleggDataType) => {
-    const farInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_FAR]
-        ? vedlegg[Skjemanummer.DOK_INNLEGGELSE_FAR]
-        : [];
+    const farInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_FAR] ?? [];
 
     return fjernSendSenereVedlegg(farInnlagtVedlegg);
 };
 
 export const getFarForSykVedlegg = (vedlegg: VedleggDataType) => {
-    const farForSykVedlegg = vedlegg[Skjemanummer.DOK_SYKDOM_FAR] ? vedlegg[Skjemanummer.DOK_SYKDOM_FAR] : [];
+    const farForSykVedlegg = vedlegg[Skjemanummer.DOK_SYKDOM_FAR] ?? [];
 
     return fjernSendSenereVedlegg(farForSykVedlegg);
 };
 
 export const getBarnInnlagtVedlegg = (vedlegg: VedleggDataType) => {
-    const barnInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_BARN]
-        ? vedlegg[Skjemanummer.DOK_INNLEGGELSE_BARN]
-        : [];
+    const barnInnlagtVedlegg = vedlegg[Skjemanummer.DOK_INNLEGGELSE_BARN] ?? [];
 
     return fjernSendSenereVedlegg(barnInnlagtVedlegg);
 };
 
 export const getMorStudererVedlegg = (vedlegg: VedleggDataType) => {
-    const morStudererVedlegg = vedlegg[Skjemanummer.DOK_UTDANNING_MOR] ? vedlegg[Skjemanummer.DOK_UTDANNING_MOR] : [];
+    const morStudererVedlegg = vedlegg[Skjemanummer.DOK_UTDANNING_MOR] ?? [];
 
     return fjernSendSenereVedlegg(morStudererVedlegg);
 };
 
 export const getMorJobberVedlegg = (vedlegg: VedleggDataType) => {
-    const morJobberVedlegg = vedlegg[Skjemanummer.DOK_ARBEID_MOR] ? vedlegg[Skjemanummer.DOK_ARBEID_MOR] : [];
+    const morJobberVedlegg = vedlegg[Skjemanummer.DOK_ARBEID_MOR] ?? [];
 
     return fjernSendSenereVedlegg(morJobberVedlegg);
 };
 
 export const getMorJobberOgStudererVedlegg = (vedlegg: VedleggDataType) => {
-    const morJobberOgStudererVedlegg = vedlegg[Skjemanummer.DOK_UTDANNING_OG_ARBEID_MOR]
-        ? vedlegg[Skjemanummer.DOK_UTDANNING_OG_ARBEID_MOR]
-        : [];
+    const morJobberOgStudererVedlegg = vedlegg[Skjemanummer.DOK_UTDANNING_OG_ARBEID_MOR] ?? [];
 
     return fjernSendSenereVedlegg(morJobberOgStudererVedlegg);
 };
 
 export const getMorIntroprogramVedlegg = (vedlegg: VedleggDataType) => {
-    const morIntroprogramVedlegg = vedlegg[Skjemanummer.DOK_DELTAKELSE_I_INTRODUKSJONSPROGRAMMET]
-        ? vedlegg[Skjemanummer.DOK_DELTAKELSE_I_INTRODUKSJONSPROGRAMMET]
-        : [];
+    const morIntroprogramVedlegg = vedlegg[Skjemanummer.DOK_DELTAKELSE_I_INTRODUKSJONSPROGRAMMET] ?? [];
 
     return fjernSendSenereVedlegg(morIntroprogramVedlegg);
 };
 
 export const getMorKvalprogramVedlegg = (vedlegg: VedleggDataType) => {
-    const morKvalprogramVedlegg = vedlegg[Skjemanummer.BEKREFTELSE_DELTAR_KVALIFISERINGSPROGRAM]
-        ? vedlegg[Skjemanummer.BEKREFTELSE_DELTAR_KVALIFISERINGSPROGRAM]
-        : [];
+    const morKvalprogramVedlegg = vedlegg[Skjemanummer.BEKREFTELSE_DELTAR_KVALIFISERINGSPROGRAM] ?? [];
 
     return fjernSendSenereVedlegg(morKvalprogramVedlegg);
 };

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
@@ -31,12 +31,9 @@ export const SøkersituasjonSteg = ({ arbeidsforhold, kjønn, mellomlagreSøknad
     const kommerFraPlanlegger = useContextGetData(ContextDataType.KOMMER_FRA_PLANLEGGER);
     const resetUttaksplanData = useResetUttaksplanData();
 
+    const situasjonFraBarn = barn && isAdoptertBarn(barn) ? 'adopsjon' : 'fødsel';
     const defaultSituasjon =
-        !søkersituasjon?.situasjon && kommerFraPlanlegger && barn
-            ? isAdoptertBarn(barn)
-                ? 'adopsjon'
-                : 'fødsel'
-            : undefined;
+        !søkersituasjon?.situasjon && kommerFraPlanlegger && barn ? situasjonFraBarn : undefined;
 
     const formMethods = useForm<SøkersituasjonFp>({
         defaultValues: søkersituasjon ?? (defaultSituasjon ? { situasjon: defaultSituasjon } : undefined),

--- a/apps/planlegger/src/steps/oppsummering/SøkOmForeldrepenger.tsx
+++ b/apps/planlegger/src/steps/oppsummering/SøkOmForeldrepenger.tsx
@@ -66,16 +66,16 @@ export const SøkOmForeldrepenger = ({ erAlenesøker, barnet }: Props) => {
 };
 
 // Felter som skal utelates fra payloaden som sendes til søknaden
-const EKSKLUDERTE_FELTER: readonly ContextDataType[] = [
+const EKSKLUDERTE_FELTER: ReadonlySet<ContextDataType> = new Set([
     ContextDataType.HVOR_MYE,
     ContextDataType.ARBEIDSSITUASJON,
     ContextDataType.HVEM_PLANLEGGER,
-];
+]);
 
 const sanitizePlanleggerState = (state: ReturnType<typeof useContextComplete>) => {
     const result: Record<string, unknown> = {};
     for (const key of Object.values(ContextDataType)) {
-        if (EKSKLUDERTE_FELTER.includes(key)) {
+        if (EKSKLUDERTE_FELTER.has(key)) {
             continue;
         }
         const value = state[key];

--- a/packages/utils/src/urlEncodingUtils.ts
+++ b/packages/utils/src/urlEncodingUtils.ts
@@ -3,7 +3,7 @@ import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from
 // From https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem.
 function base64ToBytes(base64: string) {
     const binString = atob(base64);
-    return Uint8Array.from(binString, (m) => m.charCodeAt(0));
+    return Uint8Array.from(binString, (m) => m.codePointAt(0)!);
 }
 
 // From https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem.

--- a/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
+++ b/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
@@ -256,7 +256,7 @@ export type RegelkatalogSideProps<T> = {
 export const RegelIdBadge = ({ id }: { id: string }) => (
     <code className="rounded bg-ax-bg-neutral-moderate px-2 py-0.5 font-mono text-xs">
         {id.split('.').map((segment, i, arr) => (
-            <span key={i}>
+            <span key={`${i}-${segment}`}>
                 {segment}
                 {i < arr.length - 1 && (
                     <>

--- a/scripts/create-storybook-index.mjs
+++ b/scripts/create-storybook-index.mjs
@@ -1,5 +1,5 @@
-import { copyFileSync, cpSync, existsSync, globSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join, sep } from 'node:path';
+import { cpSync, existsSync, globSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Hva

Retter opp alle ikke-TODO Sonar-feil rapportert i [SonarCloud (nytt kode-periode)](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&id=navikt_foreldrepengesoknad). De 29 `S1135` (TODO-kommentarer) er bevisst utelatt.

## Endringer

| Regel | Fil | Fiks |
|-------|-----|------|
| S7758 | `packages/utils/src/urlEncodingUtils.ts` | `charCodeAt()` → `codePointAt()` |
| S6479 | `packages/uttaksplan/src/regler/RegelkatalogSide.tsx` | Array-indeks som React-key → sammensatt key |
| S1128 ×3 | `scripts/create-storybook-index.mjs` | Fjernet ubrukte importer (`copyFileSync`, `mkdirSync`, `sep`) |
| S3358 | `apps/foreldrepengesoknad/.../SøkersituasjonSteg.tsx` | Trukket ut nøstet ternary |
| S7776 | `apps/planlegger/.../SøkOmForeldrepenger.tsx` | `EKSKLUDERTE_FELTER` → `Set` med `.has()` |
| S6606 ×15 | `apps/foreldrepengesoknad/.../manglende-vedlegg/util.ts` | `x ? x : []` → `x ?? []` |

## Verifisering

- `pnpm tsc` — 24/24 ✅
- `pnpm eslint` — 0 errors (kun eksisterende, urelaterte warnings)