### PR TITLE
refactor(engangsstonad): gjer stegrekkje til rein funksjon av data

### DIFF
--- a/apps/engangsstonad/src/app-data/useEsNavigator.ts
+++ b/apps/engangsstonad/src/app-data/useEsNavigator.ts
@@ -1,36 +1,45 @@
 import { loggUmamiEvent } from '@navikt/fp-observability';
 
-import { ContextDataType, useContextSaveData } from './EsDataContext';
+import { ContextDataMap, ContextDataType, useContextGetAnyData, useContextSaveData } from './EsDataContext';
 import { Path } from './paths';
-import { useStepConfig } from './useStepConfig';
+import { lagAppStegliste, useCurrentPath } from './useStepConfig';
 
 export const useEsNavigator = (mellomlagreOgNaviger: () => Promise<void>) => {
-    const stepConfig = useStepConfig();
+    const getStateData = useContextGetAnyData();
+    const currentPath = useCurrentPath();
     const oppdaterPath = useContextSaveData(ContextDataType.CURRENT_PATH);
 
-    const goToPreviousDefaultStep = () => {
-        const index = stepConfig.findIndex((s) => s.isSelected) - 1;
-        const previousPath = stepConfig[index]?.id ?? Path.VELKOMMEN;
-        oppdaterPath(previousPath);
-        void mellomlagreOgNaviger();
-    };
+    // Bygg ein getter som let kallande steg overstyre data det nettopp har lagra.
+    // Dette trengst fordi context-dispatch i same handler enno ikkje er reflektert
+    // i `getStateData`, og vi vil rekne neste steg ut frå ferske verdiar.
+    const medFerskeData =
+        (oppdatert: Partial<ContextDataMap>) =>
+        <TYPE extends ContextDataType>(key: TYPE): ContextDataMap[TYPE] =>
+            key in oppdatert ? oppdatert[key] : getStateData(key);
 
-    const goToNextStep = (path: Path) => {
+    const naviger = (path: Path | undefined) => {
         oppdaterPath(path);
         void mellomlagreOgNaviger();
     };
 
-    const goToNextDefaultStep = () => {
-        const index = stepConfig.findIndex((s) => s.isSelected) + 1;
-        const nextPath = stepConfig[index]?.id;
+    const goToNextDefaultStep = (oppdatertData: Partial<ContextDataMap> = {}) => {
+        const stegliste = lagAppStegliste(medFerskeData(oppdatertData));
+        const index = stegliste.indexOf(currentPath) + 1;
+        naviger(stegliste[index]);
+    };
 
-        oppdaterPath(nextPath);
-        void mellomlagreOgNaviger();
+    const goToPreviousDefaultStep = () => {
+        const stegliste = lagAppStegliste(getStateData);
+        const index = stegliste.indexOf(currentPath) - 1;
+        naviger(stegliste[index] ?? Path.VELKOMMEN);
+    };
+
+    const goToStep = (path: Path) => {
+        naviger(path);
     };
 
     const avbrytSøknad = () => {
-        oppdaterPath(undefined);
-        void mellomlagreOgNaviger();
+        naviger(undefined);
     };
 
     const fortsettSøknadSenere = () => {
@@ -40,8 +49,8 @@ export const useEsNavigator = (mellomlagreOgNaviger: () => Promise<void>) => {
 
     return {
         goToPreviousDefaultStep,
-        goToNextStep,
         goToNextDefaultStep,
+        goToStep,
         avbrytSøknad,
         fortsettSøknadSenere,
     };

--- a/apps/engangsstonad/src/app-data/useEsNavigator.ts
+++ b/apps/engangsstonad/src/app-data/useEsNavigator.ts
@@ -1,6 +1,8 @@
+import { useEffect, useRef, useState } from 'react';
+
 import { loggUmamiEvent } from '@navikt/fp-observability';
 
-import { ContextDataMap, ContextDataType, useContextGetAnyData, useContextSaveData } from './EsDataContext';
+import { ContextDataType, useContextGetAnyData, useContextSaveData } from './EsDataContext';
 import { Path } from './paths';
 import { lagAppStegliste, useCurrentPath } from './useStepConfig';
 
@@ -9,37 +11,50 @@ export const useEsNavigator = (mellomlagreOgNaviger: () => Promise<void>) => {
     const currentPath = useCurrentPath();
     const oppdaterPath = useContextSaveData(ContextDataType.CURRENT_PATH);
 
-    // Bygg ein getter som let kallande steg overstyre data det nettopp har lagra.
-    // Dette trengst fordi context-dispatch i same handler enno ikkje er reflektert
-    // i `getStateData`, og vi vil rekne neste steg ut frå ferske verdiar.
-    const medFerskeData =
-        (oppdatert: Partial<ContextDataMap>) =>
-        <TYPE extends ContextDataType>(key: TYPE): ContextDataMap[TYPE] =>
-            key in oppdatert ? oppdatert[key] : getStateData(key);
+    // Vi kan ikkje rekne ut neste/forrige steg synkront, fordi kallande steg ofte
+    // dispatcher context-oppdateringar (t.d. oppdaterOmBarnet) i same handler.
+    // Vi triggar derfor ein effekt med eit sekvensnummer; effekten køyrer etter
+    // neste render og les då ferske data via `getStateData`. Steget treng berre
+    // oppdatere context som vanleg og deretter kalle goToNextDefaultStep().
+    const retningRef = useRef<'neste' | 'forrige' | null>(null);
+    const [seq, setSeq] = useState(0);
 
-    const naviger = (path: Path | undefined) => {
+    const navigerTilDefaultSteg = (retning: 'neste' | 'forrige') => {
+        retningRef.current = retning;
+        setSeq((s) => s + 1);
+    };
+
+    useEffect(() => {
+        const retning = retningRef.current;
+        if (retning === null) {
+            return;
+        }
+        retningRef.current = null;
+
+        const stegliste = lagAppStegliste(getStateData);
+        const index = stegliste.indexOf(currentPath);
+        const nestePath = retning === 'neste' ? stegliste[index + 1] : (stegliste[index - 1] ?? Path.VELKOMMEN);
+
+        oppdaterPath(nestePath);
+        void mellomlagreOgNaviger();
+    }, [seq, getStateData, currentPath, oppdaterPath, mellomlagreOgNaviger]);
+
+    const goToNextDefaultStep = () => {
+        navigerTilDefaultSteg('neste');
+    };
+
+    const goToPreviousDefaultStep = () => {
+        navigerTilDefaultSteg('forrige');
+    };
+
+    const goToStep = (path: Path) => {
         oppdaterPath(path);
         void mellomlagreOgNaviger();
     };
 
-    const goToNextDefaultStep = (oppdatertData: Partial<ContextDataMap> = {}) => {
-        const stegliste = lagAppStegliste(medFerskeData(oppdatertData));
-        const index = stegliste.indexOf(currentPath) + 1;
-        naviger(stegliste[index]);
-    };
-
-    const goToPreviousDefaultStep = () => {
-        const stegliste = lagAppStegliste(getStateData);
-        const index = stegliste.indexOf(currentPath) - 1;
-        naviger(stegliste[index] ?? Path.VELKOMMEN);
-    };
-
-    const goToStep = (path: Path) => {
-        naviger(path);
-    };
-
     const avbrytSøknad = () => {
-        naviger(undefined);
+        oppdaterPath(undefined);
+        void mellomlagreOgNaviger();
     };
 
     const fortsettSøknadSenere = () => {

--- a/apps/engangsstonad/src/app-data/useStepConfig.ts
+++ b/apps/engangsstonad/src/app-data/useStepConfig.ts
@@ -7,6 +7,8 @@ import { notEmpty } from '@navikt/fp-validation';
 import { ContextDataMap, ContextDataType, useContextGetAnyData } from './EsDataContext';
 import { PATH_ORDER, Path, REQUIRED_APP_STEPS } from './paths';
 
+type GetData = <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE];
+
 const getPathToLabelMap = (intl: IntlShape) => ({
     [Path.SØKERSITUASJON]: intl.formatMessage({ id: 'useStepConfig.Søkersituasjon' }),
     [Path.OM_BARNET]: intl.formatMessage({ id: 'useStepConfig.OmBarnet' }),
@@ -20,88 +22,58 @@ const getPathToLabelMap = (intl: IntlShape) => ({
     [Path.KVITTERING]: '',
 });
 
-const isAfterStep = (previousStepPath: Path, currentStepPath: Path): boolean => {
-    return PATH_ORDER.indexOf(currentStepPath) > PATH_ORDER.indexOf(previousStepPath);
-};
-
-const isVisible = (
-    shouldGoToStep: boolean,
-    dataTypeStep: ContextDataType,
-    previousStepPath: Path,
-    currentPath: Path,
-    getStateData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
-) => {
-    return (shouldGoToStep && isAfterStep(previousStepPath, currentPath)) || !!getStateData(dataTypeStep);
-};
-
-const showUtenlandsoppholdStep = (
-    path: Path,
-    currentPath: Path,
-    getData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
-): boolean => {
+const skalViseUtenlandsoppholdSteg = (path: Path, getData: GetData): boolean => {
+    const utenlandsopphold = getData(ContextDataType.UTENLANDSOPPHOLD);
     if (path === Path.TIDLIGERE_UTENLANDSOPPHOLD) {
-        const utenlandsopphold = getData(ContextDataType.UTENLANDSOPPHOLD);
-        const boddErSatt = !!utenlandsopphold?.harBoddUtenforNorgeSiste12Mnd;
-        return isVisible(
-            boddErSatt,
-            ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE,
-            Path.UTENLANDSOPPHOLD,
-            currentPath,
-            getData,
-        );
+        return utenlandsopphold?.harBoddUtenforNorgeSiste12Mnd === true;
     }
     if (path === Path.SENERE_UTENLANDSOPPHOLD) {
-        const utenlandsopphold = getData(ContextDataType.UTENLANDSOPPHOLD);
-        const skalBoErSatt = !!utenlandsopphold?.skalBoUtenforNorgeNeste12Mnd;
-        return isVisible(
-            skalBoErSatt,
-            ContextDataType.UTENLANDSOPPHOLD_SENERE,
-            Path.UTENLANDSOPPHOLD,
-            currentPath,
-            getData,
-        );
+        return utenlandsopphold?.skalBoUtenforNorgeNeste12Mnd === true;
     }
     return false;
 };
 
-const showDokumentasjonStep = (
-    path: Path,
-    currentPath: Path,
-    getStateData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
-): boolean => {
-    const barn = getStateData(ContextDataType.OM_BARNET);
-    if (path === Path.TERMINBEKREFTELSE && barn?.type === 'termin') {
-        return isVisible(true, ContextDataType.DOKUMENTASJON, Path.OM_BARNET, currentPath, getStateData);
+const skalViseDokumentasjonSteg = (path: Path, getData: GetData): boolean => {
+    const barn = getData(ContextDataType.OM_BARNET);
+    if (path === Path.TERMINBEKREFTELSE) {
+        return barn?.type === 'termin';
     }
-    if (path === Path.ADOPSJONSBEKREFTELSE && barn?.type === 'adopsjon') {
-        return isVisible(true, ContextDataType.DOKUMENTASJON, Path.OM_BARNET, currentPath, getStateData);
+    if (path === Path.ADOPSJONSBEKREFTELSE) {
+        return barn?.type === 'adopsjon';
     }
     return false;
+};
+
+/**
+ * Rein utleiing av den synlege stegrekkja ut frå søknadsdata åleine.
+ * Same kjelde brukast både til progress-baren (useStepConfig) og til
+ * neste/forrige-navigasjon (useEsNavigator), slik at dei aldri kan sprike.
+ */
+export const lagAppStegliste = (getData: GetData): Path[] =>
+    PATH_ORDER.flatMap((path) =>
+        REQUIRED_APP_STEPS.includes(path) ||
+        skalViseUtenlandsoppholdSteg(path, getData) ||
+        skalViseDokumentasjonSteg(path, getData)
+            ? [path]
+            : [],
+    );
+
+export const useCurrentPath = (): Path => {
+    const location = useLocation();
+    return useMemo(
+        () => notEmpty(Object.values(Path).find((v: string) => v === decodeURIComponent(location.pathname))),
+        [location.pathname],
+    );
 };
 
 export const useStepConfig = () => {
     const intl = useIntl();
     const pathToLabelMap = getPathToLabelMap(intl);
 
-    const location = useLocation();
+    const currentPath = useCurrentPath();
     const getStateData = useContextGetAnyData();
 
-    const currentPath = useMemo(
-        () => notEmpty(Object.values(Path).find((v: string) => v === decodeURIComponent(location.pathname))),
-        [location.pathname],
-    );
-
-    const appPathList = useMemo(
-        () =>
-            PATH_ORDER.flatMap((path) =>
-                REQUIRED_APP_STEPS.includes(path) ||
-                showUtenlandsoppholdStep(path, currentPath, getStateData) ||
-                showDokumentasjonStep(path, currentPath, getStateData)
-                    ? [path]
-                    : [],
-            ),
-        [currentPath, getStateData],
-    );
+    const appPathList = useMemo(() => lagAppStegliste(getStateData), [getStateData]);
 
     return useMemo(
         () =>

--- a/apps/engangsstonad/src/app-data/useStepConfig.ts
+++ b/apps/engangsstonad/src/app-data/useStepConfig.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 
+import { erTerminDokumentasjon } from 'types/Dokumentasjon';
+
 import { notEmpty } from '@navikt/fp-validation';
 
 import { ContextDataMap, ContextDataType, useContextGetAnyData } from './EsDataContext';
@@ -25,21 +27,25 @@ const getPathToLabelMap = (intl: IntlShape) => ({
 const skalViseUtenlandsoppholdSteg = (path: Path, getData: GetData): boolean => {
     const utenlandsopphold = getData(ContextDataType.UTENLANDSOPPHOLD);
     if (path === Path.TIDLIGERE_UTENLANDSOPPHOLD) {
-        return utenlandsopphold?.harBoddUtenforNorgeSiste12Mnd === true;
+        const erValgt = utenlandsopphold?.harBoddUtenforNorgeSiste12Mnd === true;
+        return erValgt || !!getData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     }
     if (path === Path.SENERE_UTENLANDSOPPHOLD) {
-        return utenlandsopphold?.skalBoUtenforNorgeNeste12Mnd === true;
+        const erValgt = utenlandsopphold?.skalBoUtenforNorgeNeste12Mnd === true;
+        return erValgt || !!getData(ContextDataType.UTENLANDSOPPHOLD_SENERE);
     }
     return false;
 };
 
 const skalViseDokumentasjonSteg = (path: Path, getData: GetData): boolean => {
     const barn = getData(ContextDataType.OM_BARNET);
+    const dokumentasjon = getData(ContextDataType.DOKUMENTASJON);
+    const harVedlegg = !!dokumentasjon && dokumentasjon.vedlegg.length > 0;
     if (path === Path.TERMINBEKREFTELSE) {
-        return barn?.type === 'termin';
+        return barn?.type === 'termin' || (harVedlegg && erTerminDokumentasjon(dokumentasjon));
     }
     if (path === Path.ADOPSJONSBEKREFTELSE) {
-        return barn?.type === 'adopsjon';
+        return barn?.type === 'adopsjon' || (harVedlegg && !erTerminDokumentasjon(dokumentasjon));
     }
     return false;
 };
@@ -48,6 +54,11 @@ const skalViseDokumentasjonSteg = (path: Path, getData: GetData): boolean => {
  * Rein utleiing av den synlege stegrekkja ut frå søknadsdata åleine.
  * Same kjelde brukast både til progress-baren (useStepConfig) og til
  * neste/forrige-navigasjon (useEsNavigator), slik at dei aldri kan sprike.
+ *
+ * Eit betinga steg er synleg dersom svaret er valt ELLER det finst lagra data
+ * for steget. Det held stegsettet monotont (steget du står på finst alltid i
+ * lista, så Step ikkje kastar «Ingen valgte steg funnet»), og sikrar at data
+ * som faktisk blir sendt i useEsSendSøknad alltid kan sjåast/redigerast.
  */
 export const lagAppStegliste = (getData: GetData): Path[] =>
     PATH_ORDER.flatMap((path) =>

--- a/apps/engangsstonad/src/app-data/useStepConfig.ts
+++ b/apps/engangsstonad/src/app-data/useStepConfig.ts
@@ -40,12 +40,17 @@ const skalViseUtenlandsoppholdSteg = (path: Path, getData: GetData): boolean => 
 const skalViseDokumentasjonSteg = (path: Path, getData: GetData): boolean => {
     const barn = getData(ContextDataType.OM_BARNET);
     const dokumentasjon = getData(ContextDataType.DOKUMENTASJON);
-    const harVedlegg = !!dokumentasjon && dokumentasjon.vedlegg.length > 0;
     if (path === Path.TERMINBEKREFTELSE) {
-        return barn?.type === 'termin' || (harVedlegg && erTerminDokumentasjon(dokumentasjon));
+        return (
+            barn?.type === 'termin' ||
+            (!!dokumentasjon && dokumentasjon.vedlegg.length > 0 && erTerminDokumentasjon(dokumentasjon))
+        );
     }
     if (path === Path.ADOPSJONSBEKREFTELSE) {
-        return barn?.type === 'adopsjon' || (harVedlegg && !erTerminDokumentasjon(dokumentasjon));
+        return (
+            barn?.type === 'adopsjon' ||
+            (!!dokumentasjon && dokumentasjon.vedlegg.length > 0 && !erTerminDokumentasjon(dokumentasjon))
+        );
     }
     return false;
 };

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.tsx
@@ -60,7 +60,7 @@ export const DokumentasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'Søknad.Pageheading' })}>
-            <Step onStepChange={void navigator.goToNextStep} steps={stepConfig} noFieldsRequired>
+            <Step onStepChange={navigator.goToStep} steps={stepConfig} noFieldsRequired>
                 <RhfForm formMethods={formMethods} onSubmit={lagre}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -1,4 +1,4 @@
-import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
+import { ContextDataMap, ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
@@ -39,10 +39,12 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
     const onSubmit = (formValues: FormValues) => {
         const barnDto = mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon);
         oppdaterOmBarnet(barnDto);
+        const ferskeData: Partial<ContextDataMap> = { [ContextDataType.OM_BARNET]: barnDto };
         if (formValues.erBarnetFødt === true) {
             oppdaterDokumentasjon(undefined);
+            ferskeData[ContextDataType.DOKUMENTASJON] = undefined;
         }
-        return navigator.goToNextDefaultStep({ [ContextDataType.OM_BARNET]: barnDto });
+        return navigator.goToNextDefaultStep(ferskeData);
     };
 
     const formMethods = useForm<FormValues>({

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -1,5 +1,4 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
-import { Path } from 'appData/paths';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
@@ -38,11 +37,12 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
         oppdaterOmBarnet(mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon));
 
     const onSubmit = (formValues: FormValues) => {
-        mapOgLagreOmBarnet(formValues);
+        const barnDto = mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon);
+        oppdaterOmBarnet(barnDto);
         if (formValues.erBarnetFødt === true) {
             oppdaterDokumentasjon(undefined);
         }
-        return navigator.goToNextStep(utledNesteSteg(formValues, søkersituasjon));
+        return navigator.goToNextDefaultStep({ [ContextDataType.OM_BARNET]: barnDto });
     };
 
     const formMethods = useForm<FormValues>({
@@ -51,7 +51,7 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'Søknad.Pageheading' })}>
-            <Step onStepChange={navigator.goToNextStep} steps={stepConfig}>
+            <Step onStepChange={navigator.goToStep} steps={stepConfig}>
                 <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />
@@ -68,16 +68,6 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
             </Step>
         </SkjemaRotLayout>
     );
-};
-
-const utledNesteSteg = (formValues: FormValues, søkersituasjon: Søkersituasjon) => {
-    if (søkersituasjon.situasjon === 'adopsjon') {
-        return Path.ADOPSJONSBEKREFTELSE;
-    }
-    if (!formValues.erBarnetFødt && formValues.termindato !== undefined) {
-        return Path.TERMINBEKREFTELSE;
-    }
-    return Path.UTENLANDSOPPHOLD;
 };
 
 const resolveAntallBarn = (formValues: FormValues) =>

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.tsx
@@ -1,4 +1,4 @@
-import { ContextDataMap, ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
+import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
@@ -37,14 +37,11 @@ export const OmBarnetSteg = ({ kjønn, mellomlagreOgNaviger }: Props) => {
         oppdaterOmBarnet(mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon));
 
     const onSubmit = (formValues: FormValues) => {
-        const barnDto = mapBarnFraFormTilDto(formValues, søkersituasjon.situasjon);
-        oppdaterOmBarnet(barnDto);
-        const ferskeData: Partial<ContextDataMap> = { [ContextDataType.OM_BARNET]: barnDto };
+        mapOgLagreOmBarnet(formValues);
         if (formValues.erBarnetFødt === true) {
             oppdaterDokumentasjon(undefined);
-            ferskeData[ContextDataType.DOKUMENTASJON] = undefined;
         }
-        return navigator.goToNextDefaultStep(ferskeData);
+        return navigator.goToNextDefaultStep();
     };
 
     const formMethods = useForm<FormValues>({

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.tsx
@@ -35,18 +35,18 @@ export const OppsummeringSteg = ({ sendSøknad, mellomlagreOgNaviger }: Props) =
                 onAvsluttOgSlett={navigator.avbrytSøknad}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
             >
                 <OmBarnetOppsummering
                     omBarnet={omBarnet}
-                    onVilEndreSvar={() => navigator.goToNextStep(Path.OM_BARNET)}
+                    onVilEndreSvar={() => navigator.goToStep(Path.OM_BARNET)}
                 />
                 <BoIUtlandetOppsummering
-                    onVilEndreSvar={() => navigator.goToNextStep(Path.UTENLANDSOPPHOLD)}
+                    onVilEndreSvar={() => navigator.goToStep(Path.UTENLANDSOPPHOLD)}
                     tidligereUtenlandsopphold={tidligereUtenlandsopphold ?? []}
                     senereUtenlandsopphold={senereUtenlandsopphold ?? []}
                 />
-                <DokumentasjonOppsummering dokumentasjon={dokumentasjon} onVilEndreSvar={navigator.goToNextStep} />
+                <DokumentasjonOppsummering dokumentasjon={dokumentasjon} onVilEndreSvar={navigator.goToStep} />
             </OppsummeringPanel>
         </SkjemaRotLayout>
     );

--- a/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.tsx
@@ -39,7 +39,7 @@ export const SøkersituasjonSteg = ({ mellomlagreOgNaviger }: Props) => {
 
     return (
         <SkjemaRotLayout pageTitle={intl.formatMessage({ id: 'Søknad.Pageheading' })}>
-            <Step onStepChange={navigator.goToNextStep} steps={stepConfig}>
+            <Step onStepChange={navigator.goToStep} steps={stepConfig}>
                 <RhfForm formMethods={formMethods} onSubmit={lagre}>
                     <VStack gap="space-40">
                         <ErrorSummaryHookForm />

--- a/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -31,7 +31,7 @@ export const SenereUtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) => {
                 saveOnNext={lagre}
                 saveOnPrevious={oppdaterSenereUtenlandsopphold}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 onAvsluttOgSlett={navigator.avbrytSøknad}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}

--- a/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -1,5 +1,4 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
-import { Path } from 'appData/paths';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
@@ -7,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import { TidligereUtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
 import { UtenlandsoppholdPeriode } from '@navikt/fp-types';
 import { SkjemaRotLayout } from '@navikt/fp-ui';
-import { notEmpty } from '@navikt/fp-validation';
 
 type Props = {
     mellomlagreOgNaviger: () => Promise<void>;
@@ -17,15 +15,12 @@ export const TidligereUtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) =
     const stepConfig = useStepConfig();
     const navigator = useEsNavigator(mellomlagreOgNaviger);
 
-    const utenlandsopphold = notEmpty(useContextGetData(ContextDataType.UTENLANDSOPPHOLD));
     const tidligereUtenlandsopphold = useContextGetData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
     const oppdaterTidligereUtenlandsopphold = useContextSaveData(ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE);
 
     const lagre = (formValues: UtenlandsoppholdPeriode[]) => {
         oppdaterTidligereUtenlandsopphold(formValues);
-        return navigator.goToNextStep(
-            utenlandsopphold.skalBoUtenforNorgeNeste12Mnd ? Path.SENERE_UTENLANDSOPPHOLD : Path.OPPSUMMERING,
-        );
+        return navigator.goToNextDefaultStep();
     };
 
     return (
@@ -35,7 +30,7 @@ export const TidligereUtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) =
                 saveOnNext={lagre}
                 saveOnPrevious={oppdaterTidligereUtenlandsopphold}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 onAvsluttOgSlett={navigator.avbrytSøknad}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
                 stepConfig={stepConfig}

--- a/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -1,5 +1,4 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
-import { Path } from 'appData/paths';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
@@ -7,13 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import { UtenlandsoppholdPanel } from '@navikt/fp-steg-utenlandsopphold';
 import { Utenlandsopphold } from '@navikt/fp-types';
 import { SkjemaRotLayout } from '@navikt/fp-ui';
-
-const utledNesteSide = (formValues: Utenlandsopphold): Path => {
-    if (formValues?.harBoddUtenforNorgeSiste12Mnd) {
-        return Path.TIDLIGERE_UTENLANDSOPPHOLD;
-    }
-    return formValues?.skalBoUtenforNorgeNeste12Mnd ? Path.SENERE_UTENLANDSOPPHOLD : Path.OPPSUMMERING;
-};
 
 type Props = {
     mellomlagreOgNaviger: () => Promise<void>;
@@ -39,7 +31,7 @@ export const UtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) => {
             oppdaterSenereUtenlandsopphold(undefined);
         }
 
-        return navigator.goToNextStep(utledNesteSide(formValues));
+        return navigator.goToNextDefaultStep({ [ContextDataType.UTENLANDSOPPHOLD]: formValues });
     };
 
     return (
@@ -51,7 +43,7 @@ export const UtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) => {
                 onAvsluttOgSlett={navigator.avbrytSøknad}
                 onFortsettSenere={navigator.fortsettSøknadSenere}
                 goToPreviousStep={navigator.goToPreviousDefaultStep}
-                onStepChange={navigator.goToNextStep}
+                onStepChange={navigator.goToStep}
                 stepConfig={stepConfig}
                 stønadstype="Engangsstønad"
             />

--- a/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -1,4 +1,4 @@
-import { ContextDataMap, ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
+import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
@@ -24,21 +24,14 @@ export const UtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) => {
     const lagre = (formValues: Utenlandsopphold) => {
         oppdaterUtenlandsopphold(formValues);
 
-        // Send dei nullstilte periodene med som ferske data, elles ser lagAppStegliste
-        // framleis dei gamle periodene i context og navigerer til eit steg brukaren
-        // nettopp har svart nei på.
-        const ferskeData: Partial<ContextDataMap> = { [ContextDataType.UTENLANDSOPPHOLD]: formValues };
-
         if (!formValues.harBoddUtenforNorgeSiste12Mnd) {
             oppdaterTidligereUtenlandsopphold(undefined);
-            ferskeData[ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE] = undefined;
         }
         if (!formValues.skalBoUtenforNorgeNeste12Mnd) {
             oppdaterSenereUtenlandsopphold(undefined);
-            ferskeData[ContextDataType.UTENLANDSOPPHOLD_SENERE] = undefined;
         }
 
-        return navigator.goToNextDefaultStep(ferskeData);
+        return navigator.goToNextDefaultStep();
     };
 
     return (

--- a/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -1,4 +1,4 @@
-import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
+import { ContextDataMap, ContextDataType, useContextGetData, useContextSaveData } from 'appData/EsDataContext';
 import { useEsNavigator } from 'appData/useEsNavigator';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
@@ -24,14 +24,21 @@ export const UtenlandsoppholdSteg = ({ mellomlagreOgNaviger }: Props) => {
     const lagre = (formValues: Utenlandsopphold) => {
         oppdaterUtenlandsopphold(formValues);
 
+        // Send dei nullstilte periodene med som ferske data, elles ser lagAppStegliste
+        // framleis dei gamle periodene i context og navigerer til eit steg brukaren
+        // nettopp har svart nei på.
+        const ferskeData: Partial<ContextDataMap> = { [ContextDataType.UTENLANDSOPPHOLD]: formValues };
+
         if (!formValues.harBoddUtenforNorgeSiste12Mnd) {
             oppdaterTidligereUtenlandsopphold(undefined);
+            ferskeData[ContextDataType.UTENLANDSOPPHOLD_TIDLIGERE] = undefined;
         }
         if (!formValues.skalBoUtenforNorgeNeste12Mnd) {
             oppdaterSenereUtenlandsopphold(undefined);
+            ferskeData[ContextDataType.UTENLANDSOPPHOLD_SENERE] = undefined;
         }
 
-        return navigator.goToNextDefaultStep({ [ContextDataType.UTENLANDSOPPHOLD]: formValues });
+        return navigator.goToNextDefaultStep(ferskeData);
     };
 
     return (


### PR DESCRIPTION
Prøver å få samla all utledning av steg på ein stad. Er og ein feil i sentry som kanskje skyldast race conditions rundt å legga data i context og navigasjon. Testar ut i ES først

- Fjernar duplisert utledNesteSide-logikk frå kvart einskilt steg.
- lagAppStegliste (i useStepConfig) er no the single source of truth for kva steg som skal visast og i kva rekkjefølgje, deterministisk basert på søknadsdata.
- Oppdaterer useEsNavigator til å rekne ut neste/førre steg direkte frå steglista.
- Fiksar feil i DokumentasjonSteg der void-operator blokkerte navigasjon frå steget.