### PR TITLE
TFP-7005: tillat innsending av plan med kun ferie

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.test.ts
@@ -1,6 +1,6 @@
 import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
 
-import { harKunPerioderForAnnenForelder } from './submitValidering';
+import { harKunPerioderForAnnenForelder, erKunUtsettelser } from './submitValidering';
 
 const utsettelseFar: UttakPeriode_fpoversikt = {
     fom: '2026-06-01',
@@ -9,6 +9,15 @@ const utsettelseFar: UttakPeriode_fpoversikt = {
     flerbarnsdager: false,
     kontoType: 'FEDREKVOTE',
     utsettelseÅrsak: 'LOVBESTEMT_FERIE',
+};
+
+const utsettelseArbeidFar: UttakPeriode_fpoversikt = {
+    fom: '2026-06-08',
+    tom: '2026-06-12',
+    forelder: 'FAR_MEDMOR',
+    flerbarnsdager: false,
+    kontoType: 'FEDREKVOTE',
+    utsettelseÅrsak: 'ARBEID',
 };
 
 const uttakFar: UttakPeriode_fpoversikt = {
@@ -43,5 +52,27 @@ describe('harKunPerioderForAnnenForelder', () => {
 
     it('returnerer false for aleneomsorg', () => {
         expect(harKunPerioderForAnnenForelder(true, true, [uttakMor, utsettelseFar])).toBe(false);
+    });
+});
+
+describe('erKunUtsettelser', () => {
+    it('returnerer false for tom plan', () => {
+        expect(erKunUtsettelser([])).toBe(false);
+    });
+
+    it('returnerer true når planen kun har utsettelser uten ferie', () => {
+        expect(erKunUtsettelser([utsettelseArbeidFar])).toBe(true);
+    });
+
+    it('returnerer false når planen kun har ferie', () => {
+        expect(erKunUtsettelser([utsettelseFar])).toBe(false);
+    });
+
+    it('returnerer false når planen har ferie sammen med andre utsettelser', () => {
+        expect(erKunUtsettelser([utsettelseFar, utsettelseArbeidFar])).toBe(false);
+    });
+
+    it('returnerer false når planen har en ekte uttaksperiode', () => {
+        expect(erKunUtsettelser([utsettelseArbeidFar, uttakFar])).toBe(false);
     });
 });

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -136,8 +136,16 @@ export const harKunPerioderForAnnenForelder = (
     return perioder.every((periode) => Uttaksperioden.erEøsPeriode(periode) || periode.forelder !== søkersForelder);
 };
 
-const erKunUtsettelser = (perioder: UttaksplanPerioder) => {
+export const erKunUtsettelser = (perioder: UttaksplanPerioder) => {
     if (perioder.length === 0) {
+        return false;
+    }
+
+    // Ferie er ein utsettelse som legg dagar tilbake i beholdninga, og er ein gyldig søknad åleine.
+    const harFerie = perioder.some(
+        (periode) => Uttaksperioden.erIkkeEøsPeriode(periode) && periode.utsettelseÅrsak === 'LOVBESTEMT_FERIE',
+    );
+    if (harFerie) {
         return false;
     }
 


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7005

## Kontekst
Gjelder **endringssøknad**. Ferie (`LOVBESTEMT_FERIE`) er modellert som en utsettelse, og submit-regelen `erKunUtsettelser` blokkerte derfor innsending av en endring som kun la inn ferie, med feilmeldingen "Du har kun lagt til utsettelser i planen. Du må legge inn minst én uttaksperiode for å kunne søke om foreldrepenger."

I en endringssøknad frigjør ferie dager tilbake i beholdningen (f.eks. ferie i en måned med foreldrepenger → uttaket endres og dager går tilbake). Dette er en gyldig endring på lik linje med å slette uttaksdager, som allerede slipper igjennom valideringen.

## Endring
- `erKunUtsettelser` unntar nå planer som inneholder minst én ferieperiode, slik at en endring med kun ferie kan sendes inn.
- Eksponerer `erKunUtsettelser` for test og legger til enhetstester (ferie alene, ferie + andre utsettelser, ekte uttaksperiode).

## Avgrensning (scope)
Dette gjelder bevisst **kun endringssøknad**. For ny søknad blokkerer `manglerUttaksperioderForNySøknad` fortsatt en plan uten uttaksperiode — det er ønsket, siden en ny søknad med kun ferie ikke gir mening (det finnes ikke noe uttak å utsette). Den regelen kjører bare når `!erEndringssøknad`, så fiksen påvirker ikke ny søknad.
