### PR TITLE
TFP-7002(uttaksplan): vis fars overtatte mødrekvote i mors plan

### DIFF
--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.stories.tsx
@@ -303,3 +303,77 @@ export const MorOgFarOgFarGraderer: Story = {
         },
     },
 };
+
+export const MorMedFarSomHarTattOverMødrekvote: Story = {
+    name: 'Mor - far har tatt over mødrekvote de første seks ukene',
+    parameters: {
+        msw: {
+            handlers: [http.post(API_URLS.konto, () => HttpResponse.json(stønadskvoter2))],
+        },
+    },
+    args: {
+        sak: {
+            saksnummer: '1',
+            sakAvsluttet: false,
+            kanSøkeOmEndring: true,
+            sakTilhørerMor: true,
+            gjelderAdopsjon: false,
+            morUføretrygd: false,
+            harAnnenForelderTilsvarendeRettEØS: false,
+            ønskerJustertUttakVedFødsel: false,
+            rettighetType: 'BEGGE_RETT',
+            annenPart: { fnr: '29459848930' },
+            familiehendelse: { fødselsdato: '2025-03-25', termindato: '2025-03-25', antallBarn: 1 },
+            gjeldendeVedtak: {
+                perioder: [
+                    {
+                        fom: '2025-03-25',
+                        tom: '2025-05-06',
+                        kontoType: 'MØDREKVOTE',
+                        resultat: {
+                            innvilget: false,
+                            trekkerDager: false,
+                            trekkerMinsterett: false,
+                            årsak: 'ANNET',
+                        },
+                        flerbarnsdager: false,
+                        forelder: 'MOR',
+                    },
+                    {
+                        fom: '2025-05-07',
+                        tom: '2025-06-30',
+                        kontoType: 'FELLESPERIODE',
+                        flerbarnsdager: false,
+                        forelder: 'MOR',
+                    },
+                ],
+                perioderAnnenpartEøs: [],
+            },
+            barn: [{ fnr: '22442356029' }],
+            dekningsgrad: 'HUNDRE',
+            oppdatertTidspunkt: '2025-09-16T14:09:43.208',
+            forelder: 'MOR',
+            ytelse: 'FORELDREPENGER' as const,
+        },
+        annenPartsPerioder: [
+            {
+                fom: '2025-03-25',
+                tom: '2025-05-06',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
+                resultat: {
+                    innvilget: true,
+                    trekkerDager: true,
+                    trekkerMinsterett: false,
+                    årsak: 'ANNET',
+                },
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+        ],
+        navnPåForeldre: {
+            mor: 'Helga',
+            farMedmor: 'Espen',
+        },
+    },
+};

--- a/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.test.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/din-plan/DinPlan.test.tsx
@@ -6,7 +6,7 @@ import { mswWrapper } from '@navikt/fp-utils-test';
 
 import * as stories from './DinPlan.stories';
 
-const { Default, FarSøker } = composeStories(stories);
+const { Default, FarSøker, MorMedFarSomHarTattOverMødrekvote } = composeStories(stories);
 
 describe('<Default>', () => {
     it(
@@ -112,6 +112,33 @@ describe('<Default>', () => {
             expect(within(april2025).getByTestId('day:1;dayColor:BLUE')).toBeInTheDocument();
             expect(within(april2025).getByTestId('day:22;dayColor:BLUE')).toBeInTheDocument();
             expect(within(april2025).getAllByTestId('dayColor:BLUE', { exact: false })).toHaveLength(16);
+        }),
+    );
+});
+
+describe('<MorMedFarSomHarTattOverMødrekvote>', () => {
+    it(
+        'Skal vise at far har tatt over mødrekvoten – ikke tapte dager – i mors plan',
+        mswWrapper(async ({ setHandlers }) => {
+            setHandlers(MorMedFarSomHarTattOverMødrekvote.parameters.msw);
+            render(<MorMedFarSomHarTattOverMødrekvote />);
+
+            expect(await screen.findByText('Liste')).toBeInTheDocument();
+
+            // Overføringen til far skal vises som hans periode, ikke som tapte dager for mor
+            expect(screen.getAllByText('Espen har foreldrepenger').length).toBeGreaterThan(0);
+            expect(
+                screen.getByText('Overføring av Helgas kvote fordi Helga er innlagt på helseinstitusjon'),
+            ).toBeInTheDocument();
+            expect(screen.queryByText('Dager du kan tape')).not.toBeInTheDocument();
+
+            await userEvent.click(screen.getByText('Kalender'));
+
+            // Far sine overtatte dager i seksukersperioden skal være grønne, ikke svarte (tapte dager)
+            const april2025 = screen.getByTestId('year:2025;month:3');
+            expect(within(april2025).getByTestId('day:7;dayColor:GREEN')).toBeInTheDocument();
+            expect(within(april2025).queryByTestId('day:7;dayColor:BLACK')).not.toBeInTheDocument();
+            expect(within(april2025).queryAllByTestId('dayColor:BLACK', { exact: false })).toHaveLength(0);
         }),
     );
 });

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.test.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.test.ts
@@ -137,4 +137,32 @@ describe('prosesserPerioderForVisning', () => {
             },
         ]);
     });
+
+    it('beheld annen part sin reelle periode når søkar sin overlappande periode er avslått og ikkje trekkjer dagar', () => {
+        const perioderSøker: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-03-25',
+                tom: '2025-05-06',
+                forelder: 'MOR',
+                kontoType: 'MØDREKVOTE',
+                flerbarnsdager: false,
+                resultat: { innvilget: false, trekkerDager: false, trekkerMinsterett: false, årsak: 'ANNET' },
+            },
+        ];
+        const perioderAnnenPart: UttakPeriode_fpoversikt[] = [
+            {
+                fom: '2025-03-25',
+                tom: '2025-05-06',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'MØDREKVOTE',
+                overføringÅrsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
+                flerbarnsdager: false,
+                resultat: { innvilget: true, trekkerDager: true, trekkerMinsterett: false, årsak: 'ANNET' },
+            },
+        ];
+
+        const result = prosesserPerioderForVisning(perioderSøker, perioderAnnenPart);
+
+        expect(result).toContainEqual(perioderAnnenPart[0]);
+    });
 });

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
@@ -172,4 +172,4 @@ const fjernOverlappUtenSamtidigUttak = (
 // vekk seinare. Difor skal han ikkje skjula annen part sin reelle periode (t.d. når far har teke over
 // mødrekvoten medan mor sin mødrekvoteperiode er avslått).
 const okkupererTid = (periode: UttakPeriode_fpoversikt): boolean =>
-    !(periode.resultat?.innvilget === false && periode.resultat.trekkerDager === false);
+    !(periode.resultat?.innvilget === false && periode.resultat?.trekkerDager === false);

--- a/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
+++ b/packages/uttaksplan/src/utils/prosesserPerioderForVisning.ts
@@ -162,7 +162,14 @@ const fjernOverlappUtenSamtidigUttak = (
                 (søker) =>
                     søker.samtidigUttak === undefined &&
                     søker.utsettelseÅrsak === undefined &&
+                    okkupererTid(søker) &&
                     harOverlapp(periodeAnnenPart, søker),
             ),
     );
 };
+
+// Ein avslått periode som ikkje trekkjer dagar okkuperer ikkje tida i planen og blir uansett filtrert
+// vekk seinare. Difor skal han ikkje skjula annen part sin reelle periode (t.d. når far har teke over
+// mødrekvoten medan mor sin mødrekvoteperiode er avslått).
+const okkupererTid = (periode: UttakPeriode_fpoversikt): boolean =>
+    !(periode.resultat?.innvilget === false && periode.resultat.trekkerDager === false);


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7002

Når far hadde tatt over mødrekvoten de første seks ukene etter fødsel (overføring pga. mors innleggelse/sykdom), viste mors plan denne perioden som «Dager du kan tape» i koksgrå – mens fars plan viste den korrekt.

Årsak:
- Mors egen mødrekvoteperiode er avslått for den aktuelle perioden (resultat.innvilget = false og resultat.trekkerDager = false), siden hun ikke kunne ta den ut.
- Fars innvilgede, overtatte mødrekvote kom inn via annenparts vedtak og overlappet mors avslåtte periode.
- fjernOverlappUtenSamtidigUttak i prosesserPerioderForVisning tolket overlappet som et duplikat og fjernet fars reelle periode.
- Deretter fjernet filtrerBortPerioderUtenTrekkdager (i UttaksplanDataContext) mors avslåtte periode.
- Resultatet ble et hull i seksukersperioden, som hullutledningen for mor klassifiserte som tapte dager («Dager du kan tape», koksgrå/BLACK).

I fars plan er overtaket hans egen innvilgede periode, og ble derfor vist riktig hele tiden.

Løsning:
En avslått periode som ikke trekker dager okkuperer ikke tid i planen og blir uansett filtrert vekk senere. Den skal derfor ikke kunne skjule annen parts reelle periode. Det er lagt til en okkupererTid-sjekk i fjernOverlappUtenSamtidigUttak slik at fars overtatte mødrekvote beholdes. Da vises perioden korrekt som «{far} har foreldrepenger / Overføring av {mor}s kvote …» (grønn) i stedet for tapte dager.

Tester:
- Ny enhetstest i prosesserPerioderForVisning.test.ts.
- Ny dokumenterende story (MorMedFarSomHarTattOverMødrekvote) og regresjonstest i DinPlan som verifiserer grønne dager, ingen svarte dager og at «Dager du kan tape» ikke vises.