### PR TITLE
TFP-6170(uttaksplan): rett opp ikon og sideombrekking i kalender-PDF

### DIFF
--- a/packages/uttaksplan/src/kalender/legend/UttaksplanLegend.tsx
+++ b/packages/uttaksplan/src/kalender/legend/UttaksplanLegend.tsx
@@ -279,7 +279,7 @@ const LabelButton = ({
             tabIndex={!UNSELECTABLE_DAYS.has(info.label) && !readOnly ? 0 : -1}
             disabled={!erKlikkbar}
         >
-            {(info.label === 'FØDSEL' || info.label === 'TERMIN') && (
+            {(info.label === 'FØDSEL' || info.label === 'TERMIN' || info.label === 'ADOPSJON') && (
                 <HStack gap="space-4">
                     <HeartFillIcon aria-hidden color="var(--ax-bg-brand-magenta-strong)" width={25} height={25} />
                     {visTekst && <BodyShort>{label}</BodyShort>}
@@ -291,11 +291,14 @@ const LabelButton = ({
                     {visTekst && <BodyShort>{label}</BodyShort>}
                 </HStack>
             )}
-            {info.label !== 'FØDSEL' && info.label !== 'BARNEHAGEPLASS' && info.label !== 'TERMIN' && (
-                <CalendarLabel color={info.calendarPeriod.color}>
-                    {visTekst && <BodyShort className="text-left">{label}</BodyShort>}
-                </CalendarLabel>
-            )}
+            {info.label !== 'FØDSEL' &&
+                info.label !== 'BARNEHAGEPLASS' &&
+                info.label !== 'TERMIN' &&
+                info.label !== 'ADOPSJON' && (
+                    <CalendarLabel color={info.calendarPeriod.color}>
+                        {visTekst && <BodyShort className="text-left">{label}</BodyShort>}
+                    </CalendarLabel>
+                )}
         </button>
     );
 };

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -18,12 +18,46 @@ const JPEG_KVALITET = 0.7;
 // (columns={{ sm: 1, md: ... }}) gitt ulik layout på små skjermar.
 const RENDER_BREDDE_PX = 1200;
 
+// Dagcellene i kalenderen har media queries som gjer dei høgare på mellomstore
+// skjermar (sjå day.module.css). html2canvas (1.4.1) kopierer dei utrekna
+// stilane frå det opphavlege DOM-et, så ein månad fanga frå mobil kan bli høgare
+// enn frå desktop. Vi tvingar difor desktop-storleik på dagane under fanginga
+// slik at månadane alltid får same høgd uavhengig av kva eining brukaren har.
+const DESKTOP_DAG_HØGD_PX = 30;
+const DESKTOP_DAG_FONT_PX = 14;
+
 interface GenererKalenderPdfParams {
     legendElement: HTMLElement;
     månedElementer: HTMLElement[];
     antallKolonner: 1 | 2 | 3;
     filename: string;
 }
+
+// html2canvas serialiserer kvar inline-SVG til eit frittståande bilete. Då mistar
+// `fill="currentColor"` og CSS-variabel-fargar (color: var(--ax-...)) konteksten
+// si og blir ikkje teikna, slik at ikona (fødsel/termin, barnehage, åtvaring)
+// manglar i PDF-en. Vi løyser difor opp fargane til konkrete rgb-verdiar i klona
+// før fanginga.
+const løysOppIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
+    const originalSvgar = original.querySelectorAll('svg');
+    const kloneSvgar = klone.querySelectorAll('svg');
+
+    kloneSvgar.forEach((kloneSvg, index) => {
+        const originalSvg = originalSvgar[index];
+        if (!originalSvg) {
+            return;
+        }
+
+        const farge = getComputedStyle(originalSvg).color;
+        kloneSvg.style.color = farge;
+
+        kloneSvg.querySelectorAll<SVGElement>('[fill]').forEach((node) => {
+            if (node.getAttribute('fill') === 'currentColor') {
+                node.setAttribute('fill', farge);
+            }
+        });
+    });
+};
 
 const lagBildeAvElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
     html2canvas(element, {
@@ -32,10 +66,18 @@ const lagBildeAvElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
         logging: false,
         backgroundColor: '#ffffff',
         windowWidth: RENDER_BREDDE_PX,
+        onclone: (klonetDokument, klonetElement) => {
+            løysOppIkonFargar(element, klonetElement);
+
+            // Nøytraliser dei responsive dag-høgdene slik at fanginga alltid
+            // brukar desktop-layout, uavhengig av brukarens viewport.
+            const style = klonetDokument.createElement('style');
+            style.textContent = `[data-testid^="day:"]{height:${DESKTOP_DAG_HØGD_PX}px !important;font-size:${DESKTOP_DAG_FONT_PX}px !important;}`;
+            klonetDokument.head.appendChild(style);
+        },
     });
 
-const høgdeForBredde = (canvas: HTMLCanvasElement, bredde: number): number =>
-    (bredde * canvas.height) / canvas.width;
+const høgdeForBredde = (canvas: HTMLCanvasElement, bredde: number): number => (bredde * canvas.height) / canvas.width;
 
 /**
  * Genererer ein PDF av uttaksplan-kalenderen der kvar månad blir teikna som eit
@@ -57,6 +99,10 @@ export const genererKalenderPdf = async ({
 
     const tilgjengeligBredde = A4_BREDDE_MM - 2 * MARGIN_MM;
     const sideBunn = A4_HØGDE_MM - MARGIN_MM;
+    // Høgda som er tilgjengeleg for innhald på éi side. Eit einskild bilete som
+    // er høgare enn dette må skalerast ned, elles ville jsPDF teikna det utanfor
+    // sidekanten og biletet blei kutta over sideskiftet.
+    const maksInnhaldsHøgd = A4_HØGDE_MM - 2 * MARGIN_MM;
 
     let y = MARGIN_MM;
 
@@ -71,10 +117,16 @@ export const genererKalenderPdf = async ({
         );
     };
 
-    // Forklaringa (legend) øvst på første side.
+    // Forklaringa (legend) øvst på første side. Skaler ned dersom ho er høgare
+    // enn ei heil side slik at ho ikkje blir kutta.
     const legendCanvas = await lagBildeAvElement(legendElement);
-    leggTilBilete(legendCanvas, MARGIN_MM, y, tilgjengeligBredde);
-    y += høgdeForBredde(legendCanvas, tilgjengeligBredde) + RAD_GAP_MM;
+    const legendNaturligHøgd = høgdeForBredde(legendCanvas, tilgjengeligBredde);
+    const legendBredde =
+        legendNaturligHøgd > maksInnhaldsHøgd
+            ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
+            : tilgjengeligBredde;
+    leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde);
+    y += høgdeForBredde(legendCanvas, legendBredde) + RAD_GAP_MM;
 
     const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
 
@@ -86,7 +138,13 @@ export const genererKalenderPdf = async ({
         const radElementer = månedElementer.slice(i, i + antallKolonner);
         const radCanvaser = await Promise.all(radElementer.map(lagBildeAvElement));
 
-        const radHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
+        // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei
+        // side. Då held alle månadane i raden same breidde, men blir smalare
+        // slik at den høgaste får plass på éi side og ikkje blir kutta.
+        const naturligRadHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
+        const radBredde =
+            naturligRadHøgde > maksInnhaldsHøgd ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde : kolonneBredde;
+        const radHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, radBredde)));
 
         // Start ny side dersom heile raden ikkje får plass på resten av sida.
         if (y + radHøgde > sideBunn) {
@@ -96,7 +154,7 @@ export const genererKalenderPdf = async ({
 
         radCanvaser.forEach((canvas, kolonne) => {
             const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
-            leggTilBilete(canvas, x, y, kolonneBredde);
+            leggTilBilete(canvas, x, y, radBredde);
         });
 
         y += radHøgde + RAD_GAP_MM;


### PR DESCRIPTION
Følgjer opp TFP-6170 med tre feilrettingar i den nye PDF-genereringa:

https://jira.adeo.no/browse/TFP-6170

- Ikon for fødsel/termin og barnehage (og dag-ikona i kalenderen) mangla i PDF-en. html2canvas serialiserer kvar inline-SVG til eit frittståande bilete, og då blir fill="currentColor" / CSS-variabel-fargar ikkje løyst opp. Ein onclone-callback les no den utrekna fargen og set han som konkret rgb-verdi på SVG-stiane før fanginga.

- Månadane kunne framleis bli delte over sider når PDF-en blei generert frå mobil. Dagcellene har media queries som gjer dei høgare på mellomstore skjermar, og html2canvas kopierer dei utrekna stilane frå live-DOM-et. onclone tvingar no desktop-høgd på dagane slik at layouten blir deterministisk uavhengig av viewport.

- Som ekstra sikring blir legend og kvar månadsrad skalert ned dersom dei er høgare enn det printbare området, slik at eit bilete aldri blir teikna utanfor sidekanten og kutta over eit sideskift.