### PR TITLE
TFP-7015(uttaksplan): forhåndsutfyll forelder når bare én har rett

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -100,20 +100,9 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
     const erBareFarHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
 
     // Når bare én forelder kan ha foreldrepenger for den valgte perioden, skjuler
-    // vi forelder-spørsmålet og setter verdien bak panseret. Da slipper brukeren å
-    // svare på et spørsmål med kun ett gyldig alternativ.
-    const enesteMuligeForelder: BrukerRolleSak_fpoversikt | undefined =
-        forelderValgSynlighet.visMorRadio &&
-        !forelderValgSynlighet.visFarMedmorRadio &&
-        !forelderValgSynlighet.visBeggeRadio
-            ? 'MOR'
-            : forelderValgSynlighet.visFarMedmorRadio &&
-                !forelderValgSynlighet.visMorRadio &&
-                !forelderValgSynlighet.visBeggeRadio
-              ? 'FAR_MEDMOR'
-              : undefined;
-
-    const visForelderValg = enesteMuligeForelder === undefined;
+    // vi forelder-spørsmålet (se VIS_FORELDER_VALG) og setter verdien bak panseret.
+    // Da slipper brukeren å svare på et spørsmål med kun ett gyldig alternativ.
+    const { visForelderValg, enesteMuligeForelder } = forelderValgSynlighet;
 
     useEffect(() => {
         if (forelder === undefined && enesteMuligeForelder !== undefined) {

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -97,6 +98,26 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
     const skjemaKontekstuelleAlerts = useSkjemaKontekstuelleAlerts(valgtePerioder);
 
     const erBareFarHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
+
+    // Når bare én forelder kan ha foreldrepenger for perioden (kun mor eller kun
+    // far/medmor er et gyldig valg), forhåndsutfyller vi forelderverdien slik at
+    // brukeren slipper å velge i et radiosett med bare ett alternativ.
+    const forhåndsutfyltForelder: BrukerRolleSak_fpoversikt | undefined =
+        forelderValgSynlighet.visMorRadio &&
+        !forelderValgSynlighet.visFarMedmorRadio &&
+        !forelderValgSynlighet.visBeggeRadio
+            ? 'MOR'
+            : forelderValgSynlighet.visFarMedmorRadio &&
+                !forelderValgSynlighet.visMorRadio &&
+                !forelderValgSynlighet.visBeggeRadio
+              ? 'FAR_MEDMOR'
+              : undefined;
+
+    useEffect(() => {
+        if (forelder === undefined && forhåndsutfyltForelder !== undefined) {
+            resetFormValuesVedEndringAvForelder(forhåndsutfyltForelder);
+        }
+    }, [forelder, forhåndsutfyltForelder]);
 
     const blokkerendeAlert = useBlokkerendeAlert({
         valgtePerioder,

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -99,10 +99,10 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
 
     const erBareFarHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
 
-    // Når bare én forelder kan ha foreldrepenger for perioden (kun mor eller kun
-    // far/medmor er et gyldig valg), forhåndsutfyller vi forelderverdien slik at
-    // brukeren slipper å velge i et radiosett med bare ett alternativ.
-    const forhåndsutfyltForelder: BrukerRolleSak_fpoversikt | undefined =
+    // Når bare én forelder kan ha foreldrepenger for den valgte perioden, skjuler
+    // vi forelder-spørsmålet og setter verdien bak panseret. Da slipper brukeren å
+    // svare på et spørsmål med kun ett gyldig alternativ.
+    const enesteMuligeForelder: BrukerRolleSak_fpoversikt | undefined =
         forelderValgSynlighet.visMorRadio &&
         !forelderValgSynlighet.visFarMedmorRadio &&
         !forelderValgSynlighet.visBeggeRadio
@@ -113,11 +113,13 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
               ? 'FAR_MEDMOR'
               : undefined;
 
+    const visForelderValg = enesteMuligeForelder === undefined;
+
     useEffect(() => {
-        if (forelder === undefined && forhåndsutfyltForelder !== undefined) {
-            resetFormValuesVedEndringAvForelder(forhåndsutfyltForelder);
+        if (forelder === undefined && enesteMuligeForelder !== undefined) {
+            formMethods.setValue('forelder', enesteMuligeForelder, { shouldDirty: false });
         }
-    }, [forelder, forhåndsutfyltForelder]);
+    }, [forelder, enesteMuligeForelder, formMethods]);
 
     const blokkerendeAlert = useBlokkerendeAlert({
         valgtePerioder,
@@ -169,37 +171,41 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
 
     return (
         <>
-            <RhfRadioGroup
-                name="forelder"
-                control={formMethods.control}
-                validate={[isRequired(intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.Forelder.Påkrevd' }))]}
-                label={intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.Forelder.HvemGjelder' })}
-                onChange={resetFormValuesVedEndringAvForelder}
-            >
-                {
-                    [
-                        forelderValgSynlighet.visMorRadio && (
-                            <Radio key="mor" value="MOR">
-                                <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Mor" />
-                            </Radio>
-                        ),
-                        forelderValgSynlighet.visFarMedmorRadio && (
-                            <Radio key="far" value="FAR_MEDMOR">
-                                {erMedmorDelAvSøknaden ? (
-                                    <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Medmor" />
-                                ) : (
-                                    <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Far" />
-                                )}
-                            </Radio>
-                        ),
-                        forelderValgSynlighet.visBeggeRadio && (
-                            <Radio key="begge" value="BEGGE">
-                                <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Begge" />
-                            </Radio>
-                        ),
-                    ].filter(Boolean) as React.ReactElement[]
-                }
-            </RhfRadioGroup>
+            {visForelderValg && (
+                <RhfRadioGroup
+                    name="forelder"
+                    control={formMethods.control}
+                    validate={[
+                        isRequired(intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.Forelder.Påkrevd' })),
+                    ]}
+                    label={intl.formatMessage({ id: 'LeggTilEllerEndrePeriodeForm.Forelder.HvemGjelder' })}
+                    onChange={resetFormValuesVedEndringAvForelder}
+                >
+                    {
+                        [
+                            forelderValgSynlighet.visMorRadio && (
+                                <Radio key="mor" value="MOR">
+                                    <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Mor" />
+                                </Radio>
+                            ),
+                            forelderValgSynlighet.visFarMedmorRadio && (
+                                <Radio key="far" value="FAR_MEDMOR">
+                                    {erMedmorDelAvSøknaden ? (
+                                        <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Medmor" />
+                                    ) : (
+                                        <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Far" />
+                                    )}
+                                </Radio>
+                            ),
+                            forelderValgSynlighet.visBeggeRadio && (
+                                <Radio key="begge" value="BEGGE">
+                                    <FormattedMessage id="LeggTilEllerEndrePeriodeForm.Begge" />
+                                </Radio>
+                            ),
+                        ].filter(Boolean) as React.ReactElement[]
+                    }
+                </RhfRadioGroup>
+            )}
 
             {feltSynlighet.visFlerbarnsdager && (
                 <RhfRadioGroup
@@ -222,7 +228,9 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                 </RhfRadioGroup>
             )}
 
-            {forelder !== undefined && <hr className="text-ax-border-neutral-subtle" />}
+            {forelder !== undefined && (visForelderValg || feltSynlighet.visFlerbarnsdager) && (
+                <hr className="text-ax-border-neutral-subtle" />
+            )}
 
             {forelderValgSynlighet.visKontoMorRadiogruppe && (
                 <RhfRadioGroup

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -1592,7 +1592,7 @@ describe('UttaksplanKalender', () => {
         expect(within(mai).getAllByTestId('dayColor:BEIGEOUTLINE', { exact: false })).toHaveLength(4);
     });
 
-    it('skal forhåndsutfylle forelder når kun far har rett ved ny periode', async () => {
+    it('skal skjule forelder-spørsmålet og sette verdien bak panseret når kun far har rett', async () => {
         render(<KunFarHarRettOgHarPauseperiode />);
 
         const juni = screen.getByTestId('year:2024;month:5');
@@ -1603,11 +1603,11 @@ describe('UttaksplanKalender', () => {
         await userEvent.click(screen.getAllByText('Hva vil du endre til?')[3]!);
         await userEvent.click(screen.getAllByText('Legg til')[0]!);
 
-        // Når kun far har rett til foreldrepenger, skal forelderverdien være
-        // forhåndsutfylt. Vi ser at "Far skal ha?" (kvotetype-spørsmålet) vises
-        // direkte uten at brukeren har valgt forelder.
-        expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        // Når kun far har rett til foreldrepenger, skal spørsmålet om hvem som
+        // skal ha foreldrepenger ikke vises. Verdien settes bak panseret, og vi
+        // går rett til kvotetype-spørsmålet "Far skal ha?".
         expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
+        expect(screen.queryByText('Hvem skal ha foreldrepenger?')).not.toBeInTheDocument();
     });
 
     it('skal vise avslåtte periode korrekt og så markere som hull når en sletter', async () => {

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -1592,6 +1592,24 @@ describe('UttaksplanKalender', () => {
         expect(within(mai).getAllByTestId('dayColor:BEIGEOUTLINE', { exact: false })).toHaveLength(4);
     });
 
+    it('skal forhåndsutfylle forelder når kun far har rett ved ny periode', async () => {
+        render(<KunFarHarRettOgHarPauseperiode />);
+
+        const juni = screen.getByTestId('year:2024;month:5');
+
+        await userEvent.click(within(juni).getByText('17', { exact: true }));
+        await userEvent.click(within(juni).getByText('20', { exact: true }));
+
+        await userEvent.click(screen.getAllByText('Hva vil du endre til?')[3]!);
+        await userEvent.click(screen.getAllByText('Legg til')[0]!);
+
+        // Når kun far har rett til foreldrepenger, skal forelderverdien være
+        // forhåndsutfylt. Vi ser at "Far skal ha?" (kvotetype-spørsmålet) vises
+        // direkte uten at brukeren har valgt forelder.
+        expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
+    });
+
     it('skal vise avslåtte periode korrekt og så markere som hull når en sletter', async () => {
         render(<SkalViseAvslåttPeriodeKorrekt />);
 

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -747,7 +747,7 @@ describe('UttaksplanListe', () => {
         ]);
     });
 
-    it('skal forhåndsutfylle forelder når kun far har rett ved ny periode med foreldrepenger', async () => {
+    it('skal skjule forelder-spørsmålet og sette verdien bak panseret når kun far har rett', async () => {
         const oppdaterUttaksplan = vi.fn();
 
         render(<KunFarHarRettOgHarPauseperiode oppdaterUttaksplan={oppdaterUttaksplan} />);
@@ -766,11 +766,11 @@ describe('UttaksplanListe', () => {
         await userEvent.type(tilOgMedDato, dayjs('2024-06-20').format('DD.MM.YYYY'));
         await userEvent.tab();
 
-        // Når kun far har rett til foreldrepenger, skal forelderverdien være
-        // forhåndsutfylt. Vi ser at "Far skal ha?" (kvotetype-spørsmålet) vises
-        // direkte uten at brukeren har valgt forelder.
-        expect(await screen.findByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        // Når kun far har rett til foreldrepenger, skal spørsmålet om hvem som
+        // skal ha foreldrepenger ikke vises. Verdien settes bak panseret, og vi
+        // går rett til kvotetype-spørsmålet "Far skal ha?".
         expect(await screen.findByText('Far skal ha?')).toBeInTheDocument();
+        expect(screen.queryByText('Hvem skal ha foreldrepenger?')).not.toBeInTheDocument();
     });
 
     it('Skal ikke kunne legge til ferieperiode etter 6-ukerperioden for kun far har rett', async () => {

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -747,6 +747,32 @@ describe('UttaksplanListe', () => {
         ]);
     });
 
+    it('skal forhåndsutfylle forelder når kun far har rett ved ny periode med foreldrepenger', async () => {
+        const oppdaterUttaksplan = vi.fn();
+
+        render(<KunFarHarRettOgHarPauseperiode oppdaterUttaksplan={oppdaterUttaksplan} />);
+
+        expect(await screen.findByText('24. mai 24 - 28. mai 24')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('Legg til periode'));
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Legge til periode med foreldrepenger'));
+
+        expect(await screen.findByText('Hvilke datoer skal perioden være?')).toBeInTheDocument();
+        const fraOgMedDato = screen.getByLabelText('Fra og med dato');
+        await userEvent.type(fraOgMedDato, dayjs('2024-06-14').format('DD.MM.YYYY'));
+        await userEvent.tab();
+        const tilOgMedDato = screen.getByLabelText('Til og med dato');
+        await userEvent.type(tilOgMedDato, dayjs('2024-06-20').format('DD.MM.YYYY'));
+        await userEvent.tab();
+
+        // Når kun far har rett til foreldrepenger, skal forelderverdien være
+        // forhåndsutfylt. Vi ser at "Far skal ha?" (kvotetype-spørsmålet) vises
+        // direkte uten at brukeren har valgt forelder.
+        expect(await screen.findByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        expect(await screen.findByText('Far skal ha?')).toBeInTheDocument();
+    });
+
     it('Skal ikke kunne legge til ferieperiode etter 6-ukerperioden for kun far har rett', async () => {
         const oppdaterUttaksplan = vi.fn();
 

--- a/packages/uttaksplan/src/regler/Synlighetsregler.stories.tsx
+++ b/packages/uttaksplan/src/regler/Synlighetsregler.stories.tsx
@@ -17,6 +17,7 @@ import {
 import {
     VIS_BEGGE_RADIO,
     VIS_FAR_MEDMOR_RADIO,
+    VIS_FORELDER_VALG,
     VIS_KONTO_FAR_MEDMOR_RADIOGRUPPE,
     VIS_KONTO_MOR_RADIOGRUPPE,
     VIS_MOR_RADIO,
@@ -65,7 +66,9 @@ const FORELDER_VALG_OMRÅDE: Synlighetsområde = {
     område: 'Hvilke alternativ vises i «Hvem gjelder perioden»-radiogruppen?',
     beskrivelse:
         'Når brukeren legger til eller endrer en periode, må det velges hvilken forelder perioden gjelder. ' +
-        'Reglene under bestemmer hvilke alternativ (Mor, Far/medmor, Begge) som er tilgjengelige.',
+        'Reglene under bestemmer hvilke alternativ (Mor, Far/medmor, Begge) som er tilgjengelige. Finnes det ' +
+        'bare ett tilgjengelig alternativ — typisk når bare én forelder har rett — skjules hele spørsmålet, og ' +
+        'forelderverdien settes automatisk (se forelderValg.visForelderValg).',
     seOgså: [
         {
             tekst: 'Hvilke kvotetyper er gyldige for mor? (Kvotetyperegler)',
@@ -77,6 +80,7 @@ const FORELDER_VALG_OMRÅDE: Synlighetsområde = {
         },
     ],
     regler: [
+        VIS_FORELDER_VALG,
         VIS_MOR_RADIO,
         VIS_FAR_MEDMOR_RADIO,
         VIS_BEGGE_RADIO,

--- a/packages/uttaksplan/src/regler/synlighet/forelderValg.ts
+++ b/packages/uttaksplan/src/regler/synlighet/forelderValg.ts
@@ -53,23 +53,12 @@ export const useForelderValgSynlighet = (
     const visBeggeRadio = VIS_BEGGE_RADIO.skalVises(kontekst);
     const visForelderValg = VIS_FORELDER_VALG.skalVises(kontekst);
 
-    // Når forelder-spørsmålet skjules fordi det bare finnes ett gyldig valg, er
-    // dette forelderen perioden automatisk skal gjelde. Samtidig uttak (BEGGE)
-    // kan aldri være eneste alternativ, så her er det alltid mor eller far/medmor.
-    const enesteMuligeForelder: BrukerRolleSak_fpoversikt | undefined = visForelderValg
-        ? undefined
-        : visMorRadio
-          ? 'MOR'
-          : visFarMedmorRadio
-            ? 'FAR_MEDMOR'
-            : undefined;
-
     return {
         visMorRadio,
         visFarMedmorRadio,
         visBeggeRadio,
         visForelderValg,
-        enesteMuligeForelder,
+        enesteMuligeForelder: finnEnesteMuligeForelder({ visForelderValg, visMorRadio, visFarMedmorRadio }),
         visKontoMorRadiogruppe: VIS_KONTO_MOR_RADIOGRUPPE.skalVises(kontekst),
         visKontoFarMedmorRadiogruppe: VIS_KONTO_FAR_MEDMOR_RADIOGRUPPE.skalVises(kontekst),
         erMorGyldigForelder,
@@ -79,6 +68,28 @@ export const useForelderValgSynlighet = (
         gyldigeStønadskontoerForMor,
         gyldigeStønadskontoerForFarMedmor,
     };
+};
+
+/**
+ * Når forelder-spørsmålet skjules fordi det bare finnes ett gyldig valg, er
+ * dette forelderen perioden automatisk skal gjelde. Samtidig uttak (BEGGE) kan
+ * aldri være eneste alternativ, så her er det alltid mor eller far/medmor.
+ */
+const finnEnesteMuligeForelder = (args: {
+    visForelderValg: boolean;
+    visMorRadio: boolean;
+    visFarMedmorRadio: boolean;
+}): BrukerRolleSak_fpoversikt | undefined => {
+    if (args.visForelderValg) {
+        return undefined;
+    }
+    if (args.visMorRadio) {
+        return 'MOR';
+    }
+    if (args.visFarMedmorRadio) {
+        return 'FAR_MEDMOR';
+    }
+    return undefined;
 };
 
 type ForelderValgKontekst = {

--- a/packages/uttaksplan/src/regler/synlighet/forelderValg.ts
+++ b/packages/uttaksplan/src/regler/synlighet/forelderValg.ts
@@ -1,3 +1,5 @@
+import type { BrukerRolleSak_fpoversikt } from '@navikt/fp-types';
+
 import { useUttaksplanData } from '../../context/UttaksplanDataContext';
 import { useGyldigeKvotetyper } from '../kvotetype/kvoteRegler';
 import { erEøsUttakPeriode } from '../../types/UttaksplanPeriode';
@@ -46,10 +48,28 @@ export const useForelderValgSynlighet = (
         harGyldigeKontoerForFarMedmor: gyldigeStønadskontoerForFarMedmor.length > 0,
     };
 
+    const visMorRadio = VIS_MOR_RADIO.skalVises(kontekst);
+    const visFarMedmorRadio = VIS_FAR_MEDMOR_RADIO.skalVises(kontekst);
+    const visBeggeRadio = VIS_BEGGE_RADIO.skalVises(kontekst);
+    const visForelderValg = VIS_FORELDER_VALG.skalVises(kontekst);
+
+    // Når forelder-spørsmålet skjules fordi det bare finnes ett gyldig valg, er
+    // dette forelderen perioden automatisk skal gjelde. Samtidig uttak (BEGGE)
+    // kan aldri være eneste alternativ, så her er det alltid mor eller far/medmor.
+    const enesteMuligeForelder: BrukerRolleSak_fpoversikt | undefined = visForelderValg
+        ? undefined
+        : visMorRadio
+          ? 'MOR'
+          : visFarMedmorRadio
+            ? 'FAR_MEDMOR'
+            : undefined;
+
     return {
-        visMorRadio: VIS_MOR_RADIO.skalVises(kontekst),
-        visFarMedmorRadio: VIS_FAR_MEDMOR_RADIO.skalVises(kontekst),
-        visBeggeRadio: VIS_BEGGE_RADIO.skalVises(kontekst),
+        visMorRadio,
+        visFarMedmorRadio,
+        visBeggeRadio,
+        visForelderValg,
+        enesteMuligeForelder,
         visKontoMorRadiogruppe: VIS_KONTO_MOR_RADIOGRUPPE.skalVises(kontekst),
         visKontoFarMedmorRadiogruppe: VIS_KONTO_FAR_MEDMOR_RADIOGRUPPE.skalVises(kontekst),
         erMorGyldigForelder,
@@ -78,8 +98,8 @@ type ForelderValgKontekst = {
 export const VIS_MOR_RADIO: Synlighetsregel<ForelderValgKontekst> = {
     id: 'forelderValg.visMorRadio',
     beskrivelse:
-        'Mor-alternativet vises når mor er en gyldig forelder for den valgte perioden (mor har minst én ' +
-        'gyldig stønadskontotype) og mor ikke er låst av annen parts plan.',
+        'Mor er et tilgjengelig forelder-alternativ når mor er en gyldig forelder for den valgte perioden ' +
+        '(mor har minst én gyldig stønadskontotype) og mor ikke er låst av annen parts plan.',
     skalVises: (k) => k.erMorGyldigForelder && !k.erMorLåst,
 };
 
@@ -89,8 +109,9 @@ export const VIS_MOR_RADIO: Synlighetsregel<ForelderValgKontekst> = {
 export const VIS_FAR_MEDMOR_RADIO: Synlighetsregel<ForelderValgKontekst> = {
     id: 'forelderValg.visFarMedmorRadio',
     beskrivelse:
-        'Far/medmor-alternativet vises når far/medmor er en gyldig forelder for den valgte perioden ' +
-        '(far/medmor har minst én gyldig stønadskontotype) og far/medmor ikke er låst av annen parts plan.',
+        'Far/medmor er et tilgjengelig forelder-alternativ når far/medmor er en gyldig forelder for den ' +
+        'valgte perioden (far/medmor har minst én gyldig stønadskontotype) og far/medmor ikke er låst av ' +
+        'annen parts plan.',
     skalVises: (k) => k.erFarMedmorGyldigForelder && !k.erFarMedmorLåst,
 };
 
@@ -100,10 +121,26 @@ export const VIS_FAR_MEDMOR_RADIO: Synlighetsregel<ForelderValgKontekst> = {
 export const VIS_BEGGE_RADIO: Synlighetsregel<ForelderValgKontekst> = {
     id: 'forelderValg.visBeggeRadio',
     beskrivelse:
-        'Begge-alternativet (samtidig uttak) vises bare når både mor og far/medmor er gyldige foreldre ' +
-        'for perioden, og det ikke finnes noen EØS-perioder i planen — samtidig uttak støttes ikke ' +
+        'Begge-alternativet (samtidig uttak) er tilgjengelig bare når både mor og far/medmor er gyldige ' +
+        'foreldre for perioden, og det ikke finnes noen EØS-perioder i planen — samtidig uttak støttes ikke ' +
         'sammen med EØS-perioder.',
     skalVises: (k) => k.erMorGyldigForelder && k.erFarMedmorGyldigForelder && !k.erMinstEnEøsPeriode,
+};
+
+/**
+ * Vis selve forelder-spørsmålet «Hvem skal ha foreldrepenger?».
+ */
+export const VIS_FORELDER_VALG: Synlighetsregel<ForelderValgKontekst> = {
+    id: 'forelderValg.visForelderValg',
+    beskrivelse:
+        'Spørsmålet «Hvem skal ha foreldrepenger?» vises bare når det finnes mer enn ett tilgjengelig ' +
+        'forelder-alternativ (Mor, Far/medmor og/eller Begge). Når bare ett alternativ er tilgjengelig — ' +
+        'typisk når bare én forelder har rett til foreldrepenger — skjules spørsmålet, og forelderverdien ' +
+        'settes automatisk til det eneste mulige valget.',
+    skalVises: (k) =>
+        [VIS_MOR_RADIO.skalVises(k), VIS_FAR_MEDMOR_RADIO.skalVises(k), VIS_BEGGE_RADIO.skalVises(k)].filter(
+            Boolean,
+        ).length > 1,
 };
 
 /**
@@ -133,6 +170,8 @@ type ForelderValgSynlighet = {
     visMorRadio: boolean;
     visFarMedmorRadio: boolean;
     visBeggeRadio: boolean;
+    visForelderValg: boolean;
+    enesteMuligeForelder: BrukerRolleSak_fpoversikt | undefined;
     visKontoMorRadiogruppe: boolean;
     visKontoFarMedmorRadiogruppe: boolean;
     erMorGyldigForelder: boolean;


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7015

Når bare én forelder har rett til foreldrepenger, forhåndsutfylles "hvem skal ha foreldrepenger" i panelet for å legge til periode, slik at brukeren slipper å velge i et radiosett med bare ett alternativ. Gjelder både kalender- og listevisning via den delte LeggTilEllerEndrePeriodeFellesForm.