### PR TITLE
TFP-6170(uttaksplan): rett ikonfargar i prod og raskare kalender-PDF

### DIFF
--- a/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
+++ b/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
@@ -39,13 +39,9 @@ export const KalenderPdf = ({
 
         setIsCreatingPdf(true);
         try {
-            const månedElementer = Array.from(
-                kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'),
-            );
-
             await genererKalenderPdf({
                 legendElement,
-                månedElementer,
+                kalenderElement,
                 antallKolonner,
                 filename: 'Min foreldrepengeplan.pdf',
             });

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -13,11 +13,27 @@ const RAD_GAP_MM = 4;
 const SKALA = 1.5;
 const JPEG_KVALITET = 0.7;
 
+// Maks pikslar på lengste kant for eit enkelt canvas. Held vi oss under dette,
+// unngår vi nettlesarane sine canvas-grenser (som elles kan gi blankt bilete
+// eller krasj på lange planar). Blir ein bit likevel for stor, skalerer vi ned
+// fanginga av den biten dynamisk.
+const MAKS_CANVAS_KANT_PX = 8000;
+
+// Kor mange PDF-rader vi fangar i éi html2canvas-fanging. Vi fangar bitvis i
+// staden for heile kalenderen på éin gong, slik at canvas-storleiken og minne-
+// bruken blir avgrensa sjølv for lange planar (opptil 3 år), samtidig som vi
+// slepp å kalle html2canvas (som klonar heile dokumentet) éin gong per månad.
+const RADER_PER_BIT = 3;
+
+// Månadane blir rendra i ein desktop-stor offscreen-container med fast
+// kolonnebreidde, slik at PDF-en blir lik uavhengig av brukarens viewport.
+// (Calendar-grid-et er elles responsivt: 1 kolonne på smale skjermar.)
+const MND_BREDDE_PX = 400;
+const MND_GAP_PX = 12;
+
 // Dagcellene i kalenderen har media queries som gjer dei høgare på mellomstore
-// skjermar (sjå day.module.css). For at PDF-en skal bli lik uavhengig av kva
-// eining brukaren har, tvingar vi desktop-storleik på dagane medan vi fangar.
-// Stilen blir lagt på det *levande* DOM-et slik at posisjonane vi måler stemmer
-// med biletet html2canvas lagar.
+// skjermar (sjå day.module.css). Vi tvingar desktop-storleik på dagane medan vi
+// fangar, slik at høgda blir deterministisk uavhengig av viewport.
 const DESKTOP_DAG_HØGD_PX = 30;
 const DESKTOP_DAG_FONT_PX = 14;
 const DAG_HØGD_STYLE = `[data-testid^="day:"]{height:${DESKTOP_DAG_HØGD_PX}px !important;font-size:${DESKTOP_DAG_FONT_PX}px !important;}`;
@@ -42,7 +58,7 @@ interface Rektangel {
 // løyst opp – difor mangla/feila ikona i PDF-en. var() i SVG-presentasjons-
 // attributt blir dessutan ikkje løyst likt i alle nettlesarar, noko som gjorde
 // at det såg rett ut lokalt men feil i prod. Vi løyser difor variabelen sjølve
-// (frå :root) og set ein konkret rgb-verdi som fill før fanginga.
+// og set ein konkret rgb-verdi som fill før fanginga.
 const løysOppIkonFarge = (svg: SVGElement): string => {
     const computed = getComputedStyle(svg);
     const colorAttr = svg.getAttribute('color')?.trim();
@@ -60,8 +76,9 @@ const løysOppIkonFarge = (svg: SVGElement): string => {
     return computed.color;
 };
 
-// Køyrer på klona (i onclone) og bytter ut `currentColor`/CSS-variabel-fargar med
-// konkrete rgb-verdiar slik at ikona blir rasterisert med rett farge.
+// Byter ut `currentColor`/CSS-variabel-fargar med konkrete rgb-verdiar på klona,
+// slik at ikona blir rasterisert med rett farge. Fargen blir lesen frå det
+// opphavlege (levande) elementet, som har rett tema-kontekst.
 const inlineIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
     const originalSvgar = original.querySelectorAll<SVGElement>('svg');
     const kloneSvgar = klone.querySelectorAll<SVGElement>('svg');
@@ -84,29 +101,50 @@ const inlineIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
     });
 };
 
-const lagBildeAvElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
-    html2canvas(element, {
-        scale: SKALA,
-        useCORS: true,
-        logging: false,
-        backgroundColor: '#ffffff',
-        onclone: (_klonetDokument, klonetElement) => {
-            inlineIkonFargar(element, klonetElement);
-        },
-    });
-
 const høgdeForBredde = (bildeBredde: number, bildeHøgde: number, bredde: number): number =>
     (bredde * bildeHøgde) / bildeBredde;
 
-// Klypp ut eitt rektangel (ein månad) frå det samla kalender-biletet til eit eige
-// canvas. Då slepp vi å kalle html2canvas (som klonar heile dokumentet) éin gong
-// per månad, samtidig som kvar månad framleis blir eit sjølvstendig bilete vi kan
-// paginere utan å dele han over to sider.
-const klyppUtRektangel = (kjelde: HTMLCanvasElement, rekt: Rektangel): HTMLCanvasElement => {
-    const sx = Math.round(rekt.x * SKALA);
-    const sy = Math.round(rekt.y * SKALA);
-    const sb = Math.round(rekt.bredde * SKALA);
-    const sh = Math.round(rekt.høgde * SKALA);
+// Vel ein skala som held det ferdige canvas-et innanfor nettlesaren si
+// canvas-grense, men aldri høgare enn ynskt SKALA.
+const veljSkala = (breddePx: number, høgdePx: number): number => {
+    const maksKant = Math.max(breddePx, høgdePx);
+    if (maksKant * SKALA <= MAKS_CANVAS_KANT_PX) {
+        return SKALA;
+    }
+    return Math.max(MAKS_CANVAS_KANT_PX / maksKant, 0.1);
+};
+
+const lagOffscreenContainer = (forelder: HTMLElement): HTMLDivElement => {
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.left = '-100000px';
+    container.style.top = '0';
+    container.style.backgroundColor = '#ffffff';
+    container.style.width = 'max-content';
+    // Lagt under same forelder som originalen, slik at CSS-variablar (Aksel-tema)
+    // blir arva og fargane blir rett løyste.
+    forelder.appendChild(container);
+    return container;
+};
+
+// Fangar ein offscreen-container til eit canvas, med dynamisk nedskalering som
+// sikring mot for store canvas-dimensjonar.
+const fangContainer = (container: HTMLElement): Promise<HTMLCanvasElement> => {
+    const skala = veljSkala(container.scrollWidth, container.scrollHeight);
+    return html2canvas(container, {
+        scale: skala,
+        useCORS: true,
+        logging: false,
+        backgroundColor: '#ffffff',
+    });
+};
+
+// Klypp ut eitt rektangel (ein månad) frå bit-canvas-et til eit eige canvas.
+const klyppUtRektangel = (kjelde: HTMLCanvasElement, rekt: Rektangel, skala: number): HTMLCanvasElement => {
+    const sx = Math.round(rekt.x * skala);
+    const sy = Math.round(rekt.y * skala);
+    const sb = Math.round(rekt.bredde * skala);
+    const sh = Math.round(rekt.høgde * skala);
 
     const canvas = document.createElement('canvas');
     canvas.width = sb;
@@ -126,10 +164,11 @@ const klyppUtRektangel = (kjelde: HTMLCanvasElement, rekt: Rektangel): HTMLCanva
  * Genererer ein PDF av uttaksplan-kalenderen der kvar månad blir teikna som eit
  * eige bilete og plassert slik at ein månad aldri blir delt over to sider.
  *
- * For å halde genereringstida nede fangar vi heile kalenderen i éi html2canvas-
- * fanging (i staden for éi fanging per månad – html2canvas klonar heile
- * dokumentet for kvar fanging, så det blei svært treigt for lange planar). Deretter
- * klypper vi ut kvar månad frå det samla biletet og paginerer manuelt.
+ * For å halde genereringstida nede unngår vi å kalle html2canvas (som klonar
+ * heile dokumentet) éin gong per månad. I staden rendrar vi månadane i ein
+ * desktop-stor offscreen-container og fangar dei bitvis (nokre rader om gongen).
+ * Det gir få html2canvas-kall, deterministisk desktop-layout, og avgrensa
+ * canvas-storleik/minnebruk sjølv for lange planar.
  */
 export const genererKalenderPdf = async ({
     legendElement,
@@ -146,87 +185,121 @@ export const genererKalenderPdf = async ({
     // sidekanten og biletet blei kutta over sideskiftet.
     const maksInnhaldsHøgd = A4_HØGDE_MM - 2 * MARGIN_MM;
 
-    // Tving desktop-høgd på dagane på det levande DOM-et medan vi måler og fangar,
-    // slik at posisjonane vi måler stemmer med biletet og resultatet blir likt
-    // uavhengig av brukarens viewport.
+    // Tving desktop-høgd på dagane medan vi fangar.
     const dagHøgdStyle = document.createElement('style');
     dagHøgdStyle.textContent = DAG_HØGD_STYLE;
     document.head.appendChild(dagHøgdStyle);
 
-    try {
-        let y = MARGIN_MM;
+    let y = MARGIN_MM;
 
-        const leggTilBilete = (
-            canvas: HTMLCanvasElement,
-            x: number,
-            øvst: number,
-            bredde: number,
-            høgde: number,
-        ): void => {
-            pdf.addImage(canvas.toDataURL('image/jpeg', JPEG_KVALITET), 'JPEG', x, øvst, bredde, høgde);
-        };
+    const leggTilBilete = (canvas: HTMLCanvasElement, x: number, øvst: number, bredde: number, høgde: number): void => {
+        pdf.addImage(canvas.toDataURL('image/jpeg', JPEG_KVALITET), 'JPEG', x, øvst, bredde, høgde);
+    };
 
-        // Forklaringa (legend) øvst på første side. Skaler ned dersom ho er høgare
-        // enn ei heil side slik at ho ikkje blir kutta.
-        const legendCanvas = await lagBildeAvElement(legendElement);
-        const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
-        const legendBredde =
-            legendNaturligHøgd > maksInnhaldsHøgd
-                ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
-                : tilgjengeligBredde;
-        const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
-        leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
-        y += legendHøgd + RAD_GAP_MM;
+    const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
 
-        // Mål kvar månad relativt til kalender-elementet *før* vi fangar, medan
-        // dag-høgd-stilen er aktiv, slik at rektangla stemmer med biletet.
-        const månedElementer = Array.from(kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'));
-        const kalenderRect = kalenderElement.getBoundingClientRect();
-        const månedRektangler: Rektangel[] = månedElementer.map((el) => {
-            const rect = el.getBoundingClientRect();
-            return {
-                x: rect.left - kalenderRect.left,
-                y: rect.top - kalenderRect.top,
-                bredde: rect.width,
-                høgde: rect.height,
-            };
+    // Paginerer og teiknar éi rad (maks `antallKolonner` månadar) inn i PDF-en.
+    // Canvasa blir brukte og sleppte med ein gong, slik at vi ikkje held alle
+    // månadscanvasa i minnet samtidig.
+    const tegnRad = (radCanvaser: HTMLCanvasElement[]): void => {
+        // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei side.
+        const naturligRadHøgde = Math.max(
+            ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, kolonneBredde)),
+        );
+        const radBredde =
+            naturligRadHøgde > maksInnhaldsHøgd ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde : kolonneBredde;
+        const radHøgde = Math.max(
+            ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, radBredde)),
+        );
+
+        if (y + radHøgde > sideBunn) {
+            pdf.addPage('a4', 'portrait');
+            y = MARGIN_MM;
+        }
+
+        radCanvaser.forEach((canvas, kolonne) => {
+            const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
+            leggTilBilete(canvas, x, y, radBredde, høgdeForBredde(canvas.width, canvas.height, radBredde));
         });
 
-        // Éi fanging av heile kalenderen. Vi klypper ut kvar månad etterpå.
-        const kalenderCanvas = await lagBildeAvElement(kalenderElement);
-        const månedCanvaser = månedRektangler.map((rekt) => klyppUtRektangel(kalenderCanvas, rekt));
+        y += radHøgde + RAD_GAP_MM;
+    };
 
-        const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
+    try {
+        // Forklaringa (legend) øvst på første side, fanga i ein desktop-stor
+        // offscreen-container slik at ho ikkje brett seg på smale skjermar.
+        const legendContainer = lagOffscreenContainer(legendElement.parentElement ?? document.body);
+        try {
+            const legendKlone = legendElement.cloneNode(true) as HTMLElement;
+            legendContainer.appendChild(legendKlone);
+            inlineIkonFargar(legendElement, legendKlone);
 
-        for (let i = 0; i < månedCanvaser.length; i += antallKolonner) {
-            const radCanvaser = månedCanvaser.slice(i, i + antallKolonner);
+            const legendCanvas = await fangContainer(legendContainer);
+            const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
+            const legendBredde =
+                legendNaturligHøgd > maksInnhaldsHøgd
+                    ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
+                    : tilgjengeligBredde;
+            const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
+            leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
+            y += legendHøgd + RAD_GAP_MM;
+        } finally {
+            legendContainer.remove();
+        }
 
-            // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei
-            // side. Då held alle månadane i raden same breidde, men blir smalare
-            // slik at den høgaste får plass på éi side og ikkje blir kutta.
-            const naturligRadHøgde = Math.max(
-                ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, kolonneBredde)),
-            );
-            const radBredde =
-                naturligRadHøgde > maksInnhaldsHøgd
-                    ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde
-                    : kolonneBredde;
-            const radHøgde = Math.max(
-                ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, radBredde)),
-            );
+        const månedElementer = Array.from(kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'));
+        const månederPerBit = antallKolonner * RADER_PER_BIT;
 
-            // Start ny side dersom heile raden ikkje får plass på resten av sida.
-            if (y + radHøgde > sideBunn) {
-                pdf.addPage('a4', 'portrait');
-                y = MARGIN_MM;
+        // Fang månadane bitvis. Kvar bit blir rendra i ein eigen offscreen-
+        // container, fanga, klypt opp i månadar og paginert – deretter blir både
+        // container og bit-canvas sleppt før neste bit.
+        for (let i = 0; i < månedElementer.length; i += månederPerBit) {
+            const bitElementer = månedElementer.slice(i, i + månederPerBit);
+            const container = lagOffscreenContainer(kalenderElement.parentElement ?? document.body);
+            container.style.display = 'grid';
+            container.style.gridTemplateColumns = `repeat(${antallKolonner}, ${MND_BREDDE_PX}px)`;
+            container.style.columnGap = `${MND_GAP_PX}px`;
+            container.style.rowGap = `${MND_GAP_PX}px`;
+
+            try {
+                const bitKloner = bitElementer.map((el) => {
+                    const klone = el.cloneNode(true) as HTMLElement;
+                    klone.style.width = `${MND_BREDDE_PX}px`;
+                    klone.style.maxWidth = `${MND_BREDDE_PX}px`;
+                    container.appendChild(klone);
+                    return klone;
+                });
+                bitElementer.forEach((original, index) => inlineIkonFargar(original, bitKloner[index]!));
+
+                const skala = veljSkala(container.scrollWidth, container.scrollHeight);
+                const bitCanvas = await html2canvas(container, {
+                    scale: skala,
+                    useCORS: true,
+                    logging: false,
+                    backgroundColor: '#ffffff',
+                });
+
+                const containerRect = container.getBoundingClientRect();
+                const månedCanvaser = bitKloner.map((klone) => {
+                    const rect = klone.getBoundingClientRect();
+                    return klyppUtRektangel(
+                        bitCanvas,
+                        {
+                            x: rect.left - containerRect.left,
+                            y: rect.top - containerRect.top,
+                            bredde: rect.width,
+                            høgde: rect.height,
+                        },
+                        skala,
+                    );
+                });
+
+                for (let j = 0; j < månedCanvaser.length; j += antallKolonner) {
+                    tegnRad(månedCanvaser.slice(j, j + antallKolonner));
+                }
+            } finally {
+                container.remove();
             }
-
-            radCanvaser.forEach((canvas, kolonne) => {
-                const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
-                leggTilBilete(canvas, x, y, radBredde, høgdeForBredde(canvas.width, canvas.height, radBredde));
-            });
-
-            y += radHøgde + RAD_GAP_MM;
         }
 
         await pdf.save(filename, { returnPromise: true });

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -154,7 +154,7 @@ const løftDagtekst = (celle: HTMLElement): void => {
         const span = celle.ownerDocument.createElement('span');
         span.style.display = 'inline-block';
         span.style.transform = `translateY(-${DAG_TEKST_LØFT_PX}px)`;
-        celle.replaceChild(span, node);
+        node.replaceWith(span);
         span.appendChild(node);
     });
 };

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -56,6 +56,12 @@ const OFFSCREEN_KLASSE = 'fp-pdf-offscreen';
 
 // Line-height vi gir legend-teksten under fanginga (sjå sentrerTekstForFanging).
 const LEGEND_TEKST_LINE_HØGD_PX = 24;
+// Same baseline-skeivskap som for dagtala: html2canvas teiknar legend-teksten
+// litt for langt ned i forhold til fargeruta ved sida. (Det synte ikkje før, då
+// heile legenden låg på éi brei line som blei kraftig nedskalert; no når teksten
+// står i naturleg storleik blir avviket synleg.) Vi dyttar teksten tilsvarande
+// opp, slik at han hamnar på linje med midten av fargeruta.
+const LEGEND_TEKST_LØFT_PX = 4;
 // Litt loddrett luft rundt legenden, slik at teksten ikkje blir klypt sjølv om
 // html2canvas teiknar han litt lågt.
 const LEGEND_PADDING_PX = 4;
@@ -167,9 +173,13 @@ const sentrerTekstForFanging = (klone: HTMLElement): void => {
     });
 
     // Legend-tekst (Aksel BodyShort = <p>): same line-height-triks så teksten
-    // blir sentrert ved sida av fargeruta og ikkje klypt i botnen.
+    // blir sentrert ved sida av fargeruta, og same løft opp som dagtala for å
+    // rette html2canvas sin baseline-skeivskap. (Berre legenden har <p>;
+    // månadane bruker Heading/div, så dette påverkar ikkje kalenderen.)
     klone.querySelectorAll<HTMLElement>('p').forEach((tekst) => {
         tekst.style.lineHeight = `${LEGEND_TEKST_LINE_HØGD_PX}px`;
+        tekst.style.display = 'inline-block';
+        tekst.style.transform = `translateY(-${LEGEND_TEKST_LØFT_PX}px)`;
     });
 
     // Litt luft mellom vekedag-overskriftene og første veke, slik at fargane i

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -37,6 +37,19 @@ const MND_GAP_PX = 12;
 const DESKTOP_DAG_HØGD_PX = 30;
 const DESKTOP_DAG_FONT_PX = 14;
 
+// html2canvas teiknar tekst etter alfabetisk baseline (bounds.top + baseline) og
+// bommar då litt under det optiske midten – sjølv med line-height lik cellehøgda
+// sig dagtalet ~4 px ned. Vi pakkar difor talet i ein span og dyttar han denne
+// avstanden opp att, så talet hamnar midt i den farga firkanten i fanginga.
+const DAG_TEKST_LØFT_PX = 4;
+
+// Breidda vi rendrar forklaringa (legend) i før fanging. Utan ei fast breidde
+// ville HStack-en leggje alle etikettane på éi svært brei linje, og når biletet
+// så blir skalert ned til sidebreidda blir teksten liten. Med denne breidda
+// (≈ to månadskolonnar) brett legenden seg over fleire linjer og får same
+// tekststorleik som månadane på sida.
+const LEGEND_BREDDE_PX = 2 * MND_BREDDE_PX + MND_GAP_PX;
+
 // Klasse som berre offscreen-klonane får, slik at dei aldri påverkar det
 // levande DOM-et i dialogen.
 const OFFSCREEN_KLASSE = 'fp-pdf-offscreen';
@@ -116,21 +129,41 @@ const høgdeForBredde = (bildeBredde: number, bildeHøgde: number, bredde: numbe
 // html2canvas (1.4.1) sentrerer ikkje tekst loddrett slik flexbox/grid gjer –
 // det plasserer teksten etter line-boksen, og teiknar han difor litt for langt
 // ned. Resultatet er at dagtala sig ned i cellene og legend-teksten hamnar lågt
-// og blir klypt. Ved å gi tekst-elementa ein line-height lik høgda på cella si,
-// fyller line-boksen heile høgda, og html2canvas teiknar teksten sentrert.
+// og blir klypt. Vi rettar dette på klonane før fanging: line-height lik høgda
+// fyller line-boksen, og dagtalet blir i tillegg dytta litt opp (sjå under).
 //
-// Vi set stilane *inline på sjølve klonen* (ikkje via eit <style> i <head>).
+// Stilane blir sette *inline på sjølve klonen* (ikkje via eit <style> i <head>).
 // Klonane blir lagde under dialogen/portalen sin DOM, der eit globalt stylesheet
 // ikkje nødvendigvis når fram – inline-stil blir derimot alltid lesen av
 // html2canvas (som måler boksane frå dei verkelege klone-nodane).
+
+// Pakkar dei direkte tekst-noddane (dagtalet) i ein dagcelle inn i ein span som
+// blir dytta litt opp. Ikon-div-en blir ikkje rørt. Dette korrigerer html2canvas
+// sin baseline-skeivskap, slik at talet blir loddrett sentrert i fanginga.
+const løftDagtekst = (celle: HTMLElement): void => {
+    Array.from(celle.childNodes).forEach((node) => {
+        if (node.nodeType !== Node.TEXT_NODE || !node.textContent?.trim()) {
+            return;
+        }
+        const span = celle.ownerDocument.createElement('span');
+        span.style.display = 'inline-block';
+        span.style.transform = `translateY(-${DAG_TEKST_LØFT_PX}px)`;
+        celle.replaceChild(span, node);
+        span.appendChild(node);
+    });
+};
+
 const sentrerTekstForFanging = (klone: HTMLElement): void => {
     // Dagceller: tving deterministisk desktop-storleik og la line-boksen fylle
-    // cella, slik at talet blir loddrett sentrert i fanginga.
+    // cella. I tillegg pakkar vi sjølve dagtalet i ein span og dyttar han litt
+    // opp, slik at html2canvas sin baseline-skeivskap blir korrigert og talet
+    // hamnar midt i den farga firkanten.
     klone.querySelectorAll<HTMLElement>('[data-testid^="day:"]').forEach((celle) => {
         celle.style.height = `${DESKTOP_DAG_HØGD_PX}px`;
         celle.style.minHeight = `${DESKTOP_DAG_HØGD_PX}px`;
         celle.style.fontSize = `${DESKTOP_DAG_FONT_PX}px`;
         celle.style.lineHeight = `${DESKTOP_DAG_HØGD_PX}px`;
+        løftDagtekst(celle);
     });
 
     // Legend-tekst (Aksel BodyShort = <p>): same line-height-triks så teksten
@@ -264,9 +297,12 @@ export const genererKalenderPdf = async ({
         y += radHøgde + RAD_GAP_MM;
     };
 
-    // Forklaringa (legend) øvst på første side, fanga i ein desktop-stor
-    // offscreen-container slik at ho ikkje brett seg på smale skjermar.
+    // Forklaringa (legend) øvst på første side. Vi gir containeren ei fast breidde
+    // (≈ to månadskolonnar) i staden for max-content, slik at etikettane brett seg
+    // over fleire linjer og får same tekststorleik som månadane når biletet blir
+    // skalert til sidebreidda.
     const legendContainer = lagOffscreenContainer(legendElement.parentElement ?? document.body);
+    legendContainer.style.width = `${LEGEND_BREDDE_PX}px`;
     legendContainer.style.padding = `${LEGEND_PADDING_PX}px 0`;
     try {
         const legendKlone = legendElement.cloneNode(true) as HTMLElement;

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -13,34 +13,58 @@ const RAD_GAP_MM = 4;
 const SKALA = 1.5;
 const JPEG_KVALITET = 0.7;
 
-// Tvinga «desktop»-breidde slik at PDF-en blir deterministisk og uavhengig av
-// brukarens viewport. Utan dette ville Calendar sin responsive breakpoint
-// (columns={{ sm: 1, md: ... }}) gitt ulik layout på små skjermar.
-const RENDER_BREDDE_PX = 1200;
-
 // Dagcellene i kalenderen har media queries som gjer dei høgare på mellomstore
-// skjermar (sjå day.module.css). html2canvas (1.4.1) kopierer dei utrekna
-// stilane frå det opphavlege DOM-et, så ein månad fanga frå mobil kan bli høgare
-// enn frå desktop. Vi tvingar difor desktop-storleik på dagane under fanginga
-// slik at månadane alltid får same høgd uavhengig av kva eining brukaren har.
+// skjermar (sjå day.module.css). For at PDF-en skal bli lik uavhengig av kva
+// eining brukaren har, tvingar vi desktop-storleik på dagane medan vi fangar.
+// Stilen blir lagt på det *levande* DOM-et slik at posisjonane vi måler stemmer
+// med biletet html2canvas lagar.
 const DESKTOP_DAG_HØGD_PX = 30;
 const DESKTOP_DAG_FONT_PX = 14;
+const DAG_HØGD_STYLE = `[data-testid^="day:"]{height:${DESKTOP_DAG_HØGD_PX}px !important;font-size:${DESKTOP_DAG_FONT_PX}px !important;}`;
 
 interface GenererKalenderPdfParams {
     legendElement: HTMLElement;
-    månedElementer: HTMLElement[];
+    kalenderElement: HTMLElement;
     antallKolonner: 1 | 2 | 3;
     filename: string;
 }
 
-// html2canvas serialiserer kvar inline-SVG til eit frittståande bilete. Då mistar
-// `fill="currentColor"` og CSS-variabel-fargar (color: var(--ax-...)) konteksten
-// si og blir ikkje teikna, slik at ikona (fødsel/termin, barnehage, åtvaring)
-// manglar i PDF-en. Vi løyser difor opp fargane til konkrete rgb-verdiar i klona
-// før fanginga.
-const løysOppIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
-    const originalSvgar = original.querySelectorAll('svg');
-    const kloneSvgar = klone.querySelectorAll('svg');
+interface Rektangel {
+    x: number;
+    y: number;
+    bredde: number;
+    høgde: number;
+}
+
+// Aksel-ikona blir teikna med `color="var(--ax-…)"` (ein CSS-variabel) og
+// `fill="currentColor"` på stiane. html2canvas serialiserer kvar inline-SVG til
+// eit frittståande bilete, og då blir verken CSS-variabelen eller currentColor
+// løyst opp – difor mangla/feila ikona i PDF-en. var() i SVG-presentasjons-
+// attributt blir dessutan ikkje løyst likt i alle nettlesarar, noko som gjorde
+// at det såg rett ut lokalt men feil i prod. Vi løyser difor variabelen sjølve
+// (frå :root) og set ein konkret rgb-verdi som fill før fanginga.
+const løysOppIkonFarge = (svg: SVGElement): string => {
+    const computed = getComputedStyle(svg);
+    const colorAttr = svg.getAttribute('color')?.trim();
+    if (colorAttr?.startsWith('var(')) {
+        const variabelnamn = colorAttr.slice(4, -1).split(',')[0]?.trim();
+        if (variabelnamn) {
+            // Les variabelen frå ikonet sin eigen kontekst, slik at han blir løyst
+            // anten tokenet er definert på :root eller på ein Aksel-tema-wrapper.
+            const verdi = computed.getPropertyValue(variabelnamn).trim();
+            if (verdi) {
+                return verdi;
+            }
+        }
+    }
+    return computed.color;
+};
+
+// Køyrer på klona (i onclone) og bytter ut `currentColor`/CSS-variabel-fargar med
+// konkrete rgb-verdiar slik at ikona blir rasterisert med rett farge.
+const inlineIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
+    const originalSvgar = original.querySelectorAll<SVGElement>('svg');
+    const kloneSvgar = klone.querySelectorAll<SVGElement>('svg');
 
     kloneSvgar.forEach((kloneSvg, index) => {
         const originalSvg = originalSvgar[index];
@@ -48,10 +72,11 @@ const løysOppIkonFargar = (original: HTMLElement, klone: HTMLElement): void => 
             return;
         }
 
-        const farge = getComputedStyle(originalSvg).color;
+        const farge = løysOppIkonFarge(originalSvg);
         kloneSvg.style.color = farge;
 
-        kloneSvg.querySelectorAll<SVGElement>('[fill]').forEach((node) => {
+        const fillNoder: Element[] = [kloneSvg, ...kloneSvg.querySelectorAll('[fill]')];
+        fillNoder.forEach((node) => {
             if (node.getAttribute('fill') === 'currentColor') {
                 node.setAttribute('fill', farge);
             }
@@ -65,33 +90,50 @@ const lagBildeAvElement = (element: HTMLElement): Promise<HTMLCanvasElement> =>
         useCORS: true,
         logging: false,
         backgroundColor: '#ffffff',
-        windowWidth: RENDER_BREDDE_PX,
-        onclone: (klonetDokument, klonetElement) => {
-            løysOppIkonFargar(element, klonetElement);
-
-            // Nøytraliser dei responsive dag-høgdene slik at fanginga alltid
-            // brukar desktop-layout, uavhengig av brukarens viewport.
-            const style = klonetDokument.createElement('style');
-            style.textContent = `[data-testid^="day:"]{height:${DESKTOP_DAG_HØGD_PX}px !important;font-size:${DESKTOP_DAG_FONT_PX}px !important;}`;
-            klonetDokument.head.appendChild(style);
+        onclone: (_klonetDokument, klonetElement) => {
+            inlineIkonFargar(element, klonetElement);
         },
     });
 
-const høgdeForBredde = (canvas: HTMLCanvasElement, bredde: number): number => (bredde * canvas.height) / canvas.width;
+const høgdeForBredde = (bildeBredde: number, bildeHøgde: number, bredde: number): number =>
+    (bredde * bildeHøgde) / bildeBredde;
+
+// Klypp ut eitt rektangel (ein månad) frå det samla kalender-biletet til eit eige
+// canvas. Då slepp vi å kalle html2canvas (som klonar heile dokumentet) éin gong
+// per månad, samtidig som kvar månad framleis blir eit sjølvstendig bilete vi kan
+// paginere utan å dele han over to sider.
+const klyppUtRektangel = (kjelde: HTMLCanvasElement, rekt: Rektangel): HTMLCanvasElement => {
+    const sx = Math.round(rekt.x * SKALA);
+    const sy = Math.round(rekt.y * SKALA);
+    const sb = Math.round(rekt.bredde * SKALA);
+    const sh = Math.round(rekt.høgde * SKALA);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = sb;
+    canvas.height = sh;
+
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, sb, sh);
+        ctx.drawImage(kjelde, sx, sy, sb, sh, 0, 0, sb, sh);
+    }
+
+    return canvas;
+};
 
 /**
  * Genererer ein PDF av uttaksplan-kalenderen der kvar månad blir teikna som eit
  * eige bilete og plassert slik at ein månad aldri blir delt over to sider.
  *
- * react-to-pdf (og liknande verktøy) rasteriserer heile kalenderen til eitt høgt
- * lerret og klypper det opp i faste sidehøgder utan å ta omsyn til kvar månadane
- * startar og sluttar. Då kan ein månad bli kutta i to over eit sideskift. Her
- * fangar vi difor kvar månad for seg og paginerer manuelt slik at ein heil månad
- * alltid hamnar på éi side.
+ * For å halde genereringstida nede fangar vi heile kalenderen i éi html2canvas-
+ * fanging (i staden for éi fanging per månad – html2canvas klonar heile
+ * dokumentet for kvar fanging, så det blei svært treigt for lange planar). Deretter
+ * klypper vi ut kvar månad frå det samla biletet og paginerer manuelt.
  */
 export const genererKalenderPdf = async ({
     legendElement,
-    månedElementer,
+    kalenderElement,
     antallKolonner,
     filename,
 }: GenererKalenderPdfParams): Promise<void> => {
@@ -104,61 +146,91 @@ export const genererKalenderPdf = async ({
     // sidekanten og biletet blei kutta over sideskiftet.
     const maksInnhaldsHøgd = A4_HØGDE_MM - 2 * MARGIN_MM;
 
-    let y = MARGIN_MM;
+    // Tving desktop-høgd på dagane på det levande DOM-et medan vi måler og fangar,
+    // slik at posisjonane vi måler stemmer med biletet og resultatet blir likt
+    // uavhengig av brukarens viewport.
+    const dagHøgdStyle = document.createElement('style');
+    dagHøgdStyle.textContent = DAG_HØGD_STYLE;
+    document.head.appendChild(dagHøgdStyle);
 
-    const leggTilBilete = (canvas: HTMLCanvasElement, x: number, øvst: number, bredde: number): void => {
-        pdf.addImage(
-            canvas.toDataURL('image/jpeg', JPEG_KVALITET),
-            'JPEG',
-            x,
-            øvst,
-            bredde,
-            høgdeForBredde(canvas, bredde),
-        );
-    };
+    try {
+        let y = MARGIN_MM;
 
-    // Forklaringa (legend) øvst på første side. Skaler ned dersom ho er høgare
-    // enn ei heil side slik at ho ikkje blir kutta.
-    const legendCanvas = await lagBildeAvElement(legendElement);
-    const legendNaturligHøgd = høgdeForBredde(legendCanvas, tilgjengeligBredde);
-    const legendBredde =
-        legendNaturligHøgd > maksInnhaldsHøgd
-            ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
-            : tilgjengeligBredde;
-    leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde);
-    y += høgdeForBredde(legendCanvas, legendBredde) + RAD_GAP_MM;
+        const leggTilBilete = (
+            canvas: HTMLCanvasElement,
+            x: number,
+            øvst: number,
+            bredde: number,
+            høgde: number,
+        ): void => {
+            pdf.addImage(canvas.toDataURL('image/jpeg', JPEG_KVALITET), 'JPEG', x, øvst, bredde, høgde);
+        };
 
-    const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
+        // Forklaringa (legend) øvst på første side. Skaler ned dersom ho er høgare
+        // enn ei heil side slik at ho ikkje blir kutta.
+        const legendCanvas = await lagBildeAvElement(legendElement);
+        const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
+        const legendBredde =
+            legendNaturligHøgd > maksInnhaldsHøgd
+                ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
+                : tilgjengeligBredde;
+        const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
+        leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
+        y += legendHøgd + RAD_GAP_MM;
 
-    // Fang ein rad (maks `antallKolonner` månadar) om gongen i staden for alle
-    // samtidig. Kalenderen kan vere opptil 3 år (≈36 månadar), så å halde alle
-    // canvasane i minnet samstundes ville gitt unødvendig høgt minnebruk. Når vi
-    // går vidare til neste rad kan dei føregåande canvasane bli GC-a.
-    for (let i = 0; i < månedElementer.length; i += antallKolonner) {
-        const radElementer = månedElementer.slice(i, i + antallKolonner);
-        const radCanvaser = await Promise.all(radElementer.map(lagBildeAvElement));
-
-        // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei
-        // side. Då held alle månadane i raden same breidde, men blir smalare
-        // slik at den høgaste får plass på éi side og ikkje blir kutta.
-        const naturligRadHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, kolonneBredde)));
-        const radBredde =
-            naturligRadHøgde > maksInnhaldsHøgd ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde : kolonneBredde;
-        const radHøgde = Math.max(...radCanvaser.map((canvas) => høgdeForBredde(canvas, radBredde)));
-
-        // Start ny side dersom heile raden ikkje får plass på resten av sida.
-        if (y + radHøgde > sideBunn) {
-            pdf.addPage('a4', 'portrait');
-            y = MARGIN_MM;
-        }
-
-        radCanvaser.forEach((canvas, kolonne) => {
-            const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
-            leggTilBilete(canvas, x, y, radBredde);
+        // Mål kvar månad relativt til kalender-elementet *før* vi fangar, medan
+        // dag-høgd-stilen er aktiv, slik at rektangla stemmer med biletet.
+        const månedElementer = Array.from(kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'));
+        const kalenderRect = kalenderElement.getBoundingClientRect();
+        const månedRektangler: Rektangel[] = månedElementer.map((el) => {
+            const rect = el.getBoundingClientRect();
+            return {
+                x: rect.left - kalenderRect.left,
+                y: rect.top - kalenderRect.top,
+                bredde: rect.width,
+                høgde: rect.height,
+            };
         });
 
-        y += radHøgde + RAD_GAP_MM;
-    }
+        // Éi fanging av heile kalenderen. Vi klypper ut kvar månad etterpå.
+        const kalenderCanvas = await lagBildeAvElement(kalenderElement);
+        const månedCanvaser = månedRektangler.map((rekt) => klyppUtRektangel(kalenderCanvas, rekt));
 
-    await pdf.save(filename, { returnPromise: true });
+        const kolonneBredde = (tilgjengeligBredde - KOLONNE_GAP_MM * (antallKolonner - 1)) / antallKolonner;
+
+        for (let i = 0; i < månedCanvaser.length; i += antallKolonner) {
+            const radCanvaser = månedCanvaser.slice(i, i + antallKolonner);
+
+            // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei
+            // side. Då held alle månadane i raden same breidde, men blir smalare
+            // slik at den høgaste får plass på éi side og ikkje blir kutta.
+            const naturligRadHøgde = Math.max(
+                ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, kolonneBredde)),
+            );
+            const radBredde =
+                naturligRadHøgde > maksInnhaldsHøgd
+                    ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde
+                    : kolonneBredde;
+            const radHøgde = Math.max(
+                ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, radBredde)),
+            );
+
+            // Start ny side dersom heile raden ikkje får plass på resten av sida.
+            if (y + radHøgde > sideBunn) {
+                pdf.addPage('a4', 'portrait');
+                y = MARGIN_MM;
+            }
+
+            radCanvaser.forEach((canvas, kolonne) => {
+                const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
+                leggTilBilete(canvas, x, y, radBredde, høgdeForBredde(canvas.width, canvas.height, radBredde));
+            });
+
+            y += radHøgde + RAD_GAP_MM;
+        }
+
+        await pdf.save(filename, { returnPromise: true });
+    } finally {
+        dagHøgdStyle.remove();
+    }
 };

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -37,26 +37,15 @@ const MND_GAP_PX = 12;
 const DESKTOP_DAG_HØGD_PX = 30;
 const DESKTOP_DAG_FONT_PX = 14;
 
-// Klasse som berre offscreen-klonane får, slik at fange-stilane under aldri
-// påverkar det levande DOM-et i dialogen.
+// Klasse som berre offscreen-klonane får, slik at dei aldri påverkar det
+// levande DOM-et i dialogen.
 const OFFSCREEN_KLASSE = 'fp-pdf-offscreen';
 
-// html2canvas (1.4.1) sentrerer ikkje tekst loddrett via flexbox sin
-// `align-items: center` – det plasserer teksten etter line-boksen i staden. Både
-// dagcellene og legend-radene sentrerer tekst ved sida av ein fargerute med flex,
-// så utan tiltak sig teksten ned medan fargen «klatrar» opp. Ved å gi teksten ein
-// line-height lik høgda på cella/ruta fyller line-boksen heile høgda, og teksten
-// blir korrekt sentrert i fanginga. Vi scopar stilen til klonane (OFFSCREEN_KLASSE)
-// så dialogen ikkje blinkar.
-const LEGEND_RUTE_HØGD_PX = 25;
-const FANGE_STIL = `
-.${OFFSCREEN_KLASSE} [data-testid^="day:"]{
-  height:${DESKTOP_DAG_HØGD_PX}px !important;
-  font-size:${DESKTOP_DAG_FONT_PX}px !important;
-  line-height:${DESKTOP_DAG_HØGD_PX}px !important;
-}
-.${OFFSCREEN_KLASSE} p{line-height:${LEGEND_RUTE_HØGD_PX}px !important;}
-`;
+// Line-height vi gir legend-teksten under fanginga (sjå sentrerTekstForFanging).
+const LEGEND_TEKST_LINE_HØGD_PX = 24;
+// Litt loddrett luft rundt legenden, slik at teksten ikkje blir klypt sjølv om
+// html2canvas teiknar han litt lågt.
+const LEGEND_PADDING_PX = 4;
 
 interface GenererKalenderPdfParams {
     legendElement: HTMLElement;
@@ -123,6 +112,40 @@ const inlineIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
 
 const høgdeForBredde = (bildeBredde: number, bildeHøgde: number, bredde: number): number =>
     (bredde * bildeHøgde) / bildeBredde;
+
+// html2canvas (1.4.1) sentrerer ikkje tekst loddrett slik flexbox/grid gjer –
+// det plasserer teksten etter line-boksen, og teiknar han difor litt for langt
+// ned. Resultatet er at dagtala sig ned i cellene og legend-teksten hamnar lågt
+// og blir klypt. Ved å gi tekst-elementa ein line-height lik høgda på cella si,
+// fyller line-boksen heile høgda, og html2canvas teiknar teksten sentrert.
+//
+// Vi set stilane *inline på sjølve klonen* (ikkje via eit <style> i <head>).
+// Klonane blir lagde under dialogen/portalen sin DOM, der eit globalt stylesheet
+// ikkje nødvendigvis når fram – inline-stil blir derimot alltid lesen av
+// html2canvas (som måler boksane frå dei verkelege klone-nodane).
+const sentrerTekstForFanging = (klone: HTMLElement): void => {
+    // Dagceller: tving deterministisk desktop-storleik og la line-boksen fylle
+    // cella, slik at talet blir loddrett sentrert i fanginga.
+    klone.querySelectorAll<HTMLElement>('[data-testid^="day:"]').forEach((celle) => {
+        celle.style.height = `${DESKTOP_DAG_HØGD_PX}px`;
+        celle.style.minHeight = `${DESKTOP_DAG_HØGD_PX}px`;
+        celle.style.fontSize = `${DESKTOP_DAG_FONT_PX}px`;
+        celle.style.lineHeight = `${DESKTOP_DAG_HØGD_PX}px`;
+    });
+
+    // Legend-tekst (Aksel BodyShort = <p>): same line-height-triks så teksten
+    // blir sentrert ved sida av fargeruta og ikkje klypt i botnen.
+    klone.querySelectorAll<HTMLElement>('p').forEach((tekst) => {
+        tekst.style.lineHeight = `${LEGEND_TEKST_LINE_HØGD_PX}px`;
+    });
+
+    // Litt luft mellom vekedag-overskriftene og første veke, slik at fargane i
+    // øvste rad ikkje ser ut til å ligge oppå vekedag-tekstane i fanginga.
+    const headerRad = klone.querySelector<HTMLElement>('.aksel-hgrid');
+    if (headerRad) {
+        headerRad.style.marginBottom = '4px';
+    }
+};
 
 // Vel ein skala som held det ferdige canvas-et innanfor nettlesaren si
 // canvas-grense, men aldri høgare enn ynskt SKALA.
@@ -206,12 +229,6 @@ export const genererKalenderPdf = async ({
     // sidekanten og biletet blei kutta over sideskiftet.
     const maksInnhaldsHøgd = A4_HØGDE_MM - 2 * MARGIN_MM;
 
-    // Fange-stilar som tvingar desktop-høgd og loddrett sentrering. Scopa til
-    // offscreen-klonane via OFFSCREEN_KLASSE, så dialogen ikkje blir påverka.
-    const fangeStil = document.createElement('style');
-    fangeStil.textContent = FANGE_STIL;
-    document.head.appendChild(fangeStil);
-
     let y = MARGIN_MM;
 
     const leggTilBilete = (canvas: HTMLCanvasElement, x: number, øvst: number, bredde: number, høgde: number): void => {
@@ -247,85 +264,84 @@ export const genererKalenderPdf = async ({
         y += radHøgde + RAD_GAP_MM;
     };
 
+    // Forklaringa (legend) øvst på første side, fanga i ein desktop-stor
+    // offscreen-container slik at ho ikkje brett seg på smale skjermar.
+    const legendContainer = lagOffscreenContainer(legendElement.parentElement ?? document.body);
+    legendContainer.style.padding = `${LEGEND_PADDING_PX}px 0`;
     try {
-        // Forklaringa (legend) øvst på første side, fanga i ein desktop-stor
-        // offscreen-container slik at ho ikkje brett seg på smale skjermar.
-        const legendContainer = lagOffscreenContainer(legendElement.parentElement ?? document.body);
-        try {
-            const legendKlone = legendElement.cloneNode(true) as HTMLElement;
-            legendContainer.appendChild(legendKlone);
-            inlineIkonFargar(legendElement, legendKlone);
+        const legendKlone = legendElement.cloneNode(true) as HTMLElement;
+        legendContainer.appendChild(legendKlone);
+        inlineIkonFargar(legendElement, legendKlone);
+        sentrerTekstForFanging(legendKlone);
 
-            const legendCanvas = await fangContainer(legendContainer);
-            const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
-            const legendBredde =
-                legendNaturligHøgd > maksInnhaldsHøgd
-                    ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
-                    : tilgjengeligBredde;
-            const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
-            leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
-            y += legendHøgd + RAD_GAP_MM;
-        } finally {
-            legendContainer.remove();
-        }
-
-        const månedElementer = Array.from(kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'));
-        const månederPerBit = antallKolonner * RADER_PER_BIT;
-
-        // Fang månadane bitvis. Kvar bit blir rendra i ein eigen offscreen-
-        // container, fanga, klypt opp i månadar og paginert – deretter blir både
-        // container og bit-canvas sleppt før neste bit.
-        for (let i = 0; i < månedElementer.length; i += månederPerBit) {
-            const bitElementer = månedElementer.slice(i, i + månederPerBit);
-            const container = lagOffscreenContainer(kalenderElement.parentElement ?? document.body);
-            container.style.display = 'grid';
-            container.style.gridTemplateColumns = `repeat(${antallKolonner}, ${MND_BREDDE_PX}px)`;
-            container.style.columnGap = `${MND_GAP_PX}px`;
-            container.style.rowGap = `${MND_GAP_PX}px`;
-
-            try {
-                const bitKloner = bitElementer.map((el) => {
-                    const klone = el.cloneNode(true) as HTMLElement;
-                    klone.style.width = `${MND_BREDDE_PX}px`;
-                    klone.style.maxWidth = `${MND_BREDDE_PX}px`;
-                    container.appendChild(klone);
-                    return klone;
-                });
-                bitElementer.forEach((original, index) => inlineIkonFargar(original, bitKloner[index]!));
-
-                const skala = veljSkala(container.scrollWidth, container.scrollHeight);
-                const bitCanvas = await html2canvas(container, {
-                    scale: skala,
-                    useCORS: true,
-                    logging: false,
-                    backgroundColor: '#ffffff',
-                });
-
-                const containerRect = container.getBoundingClientRect();
-                const månedCanvaser = bitKloner.map((klone) => {
-                    const rect = klone.getBoundingClientRect();
-                    return klyppUtRektangel(
-                        bitCanvas,
-                        {
-                            x: rect.left - containerRect.left,
-                            y: rect.top - containerRect.top,
-                            bredde: rect.width,
-                            høgde: rect.height,
-                        },
-                        skala,
-                    );
-                });
-
-                for (let j = 0; j < månedCanvaser.length; j += antallKolonner) {
-                    tegnRad(månedCanvaser.slice(j, j + antallKolonner));
-                }
-            } finally {
-                container.remove();
-            }
-        }
-
-        await pdf.save(filename, { returnPromise: true });
+        const legendCanvas = await fangContainer(legendContainer);
+        const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
+        const legendBredde =
+            legendNaturligHøgd > maksInnhaldsHøgd
+                ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
+                : tilgjengeligBredde;
+        const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
+        leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
+        y += legendHøgd + RAD_GAP_MM;
     } finally {
-        fangeStil.remove();
+        legendContainer.remove();
     }
+
+    const månedElementer = Array.from(kalenderElement.querySelectorAll<HTMLElement>('[data-month-key]'));
+    const månederPerBit = antallKolonner * RADER_PER_BIT;
+
+    // Fang månadane bitvis. Kvar bit blir rendra i ein eigen offscreen-
+    // container, fanga, klypt opp i månadar og paginert – deretter blir både
+    // container og bit-canvas sleppt før neste bit.
+    for (let i = 0; i < månedElementer.length; i += månederPerBit) {
+        const bitElementer = månedElementer.slice(i, i + månederPerBit);
+        const container = lagOffscreenContainer(kalenderElement.parentElement ?? document.body);
+        container.style.display = 'grid';
+        container.style.gridTemplateColumns = `repeat(${antallKolonner}, ${MND_BREDDE_PX}px)`;
+        container.style.columnGap = `${MND_GAP_PX}px`;
+        container.style.rowGap = `${MND_GAP_PX}px`;
+
+        try {
+            const bitKloner = bitElementer.map((el) => {
+                const klone = el.cloneNode(true) as HTMLElement;
+                klone.style.width = `${MND_BREDDE_PX}px`;
+                klone.style.maxWidth = `${MND_BREDDE_PX}px`;
+                container.appendChild(klone);
+                return klone;
+            });
+            bitElementer.forEach((original, index) => inlineIkonFargar(original, bitKloner[index]!));
+            bitKloner.forEach(sentrerTekstForFanging);
+
+            const skala = veljSkala(container.scrollWidth, container.scrollHeight);
+            const bitCanvas = await html2canvas(container, {
+                scale: skala,
+                useCORS: true,
+                logging: false,
+                backgroundColor: '#ffffff',
+            });
+
+            const containerRect = container.getBoundingClientRect();
+            const månedCanvaser = bitKloner.map((klone) => {
+                const rect = klone.getBoundingClientRect();
+                return klyppUtRektangel(
+                    bitCanvas,
+                    {
+                        x: rect.left - containerRect.left,
+                        y: rect.top - containerRect.top,
+                        bredde: rect.width,
+                        høgde: rect.height,
+                    },
+                    skala,
+                );
+            });
+
+            for (let j = 0; j < månedCanvaser.length; j += antallKolonner) {
+                tegnRad(månedCanvaser.slice(j, j + antallKolonner));
+            }
+        } finally {
+            container.remove();
+        }
+    }
+
+    await pdf.save(filename, { returnPromise: true });
 };

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -36,7 +36,27 @@ const MND_GAP_PX = 12;
 // fangar, slik at høgda blir deterministisk uavhengig av viewport.
 const DESKTOP_DAG_HØGD_PX = 30;
 const DESKTOP_DAG_FONT_PX = 14;
-const DAG_HØGD_STYLE = `[data-testid^="day:"]{height:${DESKTOP_DAG_HØGD_PX}px !important;font-size:${DESKTOP_DAG_FONT_PX}px !important;}`;
+
+// Klasse som berre offscreen-klonane får, slik at fange-stilane under aldri
+// påverkar det levande DOM-et i dialogen.
+const OFFSCREEN_KLASSE = 'fp-pdf-offscreen';
+
+// html2canvas (1.4.1) sentrerer ikkje tekst loddrett via flexbox sin
+// `align-items: center` – det plasserer teksten etter line-boksen i staden. Både
+// dagcellene og legend-radene sentrerer tekst ved sida av ein fargerute med flex,
+// så utan tiltak sig teksten ned medan fargen «klatrar» opp. Ved å gi teksten ein
+// line-height lik høgda på cella/ruta fyller line-boksen heile høgda, og teksten
+// blir korrekt sentrert i fanginga. Vi scopar stilen til klonane (OFFSCREEN_KLASSE)
+// så dialogen ikkje blinkar.
+const LEGEND_RUTE_HØGD_PX = 25;
+const FANGE_STIL = `
+.${OFFSCREEN_KLASSE} [data-testid^="day:"]{
+  height:${DESKTOP_DAG_HØGD_PX}px !important;
+  font-size:${DESKTOP_DAG_FONT_PX}px !important;
+  line-height:${DESKTOP_DAG_HØGD_PX}px !important;
+}
+.${OFFSCREEN_KLASSE} p{line-height:${LEGEND_RUTE_HØGD_PX}px !important;}
+`;
 
 interface GenererKalenderPdfParams {
     legendElement: HTMLElement;
@@ -116,6 +136,7 @@ const veljSkala = (breddePx: number, høgdePx: number): number => {
 
 const lagOffscreenContainer = (forelder: HTMLElement): HTMLDivElement => {
     const container = document.createElement('div');
+    container.className = OFFSCREEN_KLASSE;
     container.style.position = 'fixed';
     container.style.left = '-100000px';
     container.style.top = '0';
@@ -185,10 +206,11 @@ export const genererKalenderPdf = async ({
     // sidekanten og biletet blei kutta over sideskiftet.
     const maksInnhaldsHøgd = A4_HØGDE_MM - 2 * MARGIN_MM;
 
-    // Tving desktop-høgd på dagane medan vi fangar.
-    const dagHøgdStyle = document.createElement('style');
-    dagHøgdStyle.textContent = DAG_HØGD_STYLE;
-    document.head.appendChild(dagHøgdStyle);
+    // Fange-stilar som tvingar desktop-høgd og loddrett sentrering. Scopa til
+    // offscreen-klonane via OFFSCREEN_KLASSE, så dialogen ikkje blir påverka.
+    const fangeStil = document.createElement('style');
+    fangeStil.textContent = FANGE_STIL;
+    document.head.appendChild(fangeStil);
 
     let y = MARGIN_MM;
 
@@ -304,6 +326,6 @@ export const genererKalenderPdf = async ({
 
         await pdf.save(filename, { returnPromise: true });
     } finally {
-        dagHøgdStyle.remove();
+        fangeStil.remove();
     }
 };


### PR DESCRIPTION
Følgjer opp TFP-6170/-2 med to feilrettingar i kalender-PDF-en:

- Ikon-fargane var rette lokalt men feil i prod. Ikona brukar color="var(--ax-…)" + fill="currentColor", og den gamle koden stolte på at nettlesaren løyste opp var() i SVG-presentasjonsattributtet color. Det gjer ikkje alle nettlesarar (t.d. Safari), så ikona fekk feil farge i prod. Vi løyser no opp design-tokenet sjølve via getComputedStyle på ikonet sin eigen kontekst og set ein konkret rgb-verdi som fill før fanginga.

- PDF-genereringa var svært treig fordi html2canvas blei kalla éin gong per månad, og kvart kall klonar heile dokumentet. No fangar vi heile kalenderen i éi fanging og klypper ut kvar månad frå det samla biletet. Pagineringa er uendra – ein månad blir framleis aldri delt over to sider. Determinismen (desktop-dag-høgd) er bevart ved å injisere stilen på det levande DOM-et medan vi måler og fangar.