### PR TITLE
TFP-7021(uttaksplan): vis justeringsspørsmål for far/medmor med en gang

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -89,11 +89,14 @@ export const UttaksplanForm = ({
     const termindato = getTermindato(barn);
     const uttaksdagPåEllerEtterTermin = termindato ? Uttaksdagen.denneEllerNeste(termindato).getDato() : undefined;
 
-    const perioderRundtFødselForFarMedmor = gjeldendeUttaksplan
-        ? finnPerioderRundtFødsel(gjeldendeUttaksplan, barn).filter(
-              (p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.forelder === 'FAR_MEDMOR',
-          )
-        : [];
+    // Når far/medmor kommer rett fra planleggeren ligg uttaket i defaultUttaksperioder fram til
+    // planen blir redigert (då blir uttaksplan-context fyllt). Bruk same fallback som onSubmit slik
+    // at spørsmålet om automatisk justering står fast med ein gong, utan at brukaren må tukle med planen.
+    const planForVisning = gjeldendeUttaksplan ?? defaultUttaksperioder;
+
+    const perioderRundtFødselForFarMedmor = finnPerioderRundtFødsel(planForVisning, barn).filter(
+        (p) => Uttaksperioden.erIkkeEøsPeriode(p) && p.forelder === 'FAR_MEDMOR',
+    );
 
     const periodeRundtFødsel = perioderRundtFødselForFarMedmor[0];
 
@@ -152,7 +155,7 @@ export const UttaksplanForm = ({
                     <VStack gap="space-16">
                         <AutomatiskJusteringInfotekst
                             harSvartJaPåAutoJustering={harSvartJaPåAutoJustering}
-                            uttaksplan={gjeldendeUttaksplan!}
+                            uttaksplan={planForVisning}
                         />
                         <RhfRadioGroup
                             name="ønskerJustertUttakVedFødsel"

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -90,7 +90,7 @@ export const UttaksplanForm = ({
     const uttaksdagPåEllerEtterTermin = termindato ? Uttaksdagen.denneEllerNeste(termindato).getDato() : undefined;
 
     // Når far/medmor kommer rett fra planleggeren ligg uttaket i defaultUttaksperioder fram til
-    // planen blir redigert (då blir uttaksplan-context fyllt). Bruk same fallback som onSubmit slik
+    // planen blir redigert (då blir uttaksplan-context fylt). Bruk same fallback som onSubmit slik
     // at spørsmålet om automatisk justering står fast med ein gong, utan at brukaren må tukle med planen.
     const planForVisning = gjeldendeUttaksplan ?? defaultUttaksperioder;
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
@@ -250,6 +250,14 @@ describe('<UttaksplanSteg>', () => {
 
             expect(await screen.findAllByText('Din plan med foreldrepenger')).toHaveLength(2);
 
+            // Spørsmålet om automatisk justering skal stå fast med ein gong forslaget startar på termin,
+            // utan at far/medmor må redigere planen i kalenderen eller lista først (TFP-7021).
+            expect(
+                screen.getByText(/ønsker du at vi endrer den til å starte fra fødselsdato/),
+            ).toBeInTheDocument();
+
+            // Far/medmor må svare på spørsmålet før dei kan gå vidare.
+            await userEvent.click(screen.getByRole('radio', { name: 'Nei' }));
             await userEvent.click(screen.getByText('Neste steg'));
 
             expect(screen.queryByText('Du har ikke lagt til noen perioder i planen')).not.toBeInTheDocument();


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7021

Spørsmålet om automatisk justering ved fødsel ble beregnet fra uttaksplan-context, som er undefined til far/medmor redigerer planen. For foreldre som overfører fra planleggeren lå uttaket i defaultUttaksperioder, så spørsmålet dukket først opp etter at de hadde tuklet med uttaket i kalenderen/lista.

Bruker nå samme fallback som onSubmit (gjeldendeUttaksplan ?? defaultUttaksperioder) slik at spørsmålet står fast med en gang det finnes uttak fra og med termindato.