### PR TITLE
fix(uttaksplan): vis ikke graderingsaktivitet-varsel i planleggeren

### DIFF
--- a/packages/uttaksplan/src/context/UttaksplanDataContext.tsx
+++ b/packages/uttaksplan/src/context/UttaksplanDataContext.tsx
@@ -30,6 +30,14 @@ type ContextValues = Omit<Props, 'children'> & {
     familiesituasjon: Familiesituasjon;
     familiehendelsedato: string;
     termindato: string | undefined;
+    /**
+     * Sann når appen kjenner søkers arbeidsforhold og dermed kan la brukeren
+     * velge graderingsaktivitet (arbeidsgiver/frilans/selvstendig næringsdrivende).
+     * Dette er tilfelle i foreldrepengesøknaden, men ikke i planleggeren – der
+     * finnes ingen arbeidsforhold, så varsler om manglende graderingsaktivitet
+     * skal ikke vises.
+     */
+    kanVelgeArbeidsgiver: boolean;
 };
 
 const UttaksplanDataContext = createContext<ContextValues | null>(null);
@@ -50,6 +58,7 @@ export const UttaksplanDataProvider = (props: Props) => {
             familiesituasjon,
             termindato,
             uttakPerioder: sortertePerioder,
+            kanVelgeArbeidsgiver: otherProps.aktiveArbeidsforhold !== undefined,
         };
     }, [otherProps]);
 

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -427,7 +427,7 @@ describe('UttaksplanKalender', () => {
 
         const juni = screen.getByTestId('year:2024;month:5');
 
-        await userEvent.click(within(juni).getByTestId('day:14;dayColor:GREENSTRIPED;with-icon'));
+        await userEvent.click(within(juni).getByTestId('day:14;dayColor:GREENSTRIPED'));
         await userEvent.click(within(juni).getByTestId('day:21;dayColor:GREENOUTLINE'));
 
         await userEvent.click(screen.getAllByText('Hva vil du endre til?')[2]!);
@@ -743,7 +743,7 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getByText('Fortsett'));
 
-        expect(within(september).getByTestId('day:7;dayColor:LIGHTGREENBLUE;with-icon')).toBeInTheDocument();
+        expect(within(september).getByTestId('day:7;dayColor:LIGHTGREENBLUE')).toBeInTheDocument();
     });
 
     it('mor og far tar samtidig uttak - dersom kombinert uttak er mer enn 100 % skal man ikke kunne ta mer enn 50 % fellesperiode', async () => {
@@ -815,7 +815,7 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getByText('Fortsett'));
 
-        expect(within(september).getByTestId('day:7;dayColor:LIGHTGREENBLUE;with-icon')).toBeInTheDocument();
+        expect(within(september).getByTestId('day:7;dayColor:LIGHTGREENBLUE')).toBeInTheDocument();
     });
 
     it('mor og far tar samtidig uttak - fedrekvote + mødrekvote kan ikke være mer enn 100 % til sammen', async () => {

--- a/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
+++ b/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
@@ -43,6 +43,7 @@ export const usePerioderForKalendervisning = (
         foreldreInfo: { søker, navnPåForeldre, rettighetType },
         familiehendelsedato,
         uttakPerioder,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const saksperioderInkludertTapteDager = useAlleUttakPerioderInklTapteDager();
@@ -77,6 +78,7 @@ export const usePerioderForKalendervisning = (
                     isUpdated,
                     rettighetType,
                     uttakPerioder,
+                    kanVelgeArbeidsgiver,
                 ),
             ];
         }
@@ -97,6 +99,7 @@ export const usePerioderForKalendervisning = (
                     isUpdated,
                     rettighetType,
                     uttakPerioder,
+                    kanVelgeArbeidsgiver,
                 ),
             ];
         }
@@ -110,7 +113,12 @@ export const usePerioderForKalendervisning = (
                 color,
                 srText: getKalenderSkjermlesertekstForPeriode(periode, navnPåForeldre, intl),
                 isUpdated,
-                ...leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, periode, uttakPerioder),
+                ...leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(
+                    rettighetType,
+                    periode,
+                    uttakPerioder,
+                    kanVelgeArbeidsgiver,
+                ),
             } satisfies CalendarPeriod,
         ];
     }, []);
@@ -347,10 +355,16 @@ const splittPeriodeITo = (
     isUpdated: boolean,
     rettighetType: RettighetType_fpoversikt,
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    kanVelgeArbeidsgiver: boolean,
 ): CalendarPeriod[] => {
     const forrige = Uttaksdagen.forrige(dato).getDato();
     const neste = Uttaksdagen.neste(dato).getDato();
-    const ikonProps = leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, periode, allePerioder);
+    const ikonProps = leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(
+        rettighetType,
+        periode,
+        allePerioder,
+        kanVelgeArbeidsgiver,
+    );
 
     const lagPeriode = (fom: string, tom: string): CalendarPeriod => ({
         fom,
@@ -376,13 +390,14 @@ const leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt = (
     rettighetType: RettighetType_fpoversikt,
     periode: UttaksplanperiodeMedKunTapteDager,
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    kanVelgeArbeidsgiver: boolean,
 ) => {
     const morsPerioder = allePerioder.filter(
         (p): p is UttakPeriode_fpoversikt => erVanligUttakPeriode(p) && p.forelder === 'MOR',
     );
     if (
         harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [periode, ...morsPerioder]) ||
-        harPeriodeMedUkjentGraderingsaktivitet([periode])
+        (kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode]))
     ) {
         return {
             icon: <ExclamationmarkTriangleFillIcon aria-hidden color="var(--ax-warning-600)" />,

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -29,6 +29,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
     const {
         foreldreInfo: { søker, navnPåForeldre, rettighetType },
         uttakPerioder,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const formMethods = useForm<FormValues>();
@@ -72,7 +73,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                                             className="text-ax-danger-800"
                                         />
                                     )}
-                                    {harPeriodeMedUkjentGraderingsaktivitet([p]) && (
+                                    {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([p]) && (
                                         <ExclamationmarkTriangleFillIcon
                                             title={intl.formatMessage({
                                                 id: 'PeriodeListeHeader.GraderingsaktivitetIkkeValgt',

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
@@ -31,6 +31,7 @@ export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåF
     const {
         foreldreInfo: { rettighetType },
         uttakPerioder,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     const erAvslått = erAvslåttPeriode(periode);
     const morsAktivitet = erVanligUttakPeriode(periode) && periode.morsAktivitet ? periode.morsAktivitet : undefined;
@@ -58,7 +59,7 @@ export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåF
                     className="text-ax-danger-800"
                 />
             )}
-            {harPeriodeMedUkjentGraderingsaktivitet([periode]) && (
+            {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode]) && (
                 <ExclamationmarkTriangleFillIcon
                     title={intl.formatMessage({ id: 'PeriodeListeHeader.GraderingsaktivitetIkkeValgt' })}
                     fontSize="1.5rem"

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
@@ -30,6 +30,7 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
         familiehendelsedato,
         foreldreInfo: { rettighetType, søker, navnPåForeldre },
         familiesituasjon,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const førsteFom = getFørsteUttaksplanperiodeFom(uttaksplanperioder);
@@ -53,7 +54,8 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
     );
 
     const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, uttaksplanperioder);
-    const harUkjentGraderingsaktivitet = harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder);
+    const harUkjentGraderingsaktivitet =
+        kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder);
     const harValideringsfeil = harMorsAktivitetIkkeErValgt || harUkjentGraderingsaktivitet;
     const valideringsfeilTekstId = harMorsAktivitetIkkeErValgt
         ? 'PeriodeListeHeader.MorsAktivitetIkkeValgt'

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -78,6 +78,7 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
     const {
         foreldreInfo: { rettighetType, søker },
         uttakPerioder,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const morsUttakPerioder = uttakPerioder.filter(
@@ -90,9 +91,10 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
             periode,
             morsUttakPerioder,
         }),
-        graderingsaktivitetIkkeValgt: erSøkersIkkeEøsPeriode(periode, søker)
-            ? tilAktiv(GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE, { periode })
-            : undefined,
+        graderingsaktivitetIkkeValgt:
+            kanVelgeArbeidsgiver && erSøkersIkkeEøsPeriode(periode, søker)
+                ? tilAktiv(GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE, { periode })
+                : undefined,
     });
 };
 
@@ -102,12 +104,15 @@ export const useUttaksplanListeAlerts = (
 ): UttaksplanListeAlerts => {
     const {
         foreldreInfo: { rettighetType, søker },
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
         manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_LISTE, { rettighetType, perioder }),
-        manglerGraderingsaktivitetAlert: tilAktiv(MANGLER_GRADERINGSAKTIVITET_LISTE, {
-            perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
-        }),
+        manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
+            ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_LISTE, {
+                  perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
+              })
+            : undefined,
     };
 };
 
@@ -117,12 +122,15 @@ export const useUttaksplanKalenderAlerts = (
 ): UttaksplanKalenderAlerts => {
     const {
         foreldreInfo: { rettighetType, søker },
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
         manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_KALENDER, { rettighetType, perioder }),
-        manglerGraderingsaktivitetAlert: tilAktiv(MANGLER_GRADERINGSAKTIVITET_KALENDER, {
-            perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
-        }),
+        manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
+            ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_KALENDER, {
+                  perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
+              })
+            : undefined,
     };
 };
 


### PR DESCRIPTION
Varselet "Du må velge hvor du skal jobbe samtidig som du har foreldrepenger" og tilhørende ikoner dukket opp i planleggeren, selv om man der ikke kan velge arbeidsgiver, frilans eller selvstendig næringsdrivende.

Innfører en avledet kanVelgeArbeidsgiver-flagg i UttaksplanDataContext (basert på om aktiveArbeidsforhold er satt) og gater alle varsler om ukjent graderingsaktivitet på den. Dette er konsistent med hvordan skjemaet allerede styrer visning av arbeidsgivervalg.