### PR TITLE
TFP-7010(uttaksplan): vis riktig infotekst om termin i listevisning når ba…

### DIFF
--- a/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
@@ -852,6 +852,57 @@ export const KunFarHarRettOgHarPauseperiode: Story = {
     },
 };
 
+export const KunFarHarRettOgUfødtBarn: Story = {
+    args: {
+        barn: {
+            type: BarnType.UFØDT,
+            termindato: '2024-04-04',
+            antallBarn: 1,
+        },
+        foreldreInfo: {
+            rettighetType: 'BARE_SØKER_RETT',
+            søker: 'FAR_MEDMOR',
+            navnPåForeldre: { mor: 'Hanne', farMedmor: 'Hans' },
+            erMedmorDelAvSøknaden: false,
+        },
+        harAktivitetskravIPeriodeUtenUttak: false,
+        uttakPerioder: [
+            {
+                fom: '2024-05-17',
+                tom: '2024-05-23',
+                kontoType: 'FEDREKVOTE',
+                forelder: 'FAR_MEDMOR',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2024-05-24',
+                tom: '2024-05-28',
+                forelder: 'FAR_MEDMOR',
+                utsettelseÅrsak: 'FRI',
+                morsAktivitet: 'ARBEID_OG_UTDANNING',
+                flerbarnsdager: false,
+            },
+            {
+                fom: '2024-05-31',
+                tom: '2024-06-13',
+                forelder: 'FAR_MEDMOR',
+                kontoType: 'FEDREKVOTE',
+                flerbarnsdager: false,
+            },
+        ] satisfies Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+        valgtStønadskvote: {
+            kontoer: [
+                { konto: 'MØDREKVOTE', dager: 95 },
+                { konto: 'FEDREKVOTE', dager: 95 },
+                { konto: 'FELLESPERIODE', dager: 101 },
+                { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+            ],
+            minsteretter: MINSTERETTER,
+        },
+        erEndringssøknad: false,
+    },
+};
+
 export const EøsPerioderForAnnenPart: Story = {
     args: {
         barn: {

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/FamiliehendelseContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/FamiliehendelseContent.tsx
@@ -19,17 +19,6 @@ export const FamiliehendelseContent = ({ barn }: Props) => {
     const erFarEllerMedmor = søker === 'FAR_MEDMOR';
     const kunFarEllerMedmorHarRett = harBareSøkerRett && erFarEllerMedmor;
 
-    if (isUfødtBarn(barn)) {
-        return (
-            <BodyShort>
-                <FormattedMessage
-                    id="uttaksplan.periodeListeContent.familiehendelse.termin"
-                    values={{ navnMor: navnPåForeldre.mor, erFarEllerMedmor: erFarEllerMedmor }}
-                />
-            </BodyShort>
-        );
-    }
-
     if (isAdoptertBarn(barn)) {
         return (
             <BodyShort>
@@ -42,6 +31,17 @@ export const FamiliehendelseContent = ({ barn }: Props) => {
         return (
             <BodyShort>
                 <FormattedMessage id="uttaksplan.periodeListeContent.familiehendelse.bareFarMedmorHarRett" />
+            </BodyShort>
+        );
+    }
+
+    if (isUfødtBarn(barn)) {
+        return (
+            <BodyShort>
+                <FormattedMessage
+                    id="uttaksplan.periodeListeContent.familiehendelse.termin"
+                    values={{ navnMor: navnPåForeldre.mor, erFarEllerMedmor: erFarEllerMedmor }}
+                />
             </BodyShort>
         );
     }


### PR DESCRIPTION
…re far har rett

https://jira.adeo.no/browse/TFP-7010

Listevisningens informasjonstekst om termin viste teksten for når begge har rett, fordi ufødt-sjekken kjørte før BFHR-sjekken. Flytter BFHR-sjekken foran ufødt-sjekken slik at BFHR-teksten også brukes for termin (ufødt barn).