### PR TITLE
TFP-7016(uttaksplan): ikke vis forskyvspørsmål når «endre uten å flytte» e…

### DIFF
--- a/packages/uttaksplan/src/felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel.tsx
+++ b/packages/uttaksplan/src/felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel.tsx
@@ -1,34 +1,18 @@
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { Alert, BodyShort, Button, Detail, HStack, Radio, RadioGroup, VStack } from '@navikt/ds-react';
-
-import { useForskyvEllerErstattAlerts } from '../../regler/alert/informasjonsAlertHooks';
+import { BodyShort, Button, Detail, HStack, Radio, RadioGroup, VStack } from '@navikt/ds-react';
 
 interface Props {
-    valgtePerioder: Array<{ fom: string; tom: string }>;
-    erFerie: boolean;
-    erGradert: boolean;
     setVisEndreEllerForskyvPanel: (skalVisPanel: boolean) => void;
     leggTilEllerForskyvPeriode: (skalForskyve: boolean) => void;
 }
 
 export const LeggTilPeriodeForskyvEllerErstattPanel = ({
-    valgtePerioder,
-    erFerie,
-    erGradert,
     setVisEndreEllerForskyvPanel,
     leggTilEllerForskyvPeriode,
 }: Props) => {
     const [skalForskyvePeriode, setSkalForskyvePeriode] = useState<boolean | undefined>(undefined);
-
-    const { senerePerioderReadonly, valgteDagerFørSeksUker, valgteDagerFørFamhend } = useForskyvEllerErstattAlerts({
-        valgtePerioder,
-        erFerie,
-        erGradert,
-    });
-
-    const harDisablingAlert = Boolean(senerePerioderReadonly || valgteDagerFørSeksUker || valgteDagerFørFamhend);
 
     return (
         <VStack gap="space-16">
@@ -37,7 +21,7 @@ export const LeggTilPeriodeForskyvEllerErstattPanel = ({
                 description={<FormattedMessage id="RedigeringPanel.HvaSkalSkjeBeskrivelse" />}
                 onChange={(value: boolean) => setSkalForskyvePeriode(value)}
             >
-                <Radio value={true} disabled={harDisablingAlert}>
+                <Radio value={true}>
                     <VStack gap="space-4">
                         <BodyShort>
                             <FormattedMessage id="RedigeringPanel.FlyttPlanen" />
@@ -62,15 +46,6 @@ export const LeggTilPeriodeForskyvEllerErstattPanel = ({
                     </VStack>
                 </Radio>
             </RadioGroup>
-            {senerePerioderReadonly && (
-                <Alert variant={senerePerioderReadonly.variant}>{senerePerioderReadonly.melding}</Alert>
-            )}
-            {valgteDagerFørSeksUker && (
-                <Alert variant={valgteDagerFørSeksUker.variant}>{valgteDagerFørSeksUker.melding}</Alert>
-            )}
-            {valgteDagerFørFamhend && (
-                <Alert variant={valgteDagerFørFamhend.variant}>{valgteDagerFørFamhend.melding}</Alert>
-            )}
             <HStack justify="space-between">
                 <Button
                     type="button"

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -996,13 +996,13 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getByText('Legg til'));
 
-        expect(await screen.findByText('Hva skal skje med resten av planen?')).toBeInTheDocument();
+        // Mor sine senere perioder er låst, så «Endre uten å flytte resten av
+        // planen» er eneste mulige valg. Da skal spørsmålet ikke vises, og
+        // endringen utføres direkte uten å flytte resten av planen.
+        expect(screen.queryByText('Hva skal skje med resten av planen?')).not.toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Endre uten å flytte resten av planen'));
-
-        await userEvent.click(screen.getByText('Fortsett'));
-
-        expect(within(juni).getByTestId('day:14;dayColor:LIGHTBLUEGREEN')).toBeInTheDocument();
+        const juniEtter = screen.getByTestId('year:2024;month:5');
+        expect(await within(juniEtter).findByTestId('day:14;dayColor:LIGHTBLUEGREEN')).toBeInTheDocument();
     });
 
     it('dersom far/medmor tar ut fedrekvoten i perioden rundt fødsel forbeholdt mor må han laste opp dokumentasjon', async () => {
@@ -1061,7 +1061,7 @@ describe('UttaksplanKalender', () => {
         expect(within(juni).getByTestId('day:17;dayColor:BLUESTRIPED')).toBeInTheDocument();
     });
 
-    it('skal ikke kunne forskyve perioder når en har valgt dager før familiehendelsesdato', async () => {
+    it('skal ikke vise forskyvspørsmålet når en har valgt dager før familiehendelsesdato', async () => {
         render(<MorSøkerMedSamtidigUttakFarUtsettelseFarOgGradering />);
 
         const april = screen.getByTestId('year:2024;month:3');
@@ -1075,18 +1075,14 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getByText('Endre til ferie'));
 
-        expect(await screen.findByText('Hva skal skje med resten av planen?')).toBeInTheDocument();
-        expect(
-            screen.getByText('Du kan ikke forskyve perioder når du har valgt dager før seks uker etter fødsel/termin'),
-        ).toBeInTheDocument();
-        expect(screen.getByLabelText('Endre og flytt resten av planen')).toBeDisabled();
+        // Når «Endre og flytt resten av planen» ikke er mulig (valgt dager før seks
+        // uker etter fødsel/termin) er «Endre uten å flytte» eneste valg. Da skal
+        // spørsmålet ikke vises – endringen utføres direkte uten å flytte planen.
+        expect(screen.queryByText('Hva skal skje med resten av planen?')).not.toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Endre uten å flytte resten av planen'));
-
-        await userEvent.click(screen.getByText('Fortsett'));
-
-        expect(within(april).getByTestId('day:1;dayColor:BLUEOUTLINE')).toBeInTheDocument();
-        expect(within(april).getByTestId('day:19;dayColor:BLACK')).toBeInTheDocument();
+        const aprilEtter = screen.getByTestId('year:2024;month:3');
+        expect(await within(aprilEtter).findByTestId('day:1;dayColor:BLUEOUTLINE')).toBeInTheDocument();
+        expect(within(aprilEtter).getByTestId('day:19;dayColor:BLACK')).toBeInTheDocument();
     });
 
     it('skal kunne velge å forskyve periodene ved endring til fars periode', async () => {

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -73,8 +73,6 @@ export const HvaVilDuEndreTilPanel = ({ åpneRedigeringsmodus, labels }: Props) 
         sammenslåtteValgtePerioder,
     );
 
-    // Ferie legges alltid inn for mor, og kan ikke flytte resten av planen når
-    // «Endre uten å flytte» er eneste valg.
     const kanKunErstatte = useKanKunErstatte({
         valgtePerioder: sammenslåtteValgtePerioder,
         erFerie: true,

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -10,6 +10,7 @@ import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { useUttaksplanData } from '../../../../context/UttaksplanDataContext';
 import { LeggTilPeriodeForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel';
 import { useVisForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/useVisForskyvEllerErstattPanel';
+import { useKanKunErstatte } from '../../../../regler/alert/informasjonsAlertHooks';
 import { useKnapperIRedigeringspanelSynlighet } from '../../../../regler/synlighet/knapperIRedigeringspanel';
 import { erEøsUttakPeriode, erVanligUttakPeriode } from '../../../../types/UttaksplanPeriode';
 import { getVarighetString } from '../../../../utils/dateUtils';
@@ -72,6 +73,14 @@ export const HvaVilDuEndreTilPanel = ({ åpneRedigeringsmodus, labels }: Props) 
         sammenslåtteValgtePerioder,
     );
 
+    // Ferie legges alltid inn for mor, og kan ikke flytte resten av planen når
+    // «Endre uten å flytte» er eneste valg.
+    const kanKunErstatte = useKanKunErstatte({
+        valgtePerioder: sammenslåtteValgtePerioder,
+        erFerie: true,
+        erGradert: false,
+    });
+
     const {
         skalViseUtsettelsesknapp,
         skalVisePauseknapp,
@@ -116,9 +125,6 @@ export const HvaVilDuEndreTilPanel = ({ åpneRedigeringsmodus, labels }: Props) 
             {!erMinimert && visEndreEllerForskyvPanel && (
                 <Box padding="space-24">
                     <LeggTilPeriodeForskyvEllerErstattPanel
-                        valgtePerioder={sammenslåtteValgtePerioder}
-                        erFerie
-                        erGradert={false}
                         setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                         leggTilEllerForskyvPeriode={leggTilEllerForskyvPeriode}
                     />
@@ -175,7 +181,7 @@ export const HvaVilDuEndreTilPanel = ({ åpneRedigeringsmodus, labels }: Props) 
                                             variant="secondary"
                                             size="small"
                                             onClick={() =>
-                                                erEksisterendePerioderEtterValgteDager
+                                                erEksisterendePerioderEtterValgteDager && !kanKunErstatte
                                                     ? setVisEndreEllerForskyvPanel(true)
                                                     : leggTilEllerForskyvPeriode(false)
                                             }

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -20,7 +20,7 @@ import {
 import { LeggTilPeriodeForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel';
 import { useVisForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/useVisForskyvEllerErstattPanel';
 import { useFormSubmitValidator } from '../../../../felles/uttaksplanValidatorer';
-import { useLeggTilEndreSkjemaInfoAlerts } from '../../../../regler/alert/informasjonsAlertHooks';
+import { useLeggTilEndreSkjemaInfoAlerts, useKanKunErstatte } from '../../../../regler/alert/informasjonsAlertHooks';
 import { erEøsUttakPeriode } from '../../../../types/UttaksplanPeriode';
 import { useAlleUttakPerioderInklTapteDager } from '../../../../utils/lagHullPerioder';
 import { erDetEksisterendePerioderEtterValgtePerioder } from '../../../../utils/periodeUtils';
@@ -107,6 +107,15 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
             : [],
     );
 
+    const erGradertMor =
+        skalDuKombinereArbeidOgUttakMor === true && (forelder === 'MOR' || forelder === 'BEGGE');
+
+    const kanKunErstatte = useKanKunErstatte({
+        valgtePerioder: sammenslåtteValgtePerioder,
+        erFerie: false,
+        erGradert: erGradertMor,
+    });
+
     const onSubmit = (values: LeggTilEllerEndrePeriodeFormFormValues) => {
         const submitFeilmelding = formSubmitValidator(sammenslåtteValgtePerioder, values);
 
@@ -118,6 +127,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
 
         if (
             !morsAktivitetIkkeOppgittAlert &&
+            !kanKunErstatte &&
             erDetEksisterendePerioderEtterValgtePerioder(uttakPerioder, sammenslåtteValgtePerioder)
         ) {
             setVisEndreEllerForskyvPanel(true);
@@ -144,9 +154,6 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
         <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
             {visEndreEllerForskyvPanel && (
                 <LeggTilPeriodeForskyvEllerErstattPanel
-                    valgtePerioder={sammenslåtteValgtePerioder}
-                    erFerie={false}
-                    erGradert={skalDuKombinereArbeidOgUttakMor === true && (forelder === 'MOR' || forelder === 'BEGGE')}
                     setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                     leggTilEllerForskyvPeriode={leggIKalender}
                 />

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
 
@@ -797,7 +797,12 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
 
-        expect(screen.getByText('Hva skal skje med resten av planen?')).toBeInTheDocument();
+        // Annen parts EØS-perioder ligger låst senere i planen, så «Endre uten å
+        // flytte resten av planen» er eneste valg. Da skal spørsmålet ikke vises,
+        // og ferien legges til direkte uten å flytte resten av planen.
+        expect(screen.queryByText('Hva skal skje med resten av planen?')).not.toBeInTheDocument();
+
+        await waitFor(() => expect(oppdaterUttaksplan).toHaveBeenCalledTimes(1));
     });
 
     it('Bare far har rett - avslåtte perioder skal ikke vise "med aktivitetskrav" i listevisningen', async () => {

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -26,7 +26,7 @@ import {
     FormValues as UtsettelseFormValues,
 } from '../../felles/utsettelse/LeggTilUtsettelseForm';
 import { useFormSubmitValidator } from '../../felles/uttaksplanValidatorer';
-import { useListePanelInfoAlerts } from '../../regler/alert/informasjonsAlertHooks';
+import { useListePanelInfoAlerts, useKanKunErstatte } from '../../regler/alert/informasjonsAlertHooks';
 import { lagHvaVilDuGjøreValidatorer } from '../../regler/felt/hvaVilDuGjøre';
 import { useGyldigeKvotetyper } from '../../regler/kvotetype/kvoteRegler';
 import {
@@ -115,6 +115,15 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
             : [],
     );
 
+    const kanKunErstatte = useKanKunErstatte({
+        valgtePerioder: fomValue && tomValue ? [{ fom: fomValue, tom: tomValue }] : [],
+        erFerie: hvaVilDuGjøre === 'LEGG_TIL_FERIE',
+        erGradert:
+            hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
+            (forelder === 'MOR' || forelder === 'BEGGE') &&
+            skalDuKombinereArbeidOgUttakMor === true,
+    });
+
     const handleAddPeriode = (nyPeriode: UttakPeriode_fpoversikt[], skalForskyve: boolean) => {
         const builder = new UttakPeriodeBuilder(uttakPerioder, 'liste');
         if (uttaksplanperiode) {
@@ -163,6 +172,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
 
         if (
             !harPeriodeDerMorsAktivitetIkkeErValgt &&
+            !kanKunErstatte &&
             erDetEksisterendePerioderEtterValgtePerioder(uttakPerioder, [
                 {
                     fom: uttaksplanperiode?.fom ?? notEmpty(fomValue),
@@ -321,13 +331,6 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
             <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
                 {visEndreEllerForskyvPanel && fomValue && tomValue && (
                     <LeggTilPeriodeForskyvEllerErstattPanel
-                        valgtePerioder={[{ fom: fomValue, tom: tomValue }]}
-                        erFerie={hvaVilDuGjøre === 'LEGG_TIL_FERIE'}
-                        erGradert={
-                            hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
-                            (forelder === 'MOR' || forelder === 'BEGGE') &&
-                            skalDuKombinereArbeidOgUttakMor === true
-                        }
                         setVisEndreEllerForskyvPanel={setVisEndreEllerForskyvPanel}
                         leggTilEllerForskyvPeriode={leggIListe}
                     />

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -61,6 +61,15 @@ interface Props {
     setValgtPeriodeIndex?: (valgtPeriodeIndex: number | undefined) => void;
 }
 
+const erGradertMorsUttak = (
+    hvaVilDuGjøre: HvaVilDuGjøre | undefined,
+    forelder: BrukerRolleSak_fpoversikt | 'BEGGE' | undefined,
+    skalDuKombinereArbeidOgUttakMor: boolean | undefined,
+): boolean =>
+    hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
+    (forelder === 'MOR' || forelder === 'BEGGE') &&
+    skalDuKombinereArbeidOgUttakMor === true;
+
 export const LeggTilEllerEndrePeriodeListPanel = ({
     erNyPeriodeModus,
     uttaksplanperiode,
@@ -104,24 +113,15 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const ønskerFlerbarnsdager = formMethods.watch('ønskerFlerbarnsdager');
     const skalDuKombinereArbeidOgUttakMor = formMethods.watch('skalDuKombinereArbeidOgUttakMor');
 
-    const { visEndreEllerForskyvPanel, setVisEndreEllerForskyvPanel } = useVisForskyvEllerErstattPanel(
-        fomValue && tomValue
-            ? [
-                  {
-                      fom: fomValue,
-                      tom: tomValue,
-                  },
-              ]
-            : [],
-    );
+    const valgtePerioder = fomValue && tomValue ? [{ fom: fomValue, tom: tomValue }] : [];
+
+    const { visEndreEllerForskyvPanel, setVisEndreEllerForskyvPanel } =
+        useVisForskyvEllerErstattPanel(valgtePerioder);
 
     const kanKunErstatte = useKanKunErstatte({
-        valgtePerioder: fomValue && tomValue ? [{ fom: fomValue, tom: tomValue }] : [],
+        valgtePerioder,
         erFerie: hvaVilDuGjøre === 'LEGG_TIL_FERIE',
-        erGradert:
-            hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
-            (forelder === 'MOR' || forelder === 'BEGGE') &&
-            skalDuKombinereArbeidOgUttakMor === true,
+        erGradert: erGradertMorsUttak(hvaVilDuGjøre, forelder, skalDuKombinereArbeidOgUttakMor),
     });
 
     const handleAddPeriode = (nyPeriode: UttakPeriode_fpoversikt[], skalForskyve: boolean) => {

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -178,7 +178,7 @@ export const usePeriodeDetaljerAlerts = (input: {
 };
 
 /** Alerter i forskyv- og erstatt-panelene. */
-export const useForskyvEllerErstattAlerts = (input: {
+const useForskyvEllerErstattAlerts = (input: {
     valgtePerioder: readonly Periode[];
     erFerie?: boolean;
     erGradert?: boolean;
@@ -222,6 +222,24 @@ export const useForskyvEllerErstattAlerts = (input: {
         valgteDagerFørSeksUker: tilAktiv(VALGTE_DAGER_FØR_SEKS_UKER, ctx),
         valgteDagerFørFamhend: tilAktiv(VALGTE_DAGER_FØR_FAMHEND, ctx),
     };
+};
+
+/**
+ * Når «Endre og flytt resten av planen» ikke er mulig (det finnes blokkerende
+ * forhold – senere låste perioder eller valgte dager før/rundt familiehendelsen)
+ * er «Endre uten å flytte resten av planen» det eneste mulige valget. Da skal vi
+ * ikke stille spørsmålet «Hva skal skje med resten av planen?», men utføre
+ * endringen direkte uten å flytte resten av planen.
+ */
+export const useKanKunErstatte = (input: {
+    valgtePerioder: readonly Periode[];
+    erFerie?: boolean;
+    erGradert?: boolean;
+}): boolean => {
+    const { senerePerioderReadonly, valgteDagerFørSeksUker, valgteDagerFørFamhend } =
+        useForskyvEllerErstattAlerts(input);
+
+    return Boolean(senerePerioderReadonly || valgteDagerFørSeksUker || valgteDagerFørFamhend);
 };
 
 const tilAktiv = <T,>(regel: Alertregel<T>, ctx: T): AktivAlertMetadata | undefined =>

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
@@ -198,8 +198,9 @@ export const IKKE_REDIGERBAR_PLEIEPENGER = lagAlertregel<PeriodeDetaljerKontekst
 export const SENERE_PERIODER_READONLY = lagAlertregel<ForskyvEllerErstattKontekst>({
     id: 'informasjonsAlerts.senerePerioderReadonly',
     beskrivelse:
-        'Brukeren har valgt forskyv eller erstatt, og det finnes senere perioder i ' +
-        'planen som ikke kan endres. Alerten forklarer at disse blir stående.',
+        'Brukeren legger inn eller endrer en periode, og det finnes senere perioder i ' +
+        'planen som ikke kan endres. Da er «Endre uten å flytte resten av planen» det ' +
+        'eneste mulige valget, og spørsmålet «Hva skal skje med resten av planen?» vises ikke.',
     visningssteder: ['forskyv-eller-erstatt'],
     meldinger: [
         <FormattedMessage key="RedigeringPanel.SenerePerioderReadonly" id="RedigeringPanel.SenerePerioderReadonly" />,
@@ -213,8 +214,9 @@ export const VALGTE_DAGER_FØR_SEKS_UKER = lagAlertregel<ForskyvEllerErstattKont
     id: 'informasjonsAlerts.valgteDagerFørSeksUkerEtterFamDato',
     beskrivelse:
         'Brukeren har valgt dager som ligger innenfor seks uker etter familiehendelses' +
-        'datoen (gjelder ikke adopsjon). Alerten forklarer konsekvenser for ' +
-        'forskyv/erstatt-operasjonen.',
+        'datoen (gjelder ikke adopsjon). Da kan ikke resten av planen flyttes, så ' +
+        'spørsmålet «Hva skal skje med resten av planen?» vises ikke – endringen ' +
+        'utføres direkte uten å flytte resten av planen.',
     visningssteder: ['forskyv-eller-erstatt'],
     meldinger: [
         <FormattedMessage
@@ -231,8 +233,9 @@ export const VALGTE_DAGER_FØR_FAMHEND = lagAlertregel<ForskyvEllerErstattKontek
     id: 'informasjonsAlerts.valgteDagerFørFamiliehendelsesdato',
     beskrivelse:
         'Brukeren har valgt dager før familiehendelsesdatoen, men ikke innenfor seks ' +
-        'uker etter (gjelder ikke adopsjon). Alerten forklarer konsekvenser for ' +
-        'forskyv/erstatt.',
+        'uker etter (gjelder ikke adopsjon). Da kan ikke resten av planen flyttes, så ' +
+        'spørsmålet «Hva skal skje med resten av planen?» vises ikke – endringen ' +
+        'utføres direkte uten å flytte resten av planen.',
     visningssteder: ['forskyv-eller-erstatt'],
     meldinger: [
         <FormattedMessage


### PR DESCRIPTION
…r eneste valg

https://jira.adeo.no/browse/TFP-7016

Når en legger inn eller endrer noe før/rundt termin/fødsel (ferie, gradert uttak, uttak av fellesperiode), eller når senere perioder er låst, er «Endre uten å flytte resten av planen» det eneste mulige valget. Da vises ikke lenger spørsmålet «Hva skal skje med resten av planen?» – endringen utføres direkte uten å flytte resten av planen, slik sletting av periode allerede oppfører seg.