### PR TITLE
TFP-7011(uttaksplan): vis datovalg først og filtrer «Hva vil du gjøre» i …

### DIFF
--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -32,9 +32,6 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Legg til periode'));
 
-        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Legge til ferie'));
-
         expect(await screen.findByText('Hvilke datoer skal perioden være?')).toBeInTheDocument();
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2025-06-30').format('DD.MM.YYYY'));
@@ -42,6 +39,9 @@ describe('UttaksplanListe', () => {
         const tilOgMedDato = screen.getByLabelText('Til og med dato');
         await userEvent.type(tilOgMedDato, dayjs('2025-08-28').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Legge til ferie'));
 
         await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
 
@@ -101,9 +101,6 @@ describe('UttaksplanListe', () => {
         expect(screen.getByText('09. mai 25 - 11. des. 25')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Legg til periode'));
-        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Legge til periode med foreldrepenger'));
-
         expect(await screen.findByText('Hvilke datoer skal perioden være?')).toBeInTheDocument();
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2025-06-30').format('DD.MM.YYYY'));
@@ -111,6 +108,9 @@ describe('UttaksplanListe', () => {
         const tilOgMedDato = screen.getByLabelText('Til og med dato');
         await userEvent.type(tilOgMedDato, dayjs('2025-08-28').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Legge til periode med foreldrepenger'));
 
         expect(await screen.findByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
         await userEvent.click(screen.getByText('Begge'));
@@ -504,9 +504,6 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Legg til periode'));
 
-        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Legge til periode med foreldrepenger'));
-
         expect(await screen.findByText('Hvilke datoer skal perioden være?')).toBeInTheDocument();
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2025-06-30').format('DD.MM.YYYY'));
@@ -514,6 +511,9 @@ describe('UttaksplanListe', () => {
         const tilOgMedDato = screen.getByLabelText('Til og med dato');
         await userEvent.type(tilOgMedDato, dayjs('2025-08-28').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Legge til periode med foreldrepenger'));
 
         expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
         expect(screen.queryByText('Mor')).not.toBeInTheDocument();
@@ -599,7 +599,7 @@ describe('UttaksplanListe', () => {
         ]);
     });
 
-    it('Skal ha periode med utsettelse og legge til ny periode med utsettelse', async () => {
+    it('Skal kun vise utsettelse-valget når valgt tidsrom er innenfor 6-ukersperioden', async () => {
         const oppdaterUttaksplan = vi.fn();
 
         render(<HarUtsettelse oppdaterUttaksplan={oppdaterUttaksplan} />);
@@ -619,8 +619,6 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Legg til periode'));
 
-        await userEvent.click(screen.getByText('Utsettelse'));
-
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2025-10-26').format('DD.MM.YYYY'));
         await userEvent.tab();
@@ -628,16 +626,11 @@ describe('UttaksplanListe', () => {
         await userEvent.type(tilOgMedDato, dayjs('2025-10-28').format('DD.MM.YYYY'));
         await userEvent.tab();
 
-        await userEvent.selectOptions(screen.getByLabelText('Velg hvorfor du skal utsette'), 'SØKER_SYKDOM');
+        // Tidsrom utenfor 6-ukersperioden: «Utsettelse» skal ikke være et valg
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Utsettelse' })).not.toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
-
-        expect(
-            await screen.findByText(
-                'Utsettelse kan kun legges til når en har valgt dager i 6-ukersperioden etter fødsel/termin',
-            ),
-        ).toBeInTheDocument();
-
+        // Endre til et tidsrom innenfor 6-ukersperioden → «Utsettelse» dukker opp
         await userEvent.clear(fraOgMedDato);
         await userEvent.type(fraOgMedDato, dayjs('2025-08-26').format('DD.MM.YYYY'));
         await userEvent.tab();
@@ -645,6 +638,10 @@ describe('UttaksplanListe', () => {
         await userEvent.clear(tilOgMedDato);
         await userEvent.type(tilOgMedDato, dayjs('2025-08-28').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        await userEvent.click(await screen.findByRole('radio', { name: 'Utsettelse' }));
+
+        await userEvent.selectOptions(screen.getByLabelText('Velg hvorfor du skal utsette'), 'SØKER_SYKDOM');
 
         await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
 
@@ -687,8 +684,6 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Legg til periode'));
 
-        await userEvent.click(screen.getByText('Pause'));
-
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2024-04-29').format('DD.MM.YYYY'));
         await userEvent.tab();
@@ -696,19 +691,18 @@ describe('UttaksplanListe', () => {
         await userEvent.type(tilOgMedDato, dayjs('2024-05-30').format('DD.MM.YYYY'));
         await userEvent.tab();
 
-        await userEvent.selectOptions(screen.getByLabelText('Hva gjør mor i denne perioden?'), 'ARBEID');
+        // Tidsrom før utløpet av 6-ukersperioden: «Pause» skal ikke være et valg
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Pause' })).not.toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
-
-        expect(
-            await screen.findByText(
-                'Pause kan kun legges til når en har valgt dager etter 6-ukersperioden etter fødsel/termin',
-            ),
-        ).toBeInTheDocument();
-
+        // Endre fra-dato til etter 6-ukersperioden → «Pause» dukker opp
         await userEvent.clear(fraOgMedDato);
         await userEvent.type(fraOgMedDato, dayjs('2024-05-29').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        await userEvent.click(await screen.findByRole('radio', { name: 'Pause' }));
+
+        await userEvent.selectOptions(screen.getByLabelText('Hva gjør mor i denne perioden?'), 'ARBEID');
 
         await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
 
@@ -758,15 +752,9 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getAllByText('Endre')[3]!);
 
-        await userEvent.click(screen.getByText('Ferie'));
-
-        await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
-
-        expect(
-            await screen.findByText(
-                'Ferie og perioder uten foreldrepenger kan kun legges til i 6-ukersperioden etter fødsel/termin eller før',
-            ),
-        ).toBeInTheDocument();
+        // Tidsrommet ligger etter 6-ukersperioden for kun-far-har-rett → «Ferie» er ikke et gyldig valg
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Ferie' })).not.toBeInTheDocument();
     });
 
     it('Skal ikke kunne endre EØS-perioder', async () => {
@@ -778,14 +766,15 @@ describe('UttaksplanListe', () => {
 
         await userEvent.click(screen.getByText('Legg til periode'));
 
-        await userEvent.click(screen.getByText('Legge til ferie'));
-
         const fraOgMedDato = screen.getByLabelText('Fra og med dato');
         await userEvent.type(fraOgMedDato, dayjs('2025-10-08').format('DD.MM.YYYY'));
         await userEvent.tab();
         const tilOgMedDato = screen.getByLabelText('Til og med dato');
         await userEvent.type(tilOgMedDato, dayjs('2025-10-15').format('DD.MM.YYYY'));
         await userEvent.tab();
+
+        expect(await screen.findByText('Hva vil du gjøre?')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Legge til ferie'));
 
         await userEvent.click(screen.getByText('Ferdig, legg til i plan'));
 

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -30,7 +30,7 @@ import { useFormSubmitValidator } from '../../felles/uttaksplanValidatorer';
 import { useListePanelInfoAlerts } from '../../regler/alert/informasjonsAlertHooks';
 import { lagHvaVilDuGjøreValidatorer } from '../../regler/felt/hvaVilDuGjøre';
 import { useGyldigeKvotetyper } from '../../regler/kvotetype/kvoteRegler';
-import { useHvaVilDuGjøreValgSynlighet } from '../../regler/synlighet/hvaVilDuGjøreValg';
+import { useHvaVilDuGjøreValgSynlighet, HvaVilDuGjøreValgSynlighet } from '../../regler/synlighet/hvaVilDuGjøreValg';
 import {
     Uttaksplanperiode,
     erEøsUttakPeriode,
@@ -271,8 +271,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const harGyldigTidsperiode =
         !!fomValue && !!tomValue && dayjs(fomValue).isValid() && dayjs(tomValue).isValid();
 
-    const { visLeggTilFerie, visLeggTilUtsettelse, visLeggTilPause, visLeggTilOpphold, visLeggTilPeriode } =
-        useHvaVilDuGjøreValgSynlighet(perioder);
+    const hvaVilDuGjøreSynlighet = useHvaVilDuGjøreValgSynlighet(perioder);
 
     const { gyldigeStønadskontoerForMor, gyldigeStønadskontoerForFarMedmor } = useGyldigeKvotetyper({
         valgtePerioder: perioder,
@@ -299,10 +298,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         harPeriodeDerMorsAktivitetIkkeErValgt,
     });
 
-    const hvaVilDuGjøreAlternativer = lagHvaVilDuGjøreAlternativer(
-        { visLeggTilFerie, visLeggTilUtsettelse, visLeggTilPause, visLeggTilOpphold, visLeggTilPeriode },
-        erNyPeriodeModus,
-    );
+    const hvaVilDuGjøreAlternativer = lagHvaVilDuGjøreAlternativer(hvaVilDuGjøreSynlighet, erNyPeriodeModus);
 
     return (
         <VStack
@@ -448,16 +444,8 @@ const leggTilDatoOgHvaVilDuGjøre = (
         : undefined;
 };
 
-type HvaVilDuGjøreSynlighet = {
-    visLeggTilFerie: boolean;
-    visLeggTilUtsettelse: boolean;
-    visLeggTilPause: boolean;
-    visLeggTilOpphold: boolean;
-    visLeggTilPeriode: boolean;
-};
-
 const lagHvaVilDuGjøreAlternativer = (
-    synlighet: HvaVilDuGjøreSynlighet,
+    synlighet: HvaVilDuGjøreValgSynlighet,
     erNyPeriodeModus: boolean,
 ): ReactElement[] => {
     const alternativer: Array<{ vis: boolean; value: HvaVilDuGjøre; nyTekst: ReactNode; endreTekst: ReactNode }> = [

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -1,6 +1,6 @@
 import { PencilIcon } from '@navikt/aksel-icons';
 import dayjs from 'dayjs';
-import { ReactElement, useState } from 'react';
+import { ReactElement, ReactNode, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -299,54 +299,10 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         harPeriodeDerMorsAktivitetIkkeErValgt,
     });
 
-    const hvaVilDuGjøreAlternativer: ReactElement[] = [];
-    if (visLeggTilFerie) {
-        hvaVilDuGjøreAlternativer.push(
-            <Radio value={'LEGG_TIL_FERIE' satisfies HvaVilDuGjøre} key="LEGG_TIL_FERIE">
-                {erNyPeriodeModus ? (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie" />
-                ) : (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie.endre" />
-                )}
-            </Radio>,
-        );
-    }
-    if (visLeggTilUtsettelse) {
-        hvaVilDuGjøreAlternativer.push(
-            <Radio value={'LEGG_TIL_UTSETTELSE' satisfies HvaVilDuGjøre} key="LEGG_TIL_UTSETTELSE">
-                <FormattedMessage id="uttaksplan.valgPanel.leggTilUtsettelse" />
-            </Radio>,
-        );
-    }
-    if (visLeggTilPause) {
-        hvaVilDuGjøreAlternativer.push(
-            <Radio value={'LEGG_TIL_PAUSE' satisfies HvaVilDuGjøre} key="LEGG_TIL_PAUSE">
-                <FormattedMessage id="uttaksplan.valgPanel.leggTilPause" />
-            </Radio>,
-        );
-    }
-    if (visLeggTilOpphold) {
-        hvaVilDuGjøreAlternativer.push(
-            <Radio value={'LEGG_TIL_OPPHOLD' satisfies HvaVilDuGjøre} key="LEGG_TIL_OPPHOLD">
-                {erNyPeriodeModus ? (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold" />
-                ) : (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold.endre" />
-                )}
-            </Radio>,
-        );
-    }
-    if (visLeggTilPeriode) {
-        hvaVilDuGjøreAlternativer.push(
-            <Radio value={'LEGG_TIL_PERIODE' satisfies HvaVilDuGjøre} key="LEGG_TIL_PERIODE">
-                {erNyPeriodeModus ? (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode" />
-                ) : (
-                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode.endre" />
-                )}
-            </Radio>,
-        );
-    }
+    const hvaVilDuGjøreAlternativer = lagHvaVilDuGjøreAlternativer(
+        { visLeggTilFerie, visLeggTilUtsettelse, visLeggTilPause, visLeggTilOpphold, visLeggTilPeriode },
+        erNyPeriodeModus,
+    );
 
     return (
         <VStack
@@ -490,4 +446,58 @@ const leggTilDatoOgHvaVilDuGjøre = (
               hvaVilDuGjøre: 'LEGG_TIL_PERIODE',
           }
         : undefined;
+};
+
+type HvaVilDuGjøreSynlighet = {
+    visLeggTilFerie: boolean;
+    visLeggTilUtsettelse: boolean;
+    visLeggTilPause: boolean;
+    visLeggTilOpphold: boolean;
+    visLeggTilPeriode: boolean;
+};
+
+const lagHvaVilDuGjøreAlternativer = (
+    synlighet: HvaVilDuGjøreSynlighet,
+    erNyPeriodeModus: boolean,
+): ReactElement[] => {
+    const alternativer: Array<{ vis: boolean; value: HvaVilDuGjøre; nyTekst: ReactNode; endreTekst: ReactNode }> = [
+        {
+            vis: synlighet.visLeggTilFerie,
+            value: 'LEGG_TIL_FERIE',
+            nyTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie" />,
+            endreTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie.endre" />,
+        },
+        {
+            vis: synlighet.visLeggTilUtsettelse,
+            value: 'LEGG_TIL_UTSETTELSE',
+            nyTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilUtsettelse" />,
+            endreTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilUtsettelse" />,
+        },
+        {
+            vis: synlighet.visLeggTilPause,
+            value: 'LEGG_TIL_PAUSE',
+            nyTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilPause" />,
+            endreTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilPause" />,
+        },
+        {
+            vis: synlighet.visLeggTilOpphold,
+            value: 'LEGG_TIL_OPPHOLD',
+            nyTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold" />,
+            endreTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold.endre" />,
+        },
+        {
+            vis: synlighet.visLeggTilPeriode,
+            value: 'LEGG_TIL_PERIODE',
+            nyTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode" />,
+            endreTekst: <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode.endre" />,
+        },
+    ];
+
+    return alternativer
+        .filter((alternativ) => alternativ.vis)
+        .map((alternativ) => (
+            <Radio value={alternativ.value} key={alternativ.value}>
+                {erNyPeriodeModus ? alternativ.nyTekst : alternativ.endreTekst}
+            </Radio>
+        ));
 };

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -1,5 +1,6 @@
 import { PencilIcon } from '@navikt/aksel-icons';
-import { useState } from 'react';
+import dayjs from 'dayjs';
+import { ReactElement, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -29,6 +30,7 @@ import { useFormSubmitValidator } from '../../felles/uttaksplanValidatorer';
 import { useListePanelInfoAlerts } from '../../regler/alert/informasjonsAlertHooks';
 import { lagHvaVilDuGjøreValidatorer } from '../../regler/felt/hvaVilDuGjøre';
 import { useGyldigeKvotetyper } from '../../regler/kvotetype/kvoteRegler';
+import { useHvaVilDuGjøreValgSynlighet } from '../../regler/synlighet/hvaVilDuGjøreValg';
 import {
     Uttaksplanperiode,
     erEøsUttakPeriode,
@@ -72,7 +74,6 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const {
         uttakPerioder,
         foreldreInfo: { søker, rettighetType },
-        familiesituasjon,
         familiehendelsedato,
         erPeriodeneTilAnnenPartLåst,
     } = useUttaksplanData();
@@ -266,6 +267,13 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     };
 
     const perioder = fomValue && tomValue ? [{ fom: fomValue, tom: tomValue }] : [];
+
+    const harGyldigTidsperiode =
+        !!fomValue && !!tomValue && dayjs(fomValue).isValid() && dayjs(tomValue).isValid();
+
+    const { visLeggTilFerie, visLeggTilUtsettelse, visLeggTilPause, visLeggTilOpphold, visLeggTilPeriode } =
+        useHvaVilDuGjøreValgSynlighet(perioder);
+
     const { gyldigeStønadskontoerForMor, gyldigeStønadskontoerForFarMedmor } = useGyldigeKvotetyper({
         valgtePerioder: perioder,
         harValgtSamtidigUttak: forelder === 'BEGGE',
@@ -290,6 +298,55 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         harValgtFerieEllerOpphold: hvaVilDuGjøre === 'LEGG_TIL_FERIE' || hvaVilDuGjøre === 'LEGG_TIL_OPPHOLD',
         harPeriodeDerMorsAktivitetIkkeErValgt,
     });
+
+    const hvaVilDuGjøreAlternativer: ReactElement[] = [];
+    if (visLeggTilFerie) {
+        hvaVilDuGjøreAlternativer.push(
+            <Radio value={'LEGG_TIL_FERIE' satisfies HvaVilDuGjøre} key="LEGG_TIL_FERIE">
+                {erNyPeriodeModus ? (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie" />
+                ) : (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie.endre" />
+                )}
+            </Radio>,
+        );
+    }
+    if (visLeggTilUtsettelse) {
+        hvaVilDuGjøreAlternativer.push(
+            <Radio value={'LEGG_TIL_UTSETTELSE' satisfies HvaVilDuGjøre} key="LEGG_TIL_UTSETTELSE">
+                <FormattedMessage id="uttaksplan.valgPanel.leggTilUtsettelse" />
+            </Radio>,
+        );
+    }
+    if (visLeggTilPause) {
+        hvaVilDuGjøreAlternativer.push(
+            <Radio value={'LEGG_TIL_PAUSE' satisfies HvaVilDuGjøre} key="LEGG_TIL_PAUSE">
+                <FormattedMessage id="uttaksplan.valgPanel.leggTilPause" />
+            </Radio>,
+        );
+    }
+    if (visLeggTilOpphold) {
+        hvaVilDuGjøreAlternativer.push(
+            <Radio value={'LEGG_TIL_OPPHOLD' satisfies HvaVilDuGjøre} key="LEGG_TIL_OPPHOLD">
+                {erNyPeriodeModus ? (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold" />
+                ) : (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold.endre" />
+                )}
+            </Radio>,
+        );
+    }
+    if (visLeggTilPeriode) {
+        hvaVilDuGjøreAlternativer.push(
+            <Radio value={'LEGG_TIL_PERIODE' satisfies HvaVilDuGjøre} key="LEGG_TIL_PERIODE">
+                {erNyPeriodeModus ? (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode" />
+                ) : (
+                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode.endre" />
+                )}
+            </Radio>,
+        );
+    }
 
     return (
         <VStack
@@ -334,52 +391,24 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                 )}
                 {!visEndreEllerForskyvPanel && (
                     <VStack gap="space-32">
-                        <RhfRadioGroup
-                            name="hvaVilDuGjøre"
-                            label={intl.formatMessage({ id: 'uttaksplan.valgPanel.label' })}
-                            control={formMethods.control}
-                            validate={[
-                                isRequired(intl.formatMessage({ id: 'leggTilPeriodePanel.hvaVilDuGjøre.påkrevd' })),
-                                ...hvaVilDuGjøreFeltvalidatorer,
-                            ]}
-                            onChange={resetFormValuesVedEndringAvHvaVilDuGjøre}
-                        >
-                            <Radio value={'LEGG_TIL_FERIE' satisfies HvaVilDuGjøre} autoFocus>
-                                {erNyPeriodeModus ? (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie" />
-                                ) : (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilFerie.endre" />
-                                )}
-                            </Radio>
-                            <>
-                                {søker === 'MOR' && familiesituasjon !== 'adopsjon' && (
-                                    <Radio value={'LEGG_TIL_UTSETTELSE' satisfies HvaVilDuGjøre}>
-                                        <FormattedMessage id="uttaksplan.valgPanel.leggTilUtsettelse" />
-                                    </Radio>
-                                )}
-                                {søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT' && (
-                                    <Radio value={'LEGG_TIL_PAUSE' satisfies HvaVilDuGjøre}>
-                                        <FormattedMessage id="uttaksplan.valgPanel.leggTilPause" />
-                                    </Radio>
-                                )}
-                            </>
-                            <Radio value={'LEGG_TIL_OPPHOLD' satisfies HvaVilDuGjøre}>
-                                {erNyPeriodeModus ? (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold" />
-                                ) : (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilOpphold.endre" />
-                                )}
-                            </Radio>
-                            <Radio value={'LEGG_TIL_PERIODE' satisfies HvaVilDuGjøre}>
-                                {erNyPeriodeModus ? (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode" />
-                                ) : (
-                                    <FormattedMessage id="uttaksplan.valgPanel.leggTilPeriode.endre" />
-                                )}
-                            </Radio>
-                        </RhfRadioGroup>
-
                         <TidsperiodeSpørsmål />
+
+                        {harGyldigTidsperiode && (
+                            <RhfRadioGroup
+                                name="hvaVilDuGjøre"
+                                label={intl.formatMessage({ id: 'uttaksplan.valgPanel.label' })}
+                                control={formMethods.control}
+                                validate={[
+                                    isRequired(
+                                        intl.formatMessage({ id: 'leggTilPeriodePanel.hvaVilDuGjøre.påkrevd' }),
+                                    ),
+                                    ...hvaVilDuGjøreFeltvalidatorer,
+                                ]}
+                                onChange={resetFormValuesVedEndringAvHvaVilDuGjøre}
+                            >
+                                {hvaVilDuGjøreAlternativer}
+                            </RhfRadioGroup>
+                        )}
 
                         {hvaVilDuGjøre === 'LEGG_TIL_PERIODE' && fomValue && tomValue && (
                             <LeggTilEllerEndrePeriodeFellesForm

--- a/packages/uttaksplan/src/regler/Synlighetsregler.stories.tsx
+++ b/packages/uttaksplan/src/regler/Synlighetsregler.stories.tsx
@@ -27,6 +27,13 @@ import {
     SKAL_VISE_PAUSEKNAPP,
     SKAL_VISE_UTSETTELSESKNAPP,
 } from './synlighet/knapperIRedigeringspanel';
+import {
+    VIS_LEGG_TIL_FERIE_VALG,
+    VIS_LEGG_TIL_OPPHOLD_VALG,
+    VIS_LEGG_TIL_PAUSE_VALG,
+    VIS_LEGG_TIL_PERIODE_VALG,
+    VIS_LEGG_TIL_UTSETTELSE_VALG,
+} from './synlighet/hvaVilDuGjøreValg';
 import { Synlighetsområde } from './synlighet/types';
 
 /**
@@ -105,6 +112,28 @@ const FELT_SYNLIGHET_OMRÅDE: Synlighetsområde = {
     ],
 };
 
+const HVA_VIL_DU_GJØRE_VALG_OMRÅDE: Synlighetsområde = {
+    id: 'hvaVilDuGjøreValg',
+    område: 'Hvilke alternativ vises i «Hva vil du gjøre»-radiogruppen (listevisning)?',
+    beskrivelse:
+        'I listevisningens «Legg til / endre periode»-panel velger brukeren datoer først. Reglene under ' +
+        'bestemmer hvilke alternativ (Ferie, Utsettelse, Pause, Periode uten foreldrepenger, Periode med ' +
+        'foreldrepenger) som vises for det valgte tidsrommet — slik at brukeren bare ser de gyldige valgene.',
+    seOgså: [
+        {
+            tekst: 'Tilsvarende «Legg til»-knapper i kalendervisningen',
+            onClick: linkTo('Uttaksplan/Synlighetsregler (dokumentasjon)', 'AlleSynlighetsregler'),
+        },
+    ],
+    regler: [
+        VIS_LEGG_TIL_FERIE_VALG,
+        VIS_LEGG_TIL_UTSETTELSE_VALG,
+        VIS_LEGG_TIL_PAUSE_VALG,
+        VIS_LEGG_TIL_OPPHOLD_VALG,
+        VIS_LEGG_TIL_PERIODE_VALG,
+    ],
+};
+
 const KNAPPER_I_REDIGERINGSPANEL_OMRÅDE: Synlighetsområde = {
     id: 'knapperIRedigeringspanel',
     område: 'Hvilke «Legg til»-knapper vises i redigeringspanelet?',
@@ -123,6 +152,7 @@ const KNAPPER_I_REDIGERINGSPANEL_OMRÅDE: Synlighetsområde = {
 const ALLE_SYNLIGHETSREGLER: readonly Synlighetsområde[] = [
     FORELDER_VALG_OMRÅDE,
     FELT_SYNLIGHET_OMRÅDE,
+    HVA_VIL_DU_GJØRE_VALG_OMRÅDE,
     KNAPPER_I_REDIGERINGSPANEL_OMRÅDE,
 ];
 

--- a/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
+++ b/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
@@ -108,7 +108,7 @@ type HvaVilDuGjøreValgKontekst = {
     valgtePerioder: Periode[];
 };
 
-type HvaVilDuGjøreValgSynlighet = {
+export type HvaVilDuGjøreValgSynlighet = {
     visLeggTilFerie: boolean;
     visLeggTilUtsettelse: boolean;
     visLeggTilPause: boolean;

--- a/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
+++ b/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
@@ -1,0 +1,127 @@
+import type { BrukerRolleSak_fpoversikt, Familiesituasjon, RettighetType_fpoversikt } from '@navikt/fp-types';
+
+import { useUttaksplanData } from '../../context/UttaksplanDataContext';
+import { UttaksperiodeValidatorer } from '../../utils/UttaksperiodeValidatorer';
+import { Periode } from '../types';
+import { Synlighetsregel } from './types';
+
+/**
+ * Hook som avgjør hvilke alternativ som vises i «Hva vil du gjøre»-radiogruppen i
+ * listevisningens «Legg til / endre periode»-panel. Datoene velges først, og
+ * reglene under filtrerer bort de alternativene som ikke er gyldige for det
+ * valgte tidsrommet — slik at brukeren slipper å velge et alternativ for så å få
+ * en feilmelding i etterkant.
+ *
+ * Logikken speiler kalendervisningen sin
+ * {@link import('./knapperIRedigeringspanel').useKnapperIRedigeringspanelSynlighet}.
+ * Henter søker, rettighet og familiesituasjon selv fra UttaksplanData; kalleren
+ * gir bare det valgte tidsrommet.
+ */
+export const useHvaVilDuGjøreValgSynlighet = (valgtePerioder: Periode[]): HvaVilDuGjøreValgSynlighet => {
+    const {
+        foreldreInfo: { søker, rettighetType },
+        familiesituasjon,
+        familiehendelsedato,
+    } = useUttaksplanData();
+
+    const kontekst: HvaVilDuGjøreValgKontekst = {
+        søker,
+        rettighetType,
+        familiesituasjon,
+        familiehendelsedato,
+        valgtePerioder,
+    };
+
+    return {
+        visLeggTilFerie: VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst),
+        visLeggTilUtsettelse: VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(kontekst),
+        visLeggTilPause: VIS_LEGG_TIL_PAUSE_VALG.skalVises(kontekst),
+        visLeggTilOpphold: VIS_LEGG_TIL_OPPHOLD_VALG.skalVises(kontekst),
+        visLeggTilPeriode: VIS_LEGG_TIL_PERIODE_VALG.skalVises(kontekst),
+    };
+};
+
+export const VIS_LEGG_TIL_FERIE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
+    id: 'hvaVilDuGjøreValg.visLeggTilFerie',
+    beskrivelse:
+        '«Legge til ferie» vises for alle søkere, med ett unntak: for far/medmor med BARE_SØKER_RETT skjules ' +
+        'alternativet når hele det valgte tidsrommet ligger på eller etter seks uker etter familiehendelsesdato ' +
+        '— ferie er da ikke aktuelt, og pause er det riktige valget i stedet.',
+    skalVises: (k) => !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
+};
+
+export const VIS_LEGG_TIL_UTSETTELSE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
+    id: 'hvaVilDuGjøreValg.visLeggTilUtsettelse',
+    beskrivelse:
+        '«Utsettelse» vises kun for mor (ikke ved adopsjon), og bare når det valgte tidsrommet ligger innenfor ' +
+        'intervallet fra familiehendelsesdato til og med seks uker etter — det er der utsettelse av mødrekvoten ' +
+        'er aktuelt.',
+    skalVises: (k) =>
+        k.søker === 'MOR' &&
+        k.familiesituasjon !== 'adopsjon' &&
+        UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletFamDatoOgSeksUkerEtterFamDato(
+            k.valgtePerioder,
+            k.familiehendelsedato,
+        ),
+};
+
+export const VIS_LEGG_TIL_PAUSE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
+    id: 'hvaVilDuGjøreValg.visLeggTilPause',
+    beskrivelse:
+        '«Pause» vises kun når far/medmor er alene om rettigheter (BARE_SØKER_RETT), og når ingen del av det ' +
+        'valgte tidsrommet ligger før seks uker etter familiehendelsesdato — pause er ikke gyldig i de første ' +
+        'seks ukene etter fødsel/termin.',
+    skalVises: (k) =>
+        harBareFarRett(k) &&
+        !UttaksperiodeValidatorer.erNoenPerioderFørSeksUkerEtterFamiliehendelsesdato(
+            k.valgtePerioder,
+            k.familiehendelsedato,
+        ),
+};
+
+export const VIS_LEGG_TIL_OPPHOLD_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
+    id: 'hvaVilDuGjøreValg.visLeggTilOpphold',
+    beskrivelse:
+        '«Legge til periode uten foreldrepenger» vises for alle søkere, med samme unntak som ferie: for ' +
+        'far/medmor med BARE_SØKER_RETT skjules alternativet når hele det valgte tidsrommet ligger på eller ' +
+        'etter seks uker etter familiehendelsesdato.',
+    skalVises: (k) => !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
+};
+
+export const VIS_LEGG_TIL_PERIODE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
+    id: 'hvaVilDuGjøreValg.visLeggTilPeriode',
+    beskrivelse:
+        '«Legge til periode med foreldrepenger» vises alltid når et gyldig tidsrom er valgt — det er ingen ' +
+        'tidsrom-begrensning på dette alternativet.',
+    skalVises: () => true,
+};
+
+/**
+ * Konteksten reglene trenger for å avgjøre hvilke alternativ som vises i
+ * «Hva vil du gjøre»-radiogruppen i listevisningen.
+ */
+type HvaVilDuGjøreValgKontekst = {
+    søker: BrukerRolleSak_fpoversikt;
+    rettighetType: RettighetType_fpoversikt;
+    familiesituasjon: Familiesituasjon;
+    familiehendelsedato: string;
+    valgtePerioder: Periode[];
+};
+
+type HvaVilDuGjøreValgSynlighet = {
+    visLeggTilFerie: boolean;
+    visLeggTilUtsettelse: boolean;
+    visLeggTilPause: boolean;
+    visLeggTilOpphold: boolean;
+    visLeggTilPeriode: boolean;
+};
+
+const harBareFarRett = (k: HvaVilDuGjøreValgKontekst) =>
+    k.søker === 'FAR_MEDMOR' && k.rettighetType === 'BARE_SØKER_RETT';
+
+const erFerieEllerOppholdSkjultForFarMedmorBareRett = (k: HvaVilDuGjøreValgKontekst): boolean =>
+    harBareFarRett(k) &&
+    !UttaksperiodeValidatorer.erNoenPerioderFørSeksUkerEtterFamiliehendelsesdato(
+        k.valgtePerioder,
+        k.familiehendelsedato,
+    );


### PR DESCRIPTION
…listevisning

https://jira.adeo.no/browse/TFP-7011

I listevisningens «Legg til periode» velges nå datoer først. «Hva vil du gjøre»-radiogruppen skjules til gyldige fom+tom er valgt, og viser deretter kun de alternativene som er gyldige for det valgte tidsrommet. Dette speiler kalendervisningen og fjerner frustrasjonen ved at f.eks. utsettelse først gir feilmelding etter at brukeren har trykket seg gjennom alle valg.

Logikken ligger i en ny synlighetsregel-modul (regler/synlighet/ hvaVilDuGjøreValg.ts) som speiler dagens validator-semantikk og dokumenteres i Synlighetsregler-katalogen. De eksisterende feltvalidatorene beholdes som backstop for kanttilfellet der datoene endres etter at et valg er gjort.