### PR TITLE
endre overskrift i Hva er mulig-infoboks

### DIFF
--- a/apps/planlegger/src/intl/messages/en_US.json
+++ b/apps/planlegger/src/intl/messages/en_US.json
@@ -70,7 +70,7 @@
     "Fødsel.ErFødt": "{antallBarn, select, 1 {Has the child} other {Have the children}} been born?",
     "Fødselsdato.Required": "You must answer what the date of birth is before proceeding.",
     "HvemPlanleggerSteg.HarValgfrieFelt": "All fields must be filled in, except fields marked with (optional).",
-    "HvaErMulig.Tittel": "What is possible when one adapts?",
+    "HvaErMulig.Tittel": "What is possible to change in the application",
     "HvaErMulig.MyeDuKanEndre": "There is a lot that can be changed in the plan.",
     "HvaErMulig.FarFellesperiode": "When the {hvem} takes the joint period",
     "HvaErMulig.FarFellesperiode.Adopsjon": "When {erFedre, select, true {father 2} other {{erMedmor, select, true {mother 2} other {the father}}}} takes common period",

--- a/apps/planlegger/src/intl/messages/nb_NO.json
+++ b/apps/planlegger/src/intl/messages/nb_NO.json
@@ -70,7 +70,7 @@
     "Fødsel.ErFødt": "Er {antallBarn, select, 1 {barnet} other {barna}} født?",
     "Fødselsdato.Required": "Du må oppgi fødselsdato før du går videre",
     "HvemPlanleggerSteg.HarValgfrieFelt": "Alle felt må fylles ut, unntatt felt markert med (valgfritt).",
-    "HvaErMulig.Tittel": "Hva er mulig når du tilpasser?",
+    "HvaErMulig.Tittel": "Hva er mulig å endre i søknaden",
     "HvaErMulig.MyeDuKanEndre": "Det er mye du kan endre på i planen",
     "HvaErMulig.FarFellesperiode": "Når {hvem} tar fellesperiode",
     "HvaErMulig.FarFellesperiode.Adopsjon": "Når {erFedre, select, true {far 2} other {{erMedmor, select, true {mor 2} other {far}}}} tar fellesperiode",

--- a/apps/planlegger/src/intl/messages/nn_NO.json
+++ b/apps/planlegger/src/intl/messages/nn_NO.json
@@ -70,7 +70,7 @@
     "Fødsel.ErFødt": "Er {antallBarn, select, 1 {barnet} other {barna}} fødd?",
     "Fødselsdato.Required": "Du må oppgi fødselsdato før du går vidare",
     "HvemPlanleggerSteg.HarValgfrieFelt": "Alle felt må fyllast ut, bortsett frå felt markert med (valfritt).",
-    "HvaErMulig.Tittel": "Kva er mogleg når ein tilpassar?",
+    "HvaErMulig.Tittel": "Kva er mogleg å endre i søknaden",
     "HvaErMulig.MyeDuKanEndre": "Det er mykje du kan endra på i planen",
     "HvaErMulig.FarFellesperiode": "Når {hvem} tek fellesperiode",
     "HvaErMulig.FarFellesperiode.Adopsjon": "Når {erFedre, select, true {far 2} other {{erMedmor, select, true {mor 2} other {far}}}} tek fellesperiode",

--- a/apps/planlegger/src/steps/planen-deres/hva-er-mulig/HvaErMulig.test.tsx
+++ b/apps/planlegger/src/steps/planen-deres/hva-er-mulig/HvaErMulig.test.tsx
@@ -22,7 +22,7 @@ describe('<HvaErMulig>', () => {
     //MorOgFar
     it('skal vise info for mor og far fødsel hvor begge har rett', async () => {
         render(<FødselMorOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('<HvaErMulig>', () => {
     });
     it('skal vise info for mor og far fødsel hvor kun mor har rett', async () => {
         render(<FødselMorOgFarKunMorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('<HvaErMulig>', () => {
     });
     it('skal vise info for mor og far fødsel hvor kun far har rett', async () => {
         render(<FødselMorOgFarKunFarHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
 
@@ -83,7 +83,7 @@ describe('<HvaErMulig>', () => {
     });
     it('skal vise info for mor og far fødsel hvor begge har rett - tvilling og trilling', async () => {
         render(<FødselMorOgFarBeggeHarRettTvilling />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('<HvaErMulig>', () => {
     //MorOgMedmor
     it('skal vise info for mor og medmor fødsel hvor begge har rett', async () => {
         render(<FødselMorOgMedmorBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -119,7 +119,7 @@ describe('<HvaErMulig>', () => {
     });
     it('skal vise info for mor og medmor fødsel hvor kun mor har rett', async () => {
         render(<FødselMorOgMedmorKunMorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -136,7 +136,7 @@ describe('<HvaErMulig>', () => {
     });
     it('skal vise info for mor og medmor fødsel hvor kun medmor har rett', async () => {
         render(<FødselMorOgMedmorKunMedmorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
 
@@ -163,7 +163,7 @@ describe('<HvaErMulig>', () => {
     //FarOgFar
     it('skal vise info for far og far fødsel hvor begge har rett', async () => {
         render(<FødselFarOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('To uker rundt fødsel')).toBeInTheDocument();
@@ -187,7 +187,7 @@ describe('<HvaErMulig>', () => {
     it('skal vise info for far og far fødsel hvor kun far1 har rett', async () => {
         render(<FødselFarOgFarKunFar1HarRett />);
 
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('To uker rundt fødsel')).toBeInTheDocument();
@@ -209,7 +209,7 @@ describe('<HvaErMulig>', () => {
     it('skal vise info for aleneforsørger mor fødsel', async () => {
         render(<FødselAleneforsørgerMor />);
 
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -231,7 +231,7 @@ describe('<HvaErMulig>', () => {
     //Mor og far
     it('skal vise info for mor og far adopsjon hvor begge har rett', async () => {
         render(<AdopsjonMorOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.queryByText('Dette kan du ikke endre:')).not.toBeInTheDocument();

--- a/packages/uttaksplan/src/infobokser/hva-er-mulig/HvaErMulig.test.tsx
+++ b/packages/uttaksplan/src/infobokser/hva-er-mulig/HvaErMulig.test.tsx
@@ -20,7 +20,7 @@ const {
 describe('<HvaErMulig>', () => {
     it('skal vise info for mor og far fødsel hvor begge har rett', async () => {
         render(<FødselMorOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe('<HvaErMulig>', () => {
 
     it.todo('skal vise info for mor og far fødsel hvor kun mor har rett', async () => {
         render(<FødselMorOgFarKunMorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('<HvaErMulig>', () => {
 
     it.todo('skal vise info for mor og far fødsel hvor kun far har rett', async () => {
         render(<FødselMorOgFarKunFarHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
 
@@ -84,7 +84,7 @@ describe('<HvaErMulig>', () => {
 
     it('skal vise info for mor og far fødsel hvor begge har rett - tvilling og trilling', async () => {
         render(<FødselMorOgFarBeggeHarRettTvilling />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe('<HvaErMulig>', () => {
 
     it('skal vise info for mor og medmor fødsel hvor begge har rett', async () => {
         render(<FødselMorOgMedmorBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe('<HvaErMulig>', () => {
 
     it.todo('skal vise info for mor og medmor fødsel hvor kun mor har rett', async () => {
         render(<FødselMorOgMedmorKunMorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe('<HvaErMulig>', () => {
 
     it.todo('skal vise info for mor og medmor fødsel hvor kun medmor har rett', async () => {
         render(<FødselMorOgMedmorKunMedmorHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
 
@@ -166,7 +166,7 @@ describe('<HvaErMulig>', () => {
 
     it('skal vise info for far og far fødsel hvor begge har rett', async () => {
         render(<FødselFarOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('To uker rundt fødsel')).toBeInTheDocument();
@@ -191,7 +191,7 @@ describe('<HvaErMulig>', () => {
     it('skal vise info for far og far fødsel hvor kun far1 har rett', async () => {
         render(<FødselFarOgFarKunFar1HarRett />);
 
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('To uker rundt fødsel')).toBeInTheDocument();
@@ -213,7 +213,7 @@ describe('<HvaErMulig>', () => {
     it('skal vise info for aleneforsørger mor fødsel', async () => {
         render(<FødselAleneforsørgerMor />);
 
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.getByText('Dette kan du ikke endre:')).toBeInTheDocument();
@@ -232,7 +232,7 @@ describe('<HvaErMulig>', () => {
 
     it('skal vise info for mor og far adopsjon hvor begge har rett', async () => {
         render(<AdopsjonMorOgFarBeggeHarRett />);
-        expect(await screen.findByText('Hva er mulig når du tilpasser?')).toBeInTheDocument();
+        expect(await screen.findByText('Hva er mulig å endre i søknaden')).toBeInTheDocument();
 
         expect(screen.getByText('Det er mye du kan endre på i planen')).toBeInTheDocument();
         expect(screen.queryByText('Dette kan du ikke endre:')).not.toBeInTheDocument();

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -429,7 +429,7 @@
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33": "The child is born before the 33rd week of pregnancy",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.Tekst": "The parental benefit period will be extended from the date of birth until the day before the due date. With this extension, the parental benefit is given for the same duration as if the child had been born on the due date. Attendance allowance (pleiepenger) received before the due date will be deducted from the extended parental benefit period and cannot be used later.",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.TekstMorIkkeRett": "Parental benefits with activity requirements are extended from week 7 after birth until the day before the due date. If you receive care allowance during the extended period, the days of parental allowance will be deducted and cannot be taken later. The {erMedmor, select, true {mother who gives birth} other {mother}} must meet the activity requirement when you want to take or postpone the days until later.",
-    "HvaErMulig.Tittel": "What is possible when you customize?",
+    "HvaErMulig.Tittel": "What is possible to change in the application",
     "HvaErMulig.MyeDuKanEndre": "There is a lot that can be changed in the plan.",
     "HvaErMulig.FarFellesperiode": "When the {hvem} takes the joint period",
     "HvaErMulig.FarFellesperiode.Adopsjon": "When {erFedre, select, true {father 2} other {{erMedmor, select, true {mother 2} other {the father}}}} takes common period",

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -429,7 +429,7 @@
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33": "The child is born before the 33rd week of pregnancy",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.Tekst": "The parental benefit period will be extended from the date of birth until the day before the due date. With this extension, the parental benefit is given for the same duration as if the child had been born on the due date. Attendance allowance (pleiepenger) received before the due date will be deducted from the extended parental benefit period and cannot be used later.",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.TekstMorIkkeRett": "Parental benefits with activity requirements are extended from week 7 after birth until the day before the due date. If you receive care allowance during the extended period, the days of parental allowance will be deducted and cannot be taken later. The {erMedmor, select, true {mother who gives birth} other {mother}} must meet the activity requirement when you want to take or postpone the days until later.",
-    "HvaErMulig.Tittel": "What is possible to change in the application",
+    "HvaErMulig.Tittel": "What can you change in the application",
     "HvaErMulig.MyeDuKanEndre": "There is a lot that can be changed in the plan.",
     "HvaErMulig.FarFellesperiode": "When the {hvem} takes the joint period",
     "HvaErMulig.FarFellesperiode.Adopsjon": "When {erFedre, select, true {father 2} other {{erMedmor, select, true {mother 2} other {the father}}}} takes common period",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -429,7 +429,7 @@
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33": "Barnet blir født før 33. svangerskapsuke",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.Tekst": "Perioden med foreldrepenger blir utvidet fra fødselsdatoen og frem til dagen før termindatoen. Med denne forlengelsen får {erAleneforsørger, select, true {du} other {dere}} foreldrepenger like lenge som om barnet ble født på termindato. Pleiepenger før termindato vil trekkes fra dagene med utvidet rett på foreldrepenger, og kan ikke brukes senere.",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.TekstMorIkkeRett": "Foreldrepenger med aktivitetskrav blir utvidet fra uke 7 etter fødselen og frem til dagen før termindatoen. Hvis du har pleiepenger i den utvidede perioden, vil dagene med foreldrepenger trekkes fra, og kan ikke tas senere. {erMedmor, select, true {Mor som føder} other {Mor}} må oppfylle aktivitetskravet når du skal ha eller utsette dagene til senere.",
-    "HvaErMulig.Tittel": "Hva er mulig når du tilpasser?",
+    "HvaErMulig.Tittel": "Hva er mulig å endre i søknaden",
     "HvaErMulig.MyeDuKanEndre": "Det er mye du kan endre på i planen",
     "HvaErMulig.FarFellesperiode": "Når {hvem} tar fellesperiode",
     "HvaErMulig.FarFellesperiode.Adopsjon": "Når {erFedre, select, true {far 2} other {{erMedmor, select, true {mor 2} other {far}}}} tar fellesperiode",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -429,7 +429,7 @@
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33": "Barnet blir fødd før 33. svangerskapsveke",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.Tekst": "Perioden med foreldrepengar blir utvida frå fødselsdatoen og fram til dagen før termindatoen. Med denne forlenginga får {erAleneforsørger, select, true {du} other {de}} foreldrepengar like lenge som om barnet vart fødd på termindatoen. Pleiepengar før termindato vil bli trekte frå dagane med utvida rett til foreldrepengar, og kan ikkje brukast seinare.",
     "UforutsetteEndringer.UforutsetteEndringer.FødtFørUke33.TekstMorIkkeRett": "Foreldrepengar med aktivitetskrav blir utvida frå veke 7 etter fødselen og fram til dagen før termindatoen. Om du har pleiepengar i den utvida perioden, vil dagane med foreldrepengar trekkjast frå, og kan ikkje takast seinare. {erMedmor, select, true {Mor som føder} other {Mor}} må oppfylla aktivitetskravet når du skal ha eller utsetja dagane til seinare.",
-    "HvaErMulig.Tittel": "Kva er mogleg når ein tilpassar?",
+    "HvaErMulig.Tittel": "Kva er mogleg å endre i søknaden",
     "HvaErMulig.MyeDuKanEndre": "Det er mykje du kan endra på i planen",
     "HvaErMulig.FarFellesperiode": "Når {hvem} tek fellesperiode",
     "HvaErMulig.FarFellesperiode.Adopsjon": "Når {erFedre, select, true {far 2} other {{erMedmor, select, true {mor 2} other {far}}}} tek fellesperiode",


### PR DESCRIPTION
NKS melder at overskriften er utydelig. Endrer
"Hva er mulig når du tilpasser?" til
"Hva er mulig å endre i søknaden" i uttaksplan-pakken (nb, nn, en).