### PR TITLE
TFP-7008(uttaksplan): kompakt ikon-sletteknapp med tooltip i kalender…

### DIFF
--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -296,7 +296,7 @@ describe('UttaksplanKalender', () => {
 
         const foreldrepengerFørFødsel = within(screen.getByTestId(`eksisterende-periode-2024-03-14-2024-04-03`));
 
-        await userEvent.click(foreldrepengerFørFødsel.getByText('Slett dager fra periode'));
+        await userEvent.click(foreldrepengerFørFødsel.getByRole('button', { name: 'Slett dager fra periode' }));
 
         expect(within(mars).getByTestId('day:18;dayColor:NONE')).toBeInTheDocument();
         expect(within(mars).getAllByTestId('dayColor:BLUE', { exact: false })).toHaveLength(2);
@@ -495,7 +495,7 @@ describe('UttaksplanKalender', () => {
         expect(screen.getAllByText('4 dager valgt')).toHaveLength(2);
         expect(screen.getByText('4 dager')).toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Slett dager fra periode'));
+        await userEvent.click(screen.getByRole('button', { name: 'Slett dager fra periode' }));
 
         expect(within(juni).getByTestId('day:10;dayColor:NONE')).toBeInTheDocument();
         expect(within(juni).getByTestId('day:11;dayColor:NONE')).toBeInTheDocument();
@@ -953,7 +953,7 @@ describe('UttaksplanKalender', () => {
 
         const foreldrepengerFørFødsel = within(screen.getByTestId(`eksisterende-periode-2024-03-14-2024-04-03`));
 
-        expect(foreldrepengerFørFødsel.queryByTitle('Slett dager fra periode')).not.toBeInTheDocument();
+        expect(foreldrepengerFørFødsel.queryByRole('button', { name: 'Slett dager fra periode' })).not.toBeInTheDocument();
     });
 
     it('skal automatisk få opp mor sin gradering når far velger BEGGE etter å ha trykket på mors periode', async () => {
@@ -1149,7 +1149,7 @@ describe('UttaksplanKalender', () => {
 
         const ferie = within(screen.getByTestId(`eksisterende-periode-2024-05-17-2024-05-23`));
 
-        await userEvent.click(ferie.getByText('Slett dager fra periode'));
+        await userEvent.click(ferie.getByRole('button', { name: 'Slett dager fra periode' }));
 
         // Perioden bak skal ikkje flytta (dag 31 er framleis BLUE på same plass)
         expect(within(mai).getByTestId('day:31;dayColor:BLUE')).toBeInTheDocument();
@@ -1274,7 +1274,7 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getAllByText('Hva vil du endre til?')[3]!);
 
-        await userEvent.click(screen.getByText('Slett dager fra periode'));
+        await userEvent.click(screen.getByRole('button', { name: 'Slett dager fra periode' }));
 
         expect(within(juli).getByTestId('day:15;dayColor:NONE')).toBeInTheDocument();
     });
@@ -1605,7 +1605,7 @@ describe('UttaksplanKalender', () => {
 
         expect(screen.getByText('Avslått periode')).toBeInTheDocument();
 
-        await userEvent.click(screen.getByText('Slett dager fra periode'));
+        await userEvent.click(screen.getByRole('button', { name: 'Slett dager fra periode' }));
 
         expect(within(juli).getByTestId('day:14;dayColor:BLACK')).toBeInTheDocument();
     });

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
@@ -10,7 +10,7 @@ import {
 import dayjs from 'dayjs';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Alert, BodyShort, Button, HStack, Heading, Spacer, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Button, HStack, Heading, Spacer, Tooltip, VStack } from '@navikt/ds-react';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import {
@@ -149,19 +149,20 @@ export const EksisterendeValgtePerioder = ({ perioder }: Props) => {
                         <Spacer />
 
                         {!erEøsUttakPeriode(p) && !erAnnenPartsPeriodeLåst && !erPleiepengerPeriode && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="small"
-                                data-color="danger"
-                                icon={<TrashIcon aria-hidden />}
-                                className="self-start"
-                                onClick={() => {
-                                    slettPeriode(p, false);
-                                }}
-                            >
-                                <FormattedMessage id="RedigeringPanel.SlettPeriode" />
-                            </Button>
+                            <Tooltip content={intl.formatMessage({ id: 'RedigeringPanel.SlettPeriode' })}>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="small"
+                                    data-color="danger"
+                                    icon={<TrashIcon aria-hidden />}
+                                    aria-label={intl.formatMessage({ id: 'RedigeringPanel.SlettPeriode' })}
+                                    className="self-start"
+                                    onClick={() => {
+                                        slettPeriode(p, false);
+                                    }}
+                                />
+                            </Tooltip>
                         )}
                     </HStack>
                 );


### PR DESCRIPTION
…visning

Erstatt det anonyme søppelkasseikonet for sletting av enkeltperioder i kalenderens redigeringspanel med en kompakt ikon-knapp (secondary, data-color danger). Den beskrivende teksten vises som tooltip på mouseover og som aria-label for skjermlesere.