### PR TITLE
TFP-6962: ikke vis "må gjøre endring" ved ny søknad før vedtak

### DIFF
--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -69,6 +69,7 @@ const renderSøknadRoutes = ({
                             mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
                             avbrytSøknad={avbrytSøknad}
                             foreldrepengerSaker={foreldrepengerSaker}
+                            erEndringssøknad={erEndringssøknad}
                         />
                     }
                 />
@@ -165,6 +166,7 @@ const renderSøknadRoutes = ({
                         mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
                         avbrytSøknad={avbrytSøknad}
                         foreldrepengerSaker={foreldrepengerSaker}
+                        erEndringssøknad={erEndringssøknad}
                     />
                 }
             />

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -40,6 +40,7 @@ interface UttaksplanFormProps {
     scrollToKvoteOppsummering: () => void;
     eksisterendeSak: FpSak_fpoversikt | undefined;
     opprinneligPlan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> | undefined;
+    erEndringssøknad: boolean;
 }
 
 export const UttaksplanForm = ({
@@ -51,6 +52,7 @@ export const UttaksplanForm = ({
     scrollToKvoteOppsummering,
     eksisterendeSak,
     opprinneligPlan,
+    erEndringssøknad,
 }: UttaksplanFormProps) => {
     const intl = useIntl();
 
@@ -59,12 +61,9 @@ export const UttaksplanForm = ({
     const harJustertUttakVedFødsel = useContextGetData(ContextDataType.HAR_JUSTERT_UTTAK_VED_FØDSEL);
     const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
 
-    const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
-
     const oppdaterHarJustertUttakVedFødsel = useContextSaveData(ContextDataType.HAR_JUSTERT_UTTAK_VED_FØDSEL);
     const oppdaterUttaksplan = useContextSaveData(ContextDataType.UTTAKSPLAN);
 
-    const erEndringssøknad = !!valgtEksisterendeSaksnr;
     const uttaksplanMedKunNyePerioder =
         uttaksplan?.filter((p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.resultat === undefined) ?? [];
     const gjeldendeUttaksplan = erEndringssøknad ? uttaksplanMedKunNyePerioder : uttaksplan;
@@ -119,7 +118,7 @@ export const UttaksplanForm = ({
         isUfødtBarn(barn) &&
         barn.termindato !== undefined;
 
-    const finnFørsteSubmitFeilmelding = useFinnFørsteSubmitFeilmelding({ opprinneligPlan });
+    const finnFørsteSubmitFeilmelding = useFinnFørsteSubmitFeilmelding({ opprinneligPlan, erEndringssøknad });
 
     const onSubmit = (formValues: FormValues) => {
         const planForValidering = gjeldendeUttaksplan ?? defaultUttaksperioder;

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
@@ -10,7 +10,13 @@ import { AnnenForelder } from 'types/AnnenForelder';
 import { FellesperiodeFordelingValg, Fordeling, OppstartValg } from 'types/Fordeling';
 
 import { BarnType } from '@navikt/fp-constants';
-import { Barn, Dekningsgrad, FpPersonopplysningerDto_fpoversikt, SøkersituasjonFp } from '@navikt/fp-types';
+import {
+    Barn,
+    Dekningsgrad,
+    FpPersonopplysningerDto_fpoversikt,
+    SøkersituasjonFp,
+    UttakPeriode_fpoversikt,
+} from '@navikt/fp-types';
 import {
     ALENE_OM_OMSORG_80_FARMEDMOR,
     ALENE_OM_OMSORG_100_FARMEDMOR,
@@ -71,6 +77,8 @@ type StoryArgs = {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     dekningsgrad: Dekningsgrad;
     fordeling: Fordeling;
+    valgtEksisterendeSaksnr?: string;
+    uttaksplan?: UttakPeriode_fpoversikt[];
 } & ComponentProps<typeof UttaksplanSteg>;
 
 const meta = {
@@ -80,6 +88,7 @@ const meta = {
     args: {
         mellomlagreSøknadOgNaviger: promiseAction(),
         avbrytSøknad: action('button-click'),
+        erEndringssøknad: false,
     },
     render: ({
         søkerInfo,
@@ -91,6 +100,9 @@ const meta = {
         barnet,
         dekningsgrad,
         fordeling,
+        erEndringssøknad,
+        valgtEksisterendeSaksnr,
+        uttaksplan,
     }) => {
         return (
             <MemoryRouter initialEntries={[SøknadRoutes.UTTAKSPLAN]}>
@@ -107,12 +119,15 @@ const meta = {
                         [ContextDataType.ANNEN_FORELDER]: annenForelder,
                         [ContextDataType.FORDELING]: fordeling,
                         [ContextDataType.PERIODE_MED_FORELDREPENGER]: dekningsgrad,
+                        [ContextDataType.VALGT_EKSISTERENDE_SAKSNR]: valgtEksisterendeSaksnr,
+                        [ContextDataType.UTTAKSPLAN]: uttaksplan,
                     }}
                 >
                     <UttaksplanSteg
                         søkerInfo={søkerInfo}
                         mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
                         avbrytSøknad={avbrytSøknad}
+                        erEndringssøknad={erEndringssøknad}
                     />
                 </FpDataContext>
             </MemoryRouter>
@@ -659,5 +674,48 @@ export const FødselFarBeggeHarRettStarterPåTermin: Story = {
         fordeling: {
             oppstartAvForeldrepengerValg: OppstartValg.FAMILIEHENDELSESDATO,
         },
+    },
+};
+
+const INNVILGET_RESULTAT = {
+    innvilget: true,
+    trekkerDager: true,
+    trekkerMinsterett: false,
+    årsak: 'ANNET',
+} as const;
+
+// Plan lastet fra en eksisterende, ikke-vedtatt sak: alle periodene har resultat (kommer fra gjeldende vedtak).
+const INNVILGET_PLAN_FRA_EKSISTERENDE_SAK: UttakPeriode_fpoversikt[] = [
+    {
+        fom: '2024-06-10',
+        tom: '2024-06-28',
+        forelder: 'MOR',
+        kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+        flerbarnsdager: false,
+        resultat: INNVILGET_RESULTAT,
+    },
+    {
+        fom: '2024-07-01',
+        tom: '2024-09-20',
+        forelder: 'MOR',
+        kontoType: 'MØDREKVOTE',
+        flerbarnsdager: false,
+        resultat: INNVILGET_RESULTAT,
+    },
+];
+
+/**
+ * TFP-6962: Bruker har en eksisterende sak (uten vedtak) og søker på nytt med ny sats før vedtak.
+ * Dette er en ny førstegangssøknad (erEndringssøknad=false), men VALGT_EKSISTERENDE_SAKSNR er satt
+ * og planen er forhåndsutfylt med innvilgede perioder (resultat satt). Brukeren skal kunne gå videre
+ * uten å få feilmeldingen "Du må gjøre en endring for å kunne søke om endring".
+ */
+export const NySøknadFørVedtakMedEksisterendeSak: Story = {
+    parameters: FødselMorOgFarBeggeHarRett.parameters,
+    args: {
+        ...FødselMorOgFarBeggeHarRett.args,
+        erEndringssøknad: false,
+        valgtEksisterendeSaksnr: '123456789',
+        uttaksplan: INNVILGET_PLAN_FRA_EKSISTERENDE_SAK,
     },
 };

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
@@ -18,6 +18,7 @@ const {
     FødselMorOgFarBeggeHarRettAnnenPartTomtVedtak,
     FødselMorOgFarKunMorHarRett,
     FødselFarBeggeHarRettStarterPåTermin,
+    NySøknadFørVedtakMedEksisterendeSak,
 } = composeStories(stories);
 
 describe('<UttaksplanSteg>', () => {
@@ -206,6 +207,62 @@ describe('<UttaksplanSteg>', () => {
 
             // Tilbakestill-knappen er nå deaktivert (planen er tilbakestilt til standardforslaget)
             expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).toBeDisabled();
+        }),
+    );
+
+    it(
+        'TFP-6962: skal kunne gå videre med forhåndsutfylt plan fra eksisterende sak når det er en ny søknad (ikke endringssøknad)',
+        mswWrapper(async ({ setHandlers }) => {
+            const gåTilNesteSide = vi.fn();
+            const mellomlagreSøknadOgNaviger = vi.fn();
+            setHandlers(NySøknadFørVedtakMedEksisterendeSak.parameters.msw);
+
+            render(
+                <NySøknadFørVedtakMedEksisterendeSak
+                    gåTilNesteSide={gåTilNesteSide}
+                    mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                />,
+            );
+
+            expect(await screen.findAllByText('Din plan med foreldrepenger')).toHaveLength(2);
+
+            await userEvent.click(screen.getByText('Neste steg'));
+
+            // Skal IKKE blokkere med endringssøknad-feilmeldingen for en ny søknad
+            expect(
+                screen.queryByText('Du må gjøre en endring for å kunne søke om endring'),
+            ).not.toBeInTheDocument();
+
+            // Navigasjon til neste steg skal ha skjedd
+            const navigasjonsAction = gåTilNesteSide.mock.calls.find(
+                ([action]) => action.key === ContextDataType.APP_ROUTE,
+            );
+            expect(navigasjonsAction).toBeDefined();
+        }),
+    );
+
+    it(
+        'TFP-6962: skal fortsatt vise endringssøknad-feilmelding når det faktisk er en endringssøknad uten nye perioder',
+        mswWrapper(async ({ setHandlers }) => {
+            const gåTilNesteSide = vi.fn();
+            const mellomlagreSøknadOgNaviger = vi.fn();
+            setHandlers(NySøknadFørVedtakMedEksisterendeSak.parameters.msw);
+
+            render(
+                <NySøknadFørVedtakMedEksisterendeSak
+                    gåTilNesteSide={gåTilNesteSide}
+                    mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                    erEndringssøknad
+                />,
+            );
+
+            expect(await screen.findAllByText('Din plan med foreldrepenger')).toHaveLength(2);
+
+            await userEvent.click(screen.getByText('Neste steg'));
+
+            expect(
+                await screen.findByText('Du må gjøre en endring for å kunne søke om endring'),
+            ).toBeInTheDocument();
         }),
     );
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -40,16 +40,22 @@ interface Props {
     mellomlagreSøknadOgNaviger: () => Promise<void>;
     avbrytSøknad: () => void;
     foreldrepengerSaker?: FpSak_fpoversikt[];
+    erEndringssøknad: boolean;
 }
 
-export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbrytSøknad, foreldrepengerSaker }: Props) => {
+export const UttaksplanSteg = ({
+    søkerInfo,
+    mellomlagreSøknadOgNaviger,
+    avbrytSøknad,
+    foreldrepengerSaker,
+    erEndringssøknad,
+}: Props) => {
     const intl = useIntl();
 
     const søkersituasjon = notEmpty(useContextGetData(ContextDataType.SØKERSITUASJON));
     const barn = notEmpty(useContextGetData(ContextDataType.OM_BARNET));
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
     const dekningsgrad = notEmpty(useContextGetData(ContextDataType.PERIODE_MED_FORELDREPENGER));
-    const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
     const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
     const eksisterendeSaksnummer = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
     const oppdaterUttaksplan = useContextSaveData(ContextDataType.UTTAKSPLAN);
@@ -65,8 +71,6 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
         },
         [oppdaterUttaksplan],
     );
-
-    const erEndringssøknad = !!valgtEksisterendeSaksnr;
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
     const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad, eksisterendeSak);
@@ -229,6 +233,7 @@ export const UttaksplanSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avbryt
                         defaultUttaksperioder={defaultUttaksperioder}
                         eksisterendeSak={eksisterendeSak}
                         opprinneligPlan={uttaksplanForEksisterendeSak}
+                        erEndringssøknad={erEndringssøknad}
                     />
                 </UttaksplanDataProvider>
             </Step>

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -21,15 +21,17 @@ type SubmitValideringsregel = {
 
 interface UseFinnFørsteSubmitFeilmeldingProps {
     opprinneligPlan: UttaksplanPerioder | undefined;
+    erEndringssøknad: boolean;
 }
 
-export const useFinnFørsteSubmitFeilmelding = ({ opprinneligPlan }: UseFinnFørsteSubmitFeilmeldingProps) => {
+export const useFinnFørsteSubmitFeilmelding = ({
+    opprinneligPlan,
+    erEndringssøknad,
+}: UseFinnFørsteSubmitFeilmeldingProps) => {
     const intl = useIntl();
     const søkersituasjon = notEmpty(useContextGetData(ContextDataType.SØKERSITUASJON));
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
     const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
-    const valgtEksisterendeSaksnr = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
-    const erEndringssøknad = !!valgtEksisterendeSaksnr;
     const erAntallDagerOvertrukket = useErAntallDagerOvertrukketIUttaksplan();
 
     const erSøkerFarEllerMedmor = getErSøkerFarEllerMedmor(søkersituasjon.rolle);


### PR DESCRIPTION
[## TFP-6962](https://jira.adeo.no/browse/TFP-6962)

Når bruker har en eksisterende sak uten vedtak og sender en **ny førstegangssøknad** med ny dekningsgrad (sats), viste uttaksplan-steget feilmeldingen «Du må gjøre en endring for å kunne søke om endring».

### Rotårsak
Uttaksplan-steget re-utledet sin egen `erEndringssøknad = !!valgtEksisterendeSaksnr`. `VALGT_EKSISTERENDE_SAKSNR` settes for alle barn med en eksisterende sak (brukes til å laste perioder som utgangspunkt), så en ny søknad ble feilaktig klassifisert som endringssøknad. Da ble planen filtrert til kun nye perioder (`resultat === undefined`), og siden forhåndsutfyllingen fra saken har perioder med `resultat`, ble lista tom → feilmelding.

### Fiks
Bruker den autoritative `erEndringssøknad`-verdien fra `ForeldrepengesøknadRoutes` (samme verdi som innsendingen bruker) ved å tre den inn som prop i `UttaksplanSteg`, `UttaksplanForm` og `submitValidering`, i stedet for å re-utlede den lokalt.

### Test
Lagt til regresjonstester i `UttaksplanSteg.test.tsx`:
- Ny søknad med forhåndsutfylt plan fra eksisterende sak skal kunne gå videre uten feilmeldingen.
- Reell endringssøknad uten nye perioder skal fortsatt vise feilmeldingen.

_Merk: den opprinnelige dekningsgrad-tilnærmingen ble forkastet (no-op – dekningsgrad kan ikke endres i en endringssøknad). Se resolvede review-tråder._