### PR TITLE
TFP-7004(uttaksplan): vis mors fellesperiode korrekt i fars listevisning

### DIFF
--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -487,6 +487,16 @@ describe('UttaksplanListe', () => {
         expect(screen.queryByText('Slett')).not.toBeInTheDocument();
     });
 
+    it('Mors fellesperiode skal vises som "Fellesperiode" i fars listevisning, ikke "med aktivitetskrav"', async () => {
+        render(<FarSøkerEtterAtMorHarSøkt />);
+
+        // Mor har tre fellesperioder. Når far ser oversikten sin skal disse vises
+        // som "Fellesperiode", ikke "Foreldrepenger med aktivitetskrav" (som er
+        // forbeholdt bare-far-har-rett-perioder med kontoType FORELDREPENGER).
+        expect(await screen.findAllByText('Fellesperiode')).toHaveLength(3);
+        expect(screen.queryByText('Foreldrepenger med aktivitetskrav')).not.toBeInTheDocument();
+    });
+
     it('Skal ikke kunne legge til annen part som forelder når en legger til ny periode', async () => {
         render(<FarSøkerEtterAtMorHarSøkt />);
 

--- a/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
@@ -67,13 +67,18 @@ export const getStønadskvoteNavn = (intl: IntlShape, options: GetStønadskvoteN
         );
     }
 
-    if (
+    // En bare-far-har-rett-periode bruker kontoType FORELDREPENGER og vises med
+    // aktivitetskrav-tekst basert på mors aktivitet. Gjelder kun fars egne perioder
+    // (ikke EØS, avslåtte eller aleneomsorg), slik at mors fellesperiode ikke
+    // feilmerkes når far ser oversikten sin.
+    const erBareFarHarRettForeldrepenger =
         !erAvslått &&
         !erEøsPeriode &&
         konto === 'FORELDREPENGER' &&
         erFarEllerMedmor === true &&
-        erAleneOmOmsorg === false
-    ) {
+        erAleneOmOmsorg === false;
+
+    if (erBareFarHarRettForeldrepenger) {
         if (morsAktivitet === 'IKKE_OPPGITT') {
             return intl.formatMessage({ id: 'uttaksplan.stønadskvotetype.AKTIVITETSFRI_KVOTE_BFHR' });
         }

--- a/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
+++ b/packages/uttaksplan/src/liste/utils/uttaksplanListeUtils.ts
@@ -67,7 +67,13 @@ export const getStønadskvoteNavn = (intl: IntlShape, options: GetStønadskvoteN
         );
     }
 
-    if (!erAvslått && !erEøsPeriode && erFarEllerMedmor === true && erAleneOmOmsorg === false) {
+    if (
+        !erAvslått &&
+        !erEøsPeriode &&
+        konto === 'FORELDREPENGER' &&
+        erFarEllerMedmor === true &&
+        erAleneOmOmsorg === false
+    ) {
         if (morsAktivitet === 'IKKE_OPPGITT') {
             return intl.formatMessage({ id: 'uttaksplan.stønadskvotetype.AKTIVITETSFRI_KVOTE_BFHR' });
         }


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7004

Mors uttak av fellesperiode ble vist som "Foreldrepenger med aktivitetskrav" i listevisningen når far så oversikten sin. BFHR- merkelappen ble trigget kun på innlogget brukers rolle (erFarEllerMedmor), ikke periodens kontotype, så alle perioder traff grenen når far var søker.

Avgrens aktivitetskrav-merkelappene til perioder med kontoType FORELDREPENGER (bare-far-har-rett), slik at fellesperiode faller tilbake til riktig tekst.