### PR TITLE
TFP-7006: tillat dagens dato som terminbekreftelsesdato

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
@@ -208,6 +208,8 @@ describe('<OmBarnetSteg>', () => {
             }),
         );
 
+    });
+
     it('skal avvise morgondagens dato som terminbekreftelsesdato', async () => {
         render(<MorFødsel />);
 

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
@@ -187,28 +187,26 @@ describe('<OmBarnetSteg>', () => {
 
         await userEvent.click(screen.getByText('Ett barn'));
 
+        const today = dayjs();
         const termindatoInput = screen.getByLabelText('Når er termindatoen?');
-        await userEvent.type(termindatoInput, dayjs().format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.type(termindatoInput, today.format(DDMMYYYY_DATE_FORMAT));
         await userEvent.tab();
 
         const termindatoDatertInput = screen.getByLabelText('Når er terminbekreftelsen datert?');
-        await userEvent.type(termindatoDatertInput, dayjs().format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.type(termindatoDatertInput, today.format(DDMMYYYY_DATE_FORMAT));
         await userEvent.tab();
 
         await userEvent.click(screen.getByText('Neste steg'));
 
-        expect(
-            screen.queryByText('Dato på terminbekreftelse kan ikke være frem i tid'),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Dato på terminbekreftelse kan ikke være frem i tid')).not.toBeInTheDocument();
         expect(mellomlagreSøknadOgNaviger).toHaveBeenCalledTimes(1);
         expect(gåTilNesteSide).toHaveBeenCalledWith(
             expect.objectContaining({
                 data: expect.objectContaining({
-                    terminbekreftelsedato: dayjs().format(ISO_DATE_FORMAT),
+                    terminbekreftelsedato: today.format(ISO_DATE_FORMAT),
                 }),
             }),
         );
-    });
 
     it('skal avvise morgondagens dato som terminbekreftelsesdato', async () => {
         render(<MorFødsel />);

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.test.tsx
@@ -177,6 +177,60 @@ describe('<OmBarnetSteg>', () => {
         });
     });
 
+    it('skal godta dagens dato som terminbekreftelsesdato', async () => {
+        const gåTilNesteSide = vi.fn();
+        const mellomlagreSøknadOgNaviger = vi.fn();
+        render(<MorFødsel gåTilNesteSide={gåTilNesteSide} mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger} />);
+
+        expect(await screen.findByText('Er barnet født?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Nei'));
+
+        await userEvent.click(screen.getByText('Ett barn'));
+
+        const termindatoInput = screen.getByLabelText('Når er termindatoen?');
+        await userEvent.type(termindatoInput, dayjs().format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.tab();
+
+        const termindatoDatertInput = screen.getByLabelText('Når er terminbekreftelsen datert?');
+        await userEvent.type(termindatoDatertInput, dayjs().format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.tab();
+
+        await userEvent.click(screen.getByText('Neste steg'));
+
+        expect(
+            screen.queryByText('Dato på terminbekreftelse kan ikke være frem i tid'),
+        ).not.toBeInTheDocument();
+        expect(mellomlagreSøknadOgNaviger).toHaveBeenCalledTimes(1);
+        expect(gåTilNesteSide).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    terminbekreftelsedato: dayjs().format(ISO_DATE_FORMAT),
+                }),
+            }),
+        );
+    });
+
+    it('skal avvise morgondagens dato som terminbekreftelsesdato', async () => {
+        render(<MorFødsel />);
+
+        expect(await screen.findByText('Er barnet født?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Nei'));
+
+        await userEvent.click(screen.getByText('Ett barn'));
+
+        const termindatoInput = screen.getByLabelText('Når er termindatoen?');
+        await userEvent.type(termindatoInput, dayjs().format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.tab();
+
+        const termindatoDatertInput = screen.getByLabelText('Når er terminbekreftelsen datert?');
+        await userEvent.type(termindatoDatertInput, dayjs().add(1, 'day').format(DDMMYYYY_DATE_FORMAT));
+        await userEvent.tab();
+
+        await userEvent.click(screen.getByText('Neste steg'));
+
+        expect(screen.getAllByText('Dato på terminbekreftelse kan ikke være frem i tid').length).toBeGreaterThan(0);
+    });
+
     it('skal søke stebarnsadopsjon for ett barn', async () => {
         const gåTilNesteSide = vi.fn();
         const mellomlagreSøknadOgNaviger = vi.fn();

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
@@ -17,7 +17,7 @@ import { Alert, BodyShort, Heading, ReadMore, VStack } from '@navikt/ds-react';
 import { ISO_DATE_REGEX } from '@navikt/fp-constants';
 import { RhfDatepicker } from '@navikt/fp-form-hooks';
 import { EksternArbeidsforholdDto_fpoversikt, Søkerrolle, SøkersituasjonFp } from '@navikt/fp-types';
-import { isBeforeToday, isRequired, isValidDate, isValidDateString as isValidDateBoolean } from '@navikt/fp-validation';
+import { isBeforeTodayOrToday, isRequired, isValidDate, isValidDateString as isValidDateBoolean } from '@navikt/fp-validation';
 import { terminbekreftelsedatoMåVæreUtstedetEtter22Svangerskapsuke } from '@navikt/fp-validation/src/form/dateFormValidation';
 
 import { UfødtBarn } from '../OmBarnetFormValues';
@@ -121,7 +121,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
                                 id: 'valideringsfeil.omBarnet.terminbekreftelseDato.ugyldigDatoFormat',
                             }),
                         ),
-                        isBeforeToday(
+                        isBeforeTodayOrToday(
                             intl.formatMessage({
                                 id: 'valideringsfeil.omBarnet.terminbekreftelseDato.kanIkkeVæreFremITid',
                             }),


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7006

Validatoren isBeforeToday kravde at datoen var strengt før i dag, slik at dagens dato feilaktig vart avvist med «Dato på terminbekreftelse kan ikke være frem i tid».

Bytta til isBeforeTodayOrToday som tillèt i dag og tidlegare — i tråd med at datoveljaren allereie har maxDate={dateToday}.

La til to regresjonstestatar:
- skal godta dagens dato som terminbekreftelsesdato
- skal avvise morgondagens dato som terminbekreftelsesdato