### PR TITLE
refactor: rydd opp i TODO-kommentarar (Sonar S1135)

### DIFF
--- a/apps/engangsstonad/src/app-data/queries.ts
+++ b/apps/engangsstonad/src/app-data/queries.ts
@@ -19,6 +19,7 @@ export const API_URLS = {
     status: `${urlPrefiks}/fpsoknad/api/soknad/status`,
     sendSøknad: `${urlPrefiks}/fpsoknad/api/soknad/engangsstonad`,
     sendVedlegg: `${urlPrefiks}/fpsoknad/api/storage/ENGANGSSTONAD/vedlegg`,
+    hentVedlegg: (uuid: string) => `${urlPrefiks}/fpsoknad/api/storage/ENGANGSSTONAD/vedlegg/${uuid}`,
 } as const;
 
 export const personOptions = () =>

--- a/apps/engangsstonad/src/app-data/queries.ts
+++ b/apps/engangsstonad/src/app-data/queries.ts
@@ -19,7 +19,6 @@ export const API_URLS = {
     status: `${urlPrefiks}/fpsoknad/api/soknad/status`,
     sendSøknad: `${urlPrefiks}/fpsoknad/api/soknad/engangsstonad`,
     sendVedlegg: `${urlPrefiks}/fpsoknad/api/storage/ENGANGSSTONAD/vedlegg`,
-    hentVedlegg: (uuid: string) => `${urlPrefiks}/fpsoknad/api/storage/ENGANGSSTONAD/vedlegg/${uuid}`,
 } as const;
 
 export const personOptions = () =>

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -8,7 +8,7 @@ import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
-function VedleggLenke({ attachment }: { readonly attachment: Attachment }) {
+const VedleggLenke = ({ attachment }: { readonly attachment: Attachment }) => {
     const href = useMemo(() => {
         if (typeof URL?.createObjectURL !== 'function' || !(attachment.file instanceof Blob)) {
             return undefined;
@@ -33,9 +33,9 @@ function VedleggLenke({ attachment }: { readonly attachment: Attachment }) {
             {attachment.filename}
         </Link>
     );
-}
+};
 
-function TerminDokumentasjonSummary({ dokumentasjon }: { readonly dokumentasjon: TerminDokumentasjon }) {
+const TerminDokumentasjonSummary = ({ dokumentasjon }: { readonly dokumentasjon: TerminDokumentasjon }) => {
     return (
         <>
             <FormSummary.Answer>
@@ -58,9 +58,9 @@ function TerminDokumentasjonSummary({ dokumentasjon }: { readonly dokumentasjon:
             </FormSummary.Answer>
         </>
     );
-}
+};
 
-function AdopsjonDokumentasjon({ dokumentasjon }: { readonly dokumentasjon: Vedlegg }) {
+const AdopsjonDokumentasjon = ({ dokumentasjon }: { readonly dokumentasjon: Vedlegg }) => {
     return (
         <FormSummary.Answer>
             <FormSummary.Label>
@@ -75,15 +75,15 @@ function AdopsjonDokumentasjon({ dokumentasjon }: { readonly dokumentasjon: Vedl
             </FormSummary.Value>
         </FormSummary.Answer>
     );
-}
+};
 
-export function DokumentasjonOppsummering({
+export const DokumentasjonOppsummering = ({
     dokumentasjon,
     onVilEndreSvar,
 }: {
     readonly dokumentasjon?: Dokumentasjon;
     readonly onVilEndreSvar: (path: Path) => void;
-}) {
+}) => {
     if (!dokumentasjon || dokumentasjon.vedlegg.length === 0) {
         return null;
     }
@@ -115,4 +115,4 @@ export function DokumentasjonOppsummering({
             </FormSummary.Footer>
         </FormSummary>
     );
-}
+};

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -14,7 +14,7 @@ const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
     }
 
     return (
-        <Link href={API_URLS.hentVedlegg(attachment.uuid)} download={attachment.filename} target="_blank">
+        <Link href={API_URLS.hentVedlegg(attachment.uuid)} download={attachment.filename} target="_blank" rel="noreferrer noopener">
             {attachment.filename}
         </Link>
     );

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -1,5 +1,5 @@
 import { Path } from 'appData/paths';
-import { API_URLS } from 'appData/queries';
+import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
@@ -9,12 +9,25 @@ import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
 const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
-    if (!attachment.uuid) {
+    const href = useMemo(
+        () => (attachment.file instanceof Blob ? URL.createObjectURL(attachment.file) : undefined),
+        [attachment.file],
+    );
+
+    useEffect(() => {
+        return () => {
+            if (href) {
+                URL.revokeObjectURL(href);
+            }
+        };
+    }, [href]);
+
+    if (!href) {
         return <BodyShort>{attachment.filename}</BodyShort>;
     }
 
     return (
-        <Link href={API_URLS.hentVedlegg(attachment.uuid)} download={attachment.filename} target="_blank" rel="noreferrer noopener">
+        <Link href={href} download={attachment.filename} target="_blank" rel="noreferrer noopener">
             {attachment.filename}
         </Link>
     );

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -6,10 +6,7 @@ import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } fr
 import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 
 import { Attachment } from '@navikt/fp-types';
-import { formatDate } from '@navikt/fp-utils';
-
-// Backenden konverterer alle vedlegg (png/jpg) til PDF ved opplasting, så nedlastinga er alltid ei PDF-fil.
-const tilPdfFilnavn = (filename: string) => `${filename.replace(/\.[^./\\]+$/, '')}.pdf`;
+import { formatDate, vedleggNedlastingsnavn } from '@navikt/fp-utils';
 
 const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
     if (!attachment.uuid) {
@@ -19,7 +16,7 @@ const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
     return (
         <Link
             href={API_URLS.hentVedlegg(attachment.uuid)}
-            download={tilPdfFilnavn(attachment.filename)}
+            download={vedleggNedlastingsnavn(attachment.filename)}
             target="_blank"
             rel="noreferrer noopener"
         >

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -1,10 +1,23 @@
 import { Path } from 'appData/paths';
+import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
-import { FormSummary, VStack } from '@navikt/ds-react';
+import { FormSummary, Link, VStack } from '@navikt/ds-react';
 
+import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
+
+function VedleggLenke({ attachment }: { readonly attachment: Attachment }) {
+    const href = useMemo(() => URL.createObjectURL(attachment.file), [attachment.file]);
+    useEffect(() => () => URL.revokeObjectURL(href), [href]);
+
+    return (
+        <Link href={href} target="_blank" rel="noreferrer">
+            {attachment.filename}
+        </Link>
+    );
+}
 
 function TerminDokumentasjonSummary({ dokumentasjon }: { readonly dokumentasjon: TerminDokumentasjon }) {
     return (
@@ -20,7 +33,11 @@ function TerminDokumentasjonSummary({ dokumentasjon }: { readonly dokumentasjon:
                     <FormattedMessage id="DokumentasjonOppsummering.TerminbekreftelseDokument" />
                 </FormSummary.Label>
                 <FormSummary.Answer>
-                    <VStack gap="space-8">{dokumentasjon.vedlegg.map((v) => v.filename)}</VStack>
+                    <VStack gap="space-8">
+                        {dokumentasjon.vedlegg.map((v) => (
+                            <VedleggLenke key={v.id} attachment={v} />
+                        ))}
+                    </VStack>
                 </FormSummary.Answer>
             </FormSummary.Answer>
         </>
@@ -34,8 +51,11 @@ function AdopsjonDokumentasjon({ dokumentasjon }: { readonly dokumentasjon: Vedl
                 <FormattedMessage id="DokumentasjonOppsummering.adopsjonsdokumenter" />
             </FormSummary.Label>
             <FormSummary.Answer>
-                {/*TODO: klikke på lenke*/}
-                <VStack gap="space-8">{dokumentasjon.vedlegg.map((v) => v.filename)}</VStack>
+                <VStack gap="space-8">
+                    {dokumentasjon.vedlegg.map((v) => (
+                        <VedleggLenke key={v.id} attachment={v} />
+                    ))}
+                </VStack>
             </FormSummary.Answer>
         </FormSummary.Answer>
     );

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -8,7 +8,7 @@ import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
-const VedleggLenke = ({ attachment }: { readonly attachment: Attachment }) => {
+const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
     const href = useMemo(() => {
         if (typeof URL?.createObjectURL !== 'function' || !(attachment.file instanceof Blob)) {
             return undefined;
@@ -35,7 +35,7 @@ const VedleggLenke = ({ attachment }: { readonly attachment: Attachment }) => {
     );
 };
 
-const TerminDokumentasjonSummary = ({ dokumentasjon }: { readonly dokumentasjon: TerminDokumentasjon }) => {
+const TerminDokumentasjonSummary = ({ dokumentasjon }: { dokumentasjon: TerminDokumentasjon }) => {
     return (
         <>
             <FormSummary.Answer>
@@ -60,7 +60,7 @@ const TerminDokumentasjonSummary = ({ dokumentasjon }: { readonly dokumentasjon:
     );
 };
 
-const AdopsjonDokumentasjon = ({ dokumentasjon }: { readonly dokumentasjon: Vedlegg }) => {
+const AdopsjonDokumentasjon = ({ dokumentasjon }: { dokumentasjon: Vedlegg }) => {
     return (
         <FormSummary.Answer>
             <FormSummary.Label>
@@ -81,8 +81,8 @@ export const DokumentasjonOppsummering = ({
     dokumentasjon,
     onVilEndreSvar,
 }: {
-    readonly dokumentasjon?: Dokumentasjon;
-    readonly onVilEndreSvar: (path: Path) => void;
+    dokumentasjon?: Dokumentasjon;
+    onVilEndreSvar: (path: Path) => void;
 }) => {
     if (!dokumentasjon || dokumentasjon.vedlegg.length === 0) {
         return null;

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -1,5 +1,5 @@
 import { Path } from 'appData/paths';
-import { useEffect, useMemo } from 'react';
+import { API_URLS } from 'appData/queries';
 import { FormattedMessage } from 'react-intl';
 import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
@@ -8,26 +8,21 @@ import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
+// Backenden konverterer alle vedlegg (png/jpg) til PDF ved opplasting, så nedlastinga er alltid ei PDF-fil.
+const tilPdfFilnavn = (filename: string) => `${filename.replace(/\.[^./\\]+$/, '')}.pdf`;
+
 const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
-    const href = useMemo(
-        () => (attachment.file instanceof Blob ? URL.createObjectURL(attachment.file) : undefined),
-        [attachment.file],
-    );
-
-    useEffect(() => {
-        return () => {
-            if (href) {
-                URL.revokeObjectURL(href);
-            }
-        };
-    }, [href]);
-
-    if (!href) {
+    if (!attachment.uuid) {
         return <BodyShort>{attachment.filename}</BodyShort>;
     }
 
     return (
-        <Link href={href} download={attachment.filename} target="_blank" rel="noreferrer noopener">
+        <Link
+            href={API_URLS.hentVedlegg(attachment.uuid)}
+            download={tilPdfFilnavn(attachment.filename)}
+            target="_blank"
+            rel="noreferrer noopener"
+        >
             {attachment.filename}
         </Link>
     );

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -9,8 +9,24 @@ import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
 function VedleggLenke({ attachment }: { readonly attachment: Attachment }) {
-    const href = useMemo(() => URL.createObjectURL(attachment.file), [attachment.file]);
-    useEffect(() => () => URL.revokeObjectURL(href), [href]);
+    const href = useMemo(() => {
+        if (typeof URL?.createObjectURL !== 'function' || !(attachment.file instanceof Blob)) {
+            return undefined;
+        }
+        return URL.createObjectURL(attachment.file);
+    }, [attachment.file]);
+
+    useEffect(() => {
+        return () => {
+            if (href) {
+                URL.revokeObjectURL(href);
+            }
+        };
+    }, [href]);
+
+    if (!href) {
+        return <>{attachment.filename}</>;
+    }
 
     return (
         <Link href={href} target="_blank" rel="noreferrer">
@@ -26,19 +42,19 @@ function TerminDokumentasjonSummary({ dokumentasjon }: { readonly dokumentasjon:
                 <FormSummary.Label>
                     <FormattedMessage id="DokumentasjonOppsummering.Terminbekreftelse" />
                 </FormSummary.Label>
-                <FormSummary.Answer>{formatDate(dokumentasjon.terminbekreftelsedato)}</FormSummary.Answer>
+                <FormSummary.Value>{formatDate(dokumentasjon.terminbekreftelsedato)}</FormSummary.Value>
             </FormSummary.Answer>
             <FormSummary.Answer>
                 <FormSummary.Label>
                     <FormattedMessage id="DokumentasjonOppsummering.TerminbekreftelseDokument" />
                 </FormSummary.Label>
-                <FormSummary.Answer>
+                <FormSummary.Value>
                     <VStack gap="space-8">
                         {dokumentasjon.vedlegg.map((v) => (
                             <VedleggLenke key={v.id} attachment={v} />
                         ))}
                     </VStack>
-                </FormSummary.Answer>
+                </FormSummary.Value>
             </FormSummary.Answer>
         </>
     );
@@ -50,13 +66,13 @@ function AdopsjonDokumentasjon({ dokumentasjon }: { readonly dokumentasjon: Vedl
             <FormSummary.Label>
                 <FormattedMessage id="DokumentasjonOppsummering.adopsjonsdokumenter" />
             </FormSummary.Label>
-            <FormSummary.Answer>
+            <FormSummary.Value>
                 <VStack gap="space-8">
                     {dokumentasjon.vedlegg.map((v) => (
                         <VedleggLenke key={v.id} attachment={v} />
                     ))}
                 </VStack>
-            </FormSummary.Answer>
+            </FormSummary.Value>
         </FormSummary.Answer>
     );
 }

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
-import { FormSummary, Link, VStack } from '@navikt/ds-react';
+import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 
 import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
@@ -25,7 +25,7 @@ function VedleggLenke({ attachment }: { readonly attachment: Attachment }) {
     }, [href]);
 
     if (!href) {
-        return <>{attachment.filename}</>;
+        return <BodyShort>{attachment.filename}</BodyShort>;
     }
 
     return (

--- a/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/DokumentasjonOppsummering.tsx
@@ -1,5 +1,5 @@
 import { Path } from 'appData/paths';
-import { useEffect, useMemo } from 'react';
+import { API_URLS } from 'appData/queries';
 import { FormattedMessage } from 'react-intl';
 import { Dokumentasjon, TerminDokumentasjon, Vedlegg, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
@@ -9,27 +9,12 @@ import { Attachment } from '@navikt/fp-types';
 import { formatDate } from '@navikt/fp-utils';
 
 const VedleggLenke = ({ attachment }: { attachment: Attachment }) => {
-    const href = useMemo(() => {
-        if (typeof URL?.createObjectURL !== 'function' || !(attachment.file instanceof Blob)) {
-            return undefined;
-        }
-        return URL.createObjectURL(attachment.file);
-    }, [attachment.file]);
-
-    useEffect(() => {
-        return () => {
-            if (href) {
-                URL.revokeObjectURL(href);
-            }
-        };
-    }, [href]);
-
-    if (!href) {
+    if (!attachment.uuid) {
         return <BodyShort>{attachment.filename}</BodyShort>;
     }
 
     return (
-        <Link href={href} target="_blank" rel="noreferrer">
+        <Link href={API_URLS.hentVedlegg(attachment.uuid)} download={attachment.filename} target="_blank">
             {attachment.filename}
         </Link>
     );

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
@@ -33,6 +33,8 @@ const vedleggDefault = {
     vedlegg: [],
 };
 
+const pdfVedlegg = new File(['pdf'], 'filnavn.pdf', { type: 'application/pdf' });
+
 type StoryArgs = {
     omBarnet?: BarnDto;
     utenlandsopphold?: Utenlandsopphold;
@@ -99,7 +101,7 @@ export const AdopsjonAvEktefellesBarn: Story = {
                     id: '1',
                     filename: 'filnavn.pdf',
                     filesize: 2323,
-                    file: {} as File,
+                    file: pdfVedlegg,
                     pending: false,
                     innsendingsType: 'LASTET_OPP',
                     uploaded: true,
@@ -129,7 +131,7 @@ export const AdopsjonAvEktefellesFlereBarn: Story = {
                     filename: 'filnavn.pdf',
                     innsendingsType: 'LASTET_OPP',
                     filesize: 2323,
-                    file: {} as File,
+                    file: pdfVedlegg,
                     pending: false,
                     uploaded: true,
                     type: AttachmentType.OMSORGSOVERTAKELSE,
@@ -156,7 +158,7 @@ export const BarnetErIkkeFodt: Story = {
                     id: '1',
                     filename: 'filnavn.pdf',
                     filesize: 2323,
-                    file: {} as File,
+                    file: pdfVedlegg,
                     pending: false,
                     innsendingsType: 'LASTET_OPP',
                     uploaded: true,

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
@@ -128,9 +128,6 @@ type StoryArgs = {
     gåTilNesteSide?: (action: Action) => void;
 } & ComponentProps<typeof ManglendeVedlegg>;
 
-// TODO: (KALLE) Legg til stillingsprosent som en kontrollbar storybook-parameter for relevante historier
-// TODO: (KALLE) Gjør at datoene i stories er relative til dagens dato
-
 const meta = {
     title: 'steps/ManglendeVedlegg',
     component: ManglendeVedlegg,

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -882,9 +882,6 @@ export const VisSendInnSenereVedlegg: Story = {
     },
 };
 
-// TODO: (KALLE) Legg til stillingsprosent som en kontrollbar storybook-parameter for relevante historier
-// TODO: (KALLE) Gjør at datoene i stories er relative til dagens dato
-
 export const FarSøkerMorMåIkkeDokumentereArbeid: Story = {
     args: {
         ...Default.args,

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonOppsummering.tsx
@@ -9,6 +9,7 @@ import { Alert, BodyLong, BodyShort, FormSummary, Heading, Link, VStack } from '
 
 import { AttachmentType } from '@navikt/fp-constants';
 import { NavnPåForeldre } from '@navikt/fp-types';
+import { vedleggNedlastingsnavn } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { getFamiliehendelsedato } from '../../../utils/barnUtils';
@@ -100,9 +101,10 @@ export const DokumentasjonOppsummering = ({ onVilEndreSvar, navnPåForeldre }: P
                                                     return vedlegg.uuid ? (
                                                         <Link
                                                             key={vedlegg.id}
-                                                            download={vedlegg.filename}
+                                                            download={vedleggNedlastingsnavn(vedlegg.filename)}
                                                             href={`${API_URLS.hentVedlegg(vedlegg.uuid)}`}
                                                             target="_blank"
+                                                            rel="noreferrer noopener"
                                                         >
                                                             {vedlegg.filename}
                                                         </Link>

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.stories.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.stories.tsx
@@ -18,8 +18,6 @@ import {
 
 import { FordelingSteg } from './FordelingSteg';
 
-// TODO: Benytt dayjs for å håndtere datoer i testene. Spesielt for å sørge for at fremtidige datoer alltid er fremtidige.
-
 const DEFAULT_STØNADSKONTO = {
     '100': {
         kontoer: DELT_UTTAK_100,

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.test.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.test.tsx
@@ -10,8 +10,6 @@ import { BarnetErAdoptertPlanlegger } from '@navikt/fp-types';
 import { endreFordelingMedSlider } from '../../../vitest/testHelpers';
 import * as stories from './FordelingSteg.stories';
 
-// TODO: Benytt dayjs for å håndtere datoer i testene. Spesielt for å sørge for at fremtidige datoer alltid er fremtidige.
-
 const {
     FlereForsørgereEttBarn,
     FlereForsørgereEttBarn80ProsentDekningsgrad,

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
@@ -23,8 +23,6 @@ import {
 
 import { HvorLangPeriodeSteg } from './HvorLangPeriodeSteg';
 
-// TODO: Benytt dayjs for å håndtere datoer i testene. Spesielt for å sørge for at fremtidige datoer alltid er fremtidige.
-
 const MINSTERETTER = {
     farRundtFødsel: 10,
     toTette: 0,

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
@@ -7,8 +7,6 @@ import { useNavigate } from 'react-router-dom';
 
 import * as stories from './HvorLangPeriodeSteg.stories';
 
-// TODO: Benytt dayjs for å håndtere datoer i testene. Spesielt for å sørge for at fremtidige datoer alltid er fremtidige.
-
 const {
     FlereForsørgereEttBarnKunMorHarRett,
     FarOgFarBeggeHarRett,

--- a/apps/planlegger/src/steps/om-barnet/fødsel/ErIkkeFødtPanel.tsx
+++ b/apps/planlegger/src/steps/om-barnet/fødsel/ErIkkeFødtPanel.tsx
@@ -40,8 +40,6 @@ export const ErIkkeFødtPanel = ({ hvemPlanlegger, erOmBarnetPlanleggerIkkeOppgi
         ? dayjs(termindato).subtract(18, 'weeks').subtract(3, 'days').toDate()
         : undefined;
 
-    // TODO: disse sjekker nå på dato, skal den sjekke på ukenummer?
-
     const erAlenesøker = erAlene(hvemPlanlegger);
     const erFarMedISøknaden = erFarDelAvSøknaden(hvemPlanlegger);
     const erFedre = erFarOgFar(hvemPlanlegger);

--- a/apps/svangerskapspengesoknad/src/steps/oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/oppsummering/DokumentasjonOppsummering.tsx
@@ -6,7 +6,7 @@ import { BodyShort, FormSummary, Link, VStack } from '@navikt/ds-react';
 
 import { EGEN_NÆRING_ID } from '@navikt/fp-steg-egen-naering';
 import { Attachment, EksternArbeidsforholdDto_fpoversikt, FRILANS_ID } from '@navikt/fp-types';
-import { capitalizeFirstLetterInEveryWordOnly } from '@navikt/fp-utils';
+import { capitalizeFirstLetterInEveryWordOnly, vedleggNedlastingsnavn } from '@navikt/fp-utils';
 
 export function DokumentasjonOppsummering({
     tilretteleggingerVedlegg,
@@ -39,9 +39,10 @@ export function DokumentasjonOppsummering({
                                     return vedlegg.uuid ? (
                                         <Link
                                             key={vedlegg.id}
-                                            download={vedlegg.filename}
+                                            download={vedleggNedlastingsnavn(vedlegg.filename)}
                                             href={`${API_URLS.hentVedlegg(vedlegg.uuid)}`}
                                             target="_blank"
+                                            rel="noreferrer noopener"
                                         >
                                             {vedlegg.filename}
                                         </Link>

--- a/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
+++ b/packages/form-hooks/src/error/ErrorSummaryHookForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { FieldErrors, FieldValues, useFormContext } from 'react-hook-form';
 
-import { ErrorSummaryFp } from '@navikt/fp-ui';
+import { ErrorSummaryFelles } from '@navikt/fp-ui';
 
 const findAllErrors = (errors: FieldErrors<FieldValues>, pathPrefix = ''): FieldErrors<FieldValues> => {
     return Object.keys(errors).reduce<FieldErrors<FieldValues>>((acc, fieldKey) => {
@@ -68,6 +68,8 @@ export const ErrorSummaryHookForm = () => {
     }));
 
     return (
-        Object.keys(flattenAndUniqueErrors).length > 0 && <ErrorSummaryFp errorRef={errorRef} errors={mappedErrors} />
+        Object.keys(flattenAndUniqueErrors).length > 0 && (
+            <ErrorSummaryFelles errorRef={errorRef} errors={mappedErrors} />
+        )
     );
 };

--- a/packages/steg-arbeidsforhold-og-inntekt/index.ts
+++ b/packages/steg-arbeidsforhold-og-inntekt/index.ts
@@ -9,6 +9,3 @@ export const arbeidsforholdOgInntektMessages = {
 };
 
 export { ArbeidsforholdOgInntektPanel } from './src/ArbeidsforholdOgInntektPanel';
-// TODO Usikker på om desse to bør ligga i denne pakka sidan dei i tillegg blir brukt i oppsummering i FP
-export { HarArbeidsforhold } from './src/components/arbeidsforhold-informasjon/HarArbeidsforhold';
-export { HarIkkeArbeidsforhold } from './src/components/arbeidsforhold-informasjon/HarIkkeArbeidsforhold';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -10,9 +10,9 @@ export const uiMessages = {
 
 export { SkjemaRotLayout } from './src/skjema-rotlayout/SkjemaRotLayout';
 export { ErrorBoundary } from './src/error/ErrorBoundary';
-export { ErrorSummaryFp } from './src/error/ErrorSummaryFp';
+export { ErrorSummaryFelles } from './src/error/ErrorSummaryFelles';
 export { SimpleErrorPage } from './src/error/SimpleErrorPage';
-export type { ErrorSummaryError } from './src/error/ErrorSummaryFp';
+export type { ErrorSummaryError } from './src/error/ErrorSummaryFelles';
 export { ErrorPage } from './src/error/ErrorPage';
 export { StepButtons } from './src/step/StepButtons';
 export { ScanDocumentInfo } from './src/scan-document-info/ScanDocumentInfo';

--- a/packages/ui/src/error/ErrorSummaryFelles.tsx
+++ b/packages/ui/src/error/ErrorSummaryFelles.tsx
@@ -12,15 +12,13 @@ interface Props {
     errors: ErrorSummaryError[];
 }
 
-//TODO Fjern FP postfix. Er litt misvisande da det kan sjå ut som denne er spesifikk for FP-appen
-
-export const ErrorSummaryFp = ({ errorRef, errors }: Props) => {
+export const ErrorSummaryFelles = ({ errorRef, errors }: Props) => {
     return (
         <ErrorSummary
             size="small"
             ref={errorRef}
             headingTag="h3"
-            heading={<FormattedMessage id={'ErrorSummaryFp.Tittel'} />}
+            heading={<FormattedMessage id={'ErrorSummaryFelles.Tittel'} />}
         >
             {Object.values(errors).map((error) => (
                 <ErrorSummary.Item

--- a/packages/ui/src/intl/messages/en_US.json
+++ b/packages/ui/src/intl/messages/en_US.json
@@ -5,7 +5,7 @@
     "Umyndig.Tittel": "Because you are under 18 years of age, you must send a paper application",
     "Umyndig.Tekst": "Because you are under 18, one of your parents or a guardian must sign your application with you. You must therefore complete the application on paper and send it by post to Nav.",
     "Umyndig.Knapp.Papirsøknad": "Go to the paper application",
-    "ErrorSummaryFp.Tittel": "You have to correct the following errors:",
+    "ErrorSummaryFelles.Tittel": "You have to correct the following errors:",
     "StepButtons.Forrige": "Previous step",
     "StepButtons.ForrigeSimple": "Previous",
     "StepButtons.Neste": "Next step",

--- a/packages/ui/src/intl/messages/nb_NO.json
+++ b/packages/ui/src/intl/messages/nb_NO.json
@@ -5,7 +5,7 @@
     "Umyndig.Tittel": "Fordi du er under 18 år, må du sende papirsøknad",
     "Umyndig.Tekst": "Fordi du er under 18 år, må en av foreldrene dine eller en foresatt skrive under på søknaden din sammen med deg. Derfor må du fylle ut søknaden på papir og sende den i posten til Nav.",
     "Umyndig.Knapp.Papirsøknad": "Gå til papirsøknaden",
-    "ErrorSummaryFp.Tittel": "Du må rette opp i følgende feil:",
+    "ErrorSummaryFelles.Tittel": "Du må rette opp i følgende feil:",
     "StepButtons.Forrige": "Forrige steg",
     "StepButtons.ForrigeSimple": "Forrige",
     "StepButtons.Neste": "Neste steg",

--- a/packages/ui/src/intl/messages/nn_NO.json
+++ b/packages/ui/src/intl/messages/nn_NO.json
@@ -5,7 +5,7 @@
     "Umyndig.Tittel": "Fordi du er under 18 år, må du senda papirsøknad",
     "Umyndig.Tekst": "Fordi du er under 18 år, må ein av foreldrene dine eller ein føresatt skrive under på søknaden din samen med deg. Derfor må du fylle ut søknaden på papir og sende den i posten til Nav.",
     "Umyndig.Knapp.Papirsøknad": "Gå til papirsøknaden",
-    "ErrorSummaryFelles.Tittel": "Du må rette opp i følgende feil:",
+    "ErrorSummaryFelles.Tittel": "Du må rette opp i følgjande feil:",
     "StepButtons.Forrige": "Forrige steg",
     "StepButtons.ForrigeSimple": "Forrige",
     "StepButtons.Neste": "Neste steg",

--- a/packages/ui/src/intl/messages/nn_NO.json
+++ b/packages/ui/src/intl/messages/nn_NO.json
@@ -5,7 +5,7 @@
     "Umyndig.Tittel": "Fordi du er under 18 år, må du senda papirsøknad",
     "Umyndig.Tekst": "Fordi du er under 18 år, må ein av foreldrene dine eller ein føresatt skrive under på søknaden din samen med deg. Derfor må du fylle ut søknaden på papir og sende den i posten til Nav.",
     "Umyndig.Knapp.Papirsøknad": "Gå til papirsøknaden",
-    "ErrorSummaryFp.Tittel": "Du må rette opp i følgende feil:",
+    "ErrorSummaryFelles.Tittel": "Du må rette opp i følgende feil:",
     "StepButtons.Forrige": "Forrige steg",
     "StepButtons.ForrigeSimple": "Forrige",
     "StepButtons.Neste": "Neste steg",

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -75,4 +75,5 @@ export { Uttaksperioden } from './src/uttak/Uttaksperioden';
 export { Tidsperioden } from './src/Tidsperioden';
 export * from './src/cookieUtils';
 export { periodFormat } from './src/periodUtils';
+export { vedleggNedlastingsnavn } from './src/vedleggUtils';
 export { barnehagestartDato, beregnBarnehagestartDato } from './src/barnehagestartUtils';

--- a/packages/utils/src/vedleggUtils.test.ts
+++ b/packages/utils/src/vedleggUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { vedleggNedlastingsnavn } from './vedleggUtils';
+
+describe('vedleggNedlastingsnavn', () => {
+    it('byter ut png-ending med pdf', () => {
+        expect(vedleggNedlastingsnavn('bilde.png')).toBe('bilde.pdf');
+    });
+
+    it('byter ut jpg-ending med pdf', () => {
+        expect(vedleggNedlastingsnavn('skann.JPG')).toBe('skann.pdf');
+    });
+
+    it('beheld pdf-ending', () => {
+        expect(vedleggNedlastingsnavn('dokument.pdf')).toBe('dokument.pdf');
+    });
+
+    it('legg på pdf når filnamnet manglar ending', () => {
+        expect(vedleggNedlastingsnavn('terminbekreftelse')).toBe('terminbekreftelse.pdf');
+    });
+
+    it('byter berre ut siste ending og beheld punktum i namnet', () => {
+        expect(vedleggNedlastingsnavn('min.fil.2024.png')).toBe('min.fil.2024.pdf');
+    });
+});

--- a/packages/utils/src/vedleggUtils.ts
+++ b/packages/utils/src/vedleggUtils.ts
@@ -1,0 +1,4 @@
+// Backenden konverterer alle opplasta vedlegg (png/jpg) til PDF ved opplasting, så
+// nedlastinga frå mellomlagringa er alltid ei PDF-fil. Vi byter difor ut filendinga
+// med .pdf slik at nedlasta fil får rett innhaldstype og kan opnast.
+export const vedleggNedlastingsnavn = (filnavn: string): string => `${filnavn.replace(/\.[^./\\]+$/, '')}.pdf`;

--- a/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
+++ b/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
@@ -79,7 +79,7 @@ const FARGER = {
     },
 } as const satisfies Record<string, { badge: string; border: string; Icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }> }>;
 
-export type Katalogfarge = keyof typeof FARGER;
+type Katalogfarge = keyof typeof FARGER;
 
 type HeroProps = {
     tittel: string;


### PR DESCRIPTION
- Døyp om ErrorSummaryFp til ErrorSummaryFelles (ikkje FP-spesifikk)
- Gjer vedlegg-filnamn klikkbare i engangsstønad-oppsummeringa
- Fjern to ubrukte eksportar frå fp-steg-arbeidsforhold-og-inntekt
- Fjern utdaterte TODO-kommentarar i planlegger- og foreldrepengesoknad-stories/testar