### PR TITLE
TFP-7020(uttaksplan): rett feilteljing av graderte trekkdagar i telleverket

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
@@ -8,7 +8,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { getAntallUttaksdagerIVinduRundtFødsel } from '@navikt/fp-uttaksplan';
+import { finnAntallTidelerÅTrekke } from '@navikt/fp-uttaksplan';
 
 type Periode = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
 
@@ -59,30 +59,6 @@ const filtrerAvslåttePerioderMenBeholdPleiepenger = (periode: Periode): boolean
     return periode.resultat?.trekkerDager ?? true;
 };
 
-const finnAntallDagerÅTrekke = (periode: Periode, erFødsel: boolean, familiehendelsesdato: string): number => {
-    if (Uttaksperioden.erEøsPeriode(periode)) {
-        return periode.trekkdager;
-    }
-    const arbeidstidprosent = periode.gradering?.arbeidstidprosent;
-    const samtidigUttak = periode.samtidigUttak;
-    const dager = Uttaksperioden.getAntallUttaksdager(periode);
-    if (arbeidstidprosent) {
-        const graderingsProsent = (100 - arbeidstidprosent) / 100;
-        // Mor sin gradering i tidsrommet 3 uker før / 6 uker etter familiehendelsesdato
-        // gir ikkje forlenging av stønadsperioden – dagane skal trekkjast som heile.
-        if (erFødsel && periode.forelder === 'MOR') {
-            const dagerIVindu = getAntallUttaksdagerIVinduRundtFødsel(periode.fom, periode.tom, familiehendelsesdato);
-            const dagerUtenforVindu = dager - dagerIVindu;
-            return dagerIVindu + dagerUtenforVindu * graderingsProsent;
-        }
-        return dager * graderingsProsent;
-    }
-    if (samtidigUttak) {
-        return dager * (samtidigUttak / 100);
-    }
-    return dager;
-};
-
 const beregnBrukteUttaksdager = (
     tilgjengeligeStønadskvoter: KontoBeregningDto,
     perioder: Periode[],
@@ -92,10 +68,13 @@ const beregnBrukteUttaksdager = (
     return tilgjengeligeStønadskvoter.kontoer
         .map((konto) => {
             const perioderForKonto = perioder.filter((p) => p.kontoType === konto.konto);
-            const dager = Math.floor(
-                perioderForKonto.reduce((sum, p) => sum + finnAntallDagerÅTrekke(p, erFødsel, familiehendelsesdato), 0),
+            // Trekkdagar summerast i tideler (heiltal) for å unngå flyttalsfeil, og
+            // golvast til heile dagar heilt til slutt – sjå finnAntallTidelerÅTrekke.
+            const tideler = perioderForKonto.reduce(
+                (sum, p) => sum + finnAntallTidelerÅTrekke(p, erFødsel, familiehendelsesdato),
+                0,
             );
-            return { konto: konto.konto, dager };
+            return { konto: konto.konto, dager: Math.floor(tideler / 10) };
         })
         .filter((k) => k.dager > 0);
 };

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -28,6 +28,7 @@ export {
     harPeriodeDerMorsAktivitetIkkeErValgt,
     harPeriodeMedUkjentGraderingsaktivitet,
     getAntallUttaksdagerIVinduRundtFødsel,
+    finnAntallTidelerÅTrekke,
 } from './src/utils/periodeUtils';
 export { prosesserPerioderForVisning } from './src/utils/prosesserPerioderForVisning';
 export { deltUttak } from './src/utils/forslag/deltUttak';

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.test.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.test.tsx
@@ -93,3 +93,37 @@ describe('summerDagerIPerioder – mors gradering i 3v før / 6v etter familiehe
         expect(dager).toBe(15);
     });
 });
+
+describe('summerDagerIPerioder – summering av graderte dagar (ingen flyttalsfeil)', () => {
+    const lagFellesperiodeEndag = (dato: string): UttakPeriode_fpoversikt => ({
+        fom: dato,
+        tom: dato,
+        forelder: 'MOR',
+        kontoType: 'FELLESPERIODE',
+        flerbarnsdager: false,
+        gradering: { arbeidstidprosent: 40, aktivitet: { type: 'ORDINÆRT_ARBEID' } },
+    });
+
+    it('skal telje 6 dagar (ikkje 5) for ti graderte endagsperiodar à 0,6 dag', () => {
+        // Kvar dag med 40 % arbeid trekkjer 0,6 dag. 10 × 0,6 = 6,0 dagar.
+        // I flyttal blir summen 5,999999999999999, og ein naiv Math.floor på
+        // summen ville (feilaktig) gitt 5 og late ein fellesperiodedag stå att.
+        const enUkedagPerHverdag = [
+            '2024-04-01',
+            '2024-04-02',
+            '2024-04-03',
+            '2024-04-04',
+            '2024-04-05',
+            '2024-04-08',
+            '2024-04-09',
+            '2024-04-10',
+            '2024-04-11',
+            '2024-04-12',
+        ];
+        const perioder = enUkedagPerHverdag.map(lagFellesperiodeEndag);
+
+        const dager = summerDagerIPerioder(perioder, KONTOER.kontoer, 'adopsjon', FAMILIEHENDELSESDATO);
+
+        expect(dager).toBe(6);
+    });
+});

--- a/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
+++ b/packages/uttaksplan/src/utils/kvoteOppsummeringUtils.tsx
@@ -9,11 +9,10 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Uttaksperioden } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../context/UttaksplanDataContext';
 import { erEøsUttakPeriode, erVanligUttakPeriode } from '../types/UttaksplanPeriode';
-import { getAntallUttaksdagerIVinduRundtFødsel } from './periodeUtils';
+import { finnAntallTidelerÅTrekke } from './periodeUtils';
 
 export const useErAntallDagerOvertrukketIUttaksplan = () => {
     const {
@@ -298,7 +297,11 @@ export const summerDagerIPerioder = (
         return 0;
     }
 
-    let dagerTotalt = 0;
+    const erFødsel = familiesituasjon === 'fødsel';
+
+    // Trekkdagar summerast i tideler (heiltal) for å unngå flyttalsfeil; sjå
+    // finnAntallTidelerÅTrekke. Resultatet golvast til heile dagar heilt til slutt.
+    let tidelerTotalt = 0;
 
     for (const aktuellKontoType of aktuelleKontotyper) {
         const gjeldendeKonto = konto.find((k) => k.konto === aktuellKontoType);
@@ -307,27 +310,27 @@ export const summerDagerIPerioder = (
             continue;
         }
 
-        const dagerEøs = Math.min(
+        const tidelerEøs = Math.min(
             sum(
                 perioder
                     .filter((p) => 'trekkdager' in p && getUttaksKontoType(p) === aktuellKontoType)
-                    .map((p) => finnAntallDagerÅTrekke(p, familiesituasjon, familiehendelsedato)),
+                    .map((p) => finnAntallTidelerÅTrekke(p, erFødsel, familiehendelsedato)),
             ),
-            gjeldendeKonto.dager,
+            gjeldendeKonto.dager * 10,
         );
-        const dagerNorge = sum(
+        const tidelerNorge = sum(
             perioder
                 .filter(
                     (p) =>
                         (!('trekkdager' in p) && getUttaksKontoType(p) === aktuellKontoType) ||
                         harOppholdÅrsakLikKontoType(aktuellKontoType, p),
                 )
-                .map((p) => finnAntallDagerÅTrekke(p, familiesituasjon, familiehendelsedato)),
+                .map((p) => finnAntallTidelerÅTrekke(p, erFødsel, familiehendelsedato)),
         );
-        dagerTotalt += dagerEøs + dagerNorge;
+        tidelerTotalt += tidelerEøs + tidelerNorge;
     }
 
-    return Math.floor(dagerTotalt);
+    return Math.floor(tidelerTotalt / 10);
 };
 
 export const getUttaksKontoType = (
@@ -365,34 +368,4 @@ const getStønadskvoteTypeFromOppholdÅrsakType = (årsak: UttakOppholdÅrsak_fp
         default:
             return undefined;
     }
-};
-
-const finnAntallDagerÅTrekke = (
-    periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt,
-    familiesituasjon: Familiesituasjon,
-    familiehendelsedato: string,
-) => {
-    if (erEøsUttakPeriode(periode)) {
-        return periode.trekkdager;
-    }
-
-    const arbeidstidprosent = periode.gradering?.arbeidstidprosent;
-    const samtidigUttak = periode.samtidigUttak;
-    const dager = Uttaksperioden.getAntallUttaksdager(periode);
-
-    if (arbeidstidprosent) {
-        const graderingsProsent = (100 - arbeidstidprosent) / 100;
-        // Mor sin gradering i tidsrommet 3 uker før / 6 uker etter familiehendelsesdato
-        // gir ikkje forlenging av stønadsperioden – dagane skal trekkjast som heile.
-        if (familiesituasjon === 'fødsel' && periode.forelder === 'MOR') {
-            const dagerIVindu = getAntallUttaksdagerIVinduRundtFødsel(periode.fom, periode.tom, familiehendelsedato);
-            const dagerUtenforVindu = dager - dagerIVindu;
-            return dagerIVindu + dagerUtenforVindu * graderingsProsent;
-        }
-        return dager * graderingsProsent;
-    }
-    if (samtidigUttak) {
-        return dager * (samtidigUttak / 100);
-    }
-    return dager;
 };

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -1,6 +1,10 @@
 import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
 
-import { harPeriodeDerMorsAktivitetIkkeErValgt, harPeriodeMedUkjentGraderingsaktivitet } from './periodeUtils';
+import {
+    finnAntallTidelerÅTrekke,
+    harPeriodeDerMorsAktivitetIkkeErValgt,
+    harPeriodeMedUkjentGraderingsaktivitet,
+} from './periodeUtils';
 
 const lagFarPeriode = (overrides: Partial<UttakPeriode_fpoversikt> = {}): UttakPeriode_fpoversikt => ({
     fom: '2025-06-02',
@@ -176,5 +180,19 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
 
     it('skal returnere false for tom liste', () => {
         expect(harPeriodeMedUkjentGraderingsaktivitet([])).toBe(false);
+    });
+});
+
+describe('finnAntallTidelerÅTrekke', () => {
+    it('skal runde desimalprosent eksakt ned til 1 desimal utan flyttals-underflyt', () => {
+        const periodeMed25Uttaksdager = lagFarPeriode({
+            fom: '2025-06-02',
+            tom: '2025-07-04',
+            samtidigUttak: 9.2,
+        });
+
+        const tideler = finnAntallTidelerÅTrekke(periodeMed25Uttaksdager, false, '2025-01-01');
+
+        expect(tideler).toBe(23);
     });
 });

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -50,8 +50,21 @@ export const getAntallUttaksdagerIVinduRundtFødsel = (
     return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
 };
 
+const getDesimalSomSkalertHeltall = (verdi: number): { verdi: bigint; skala: bigint } => {
+    const tekst = verdi.toString().includes('e') ? verdi.toFixed(10).replace(/\.?0+$/, '') : verdi.toString();
+    const [heltall, desimaler = ''] = tekst.split('.');
+
+    return {
+        verdi: BigInt(`${heltall}${desimaler}`),
+        skala: 10n ** BigInt(desimaler.length),
+    };
+};
+
 // virkedagar × prosent / 100, runda ned til 1 desimal og uttrykt i tideler (heiltal).
-const tidelerNedrundet = (dager: number, prosent: number): number => Math.floor((dager * prosent) / 10);
+const tidelerNedrundet = (dager: number, prosent: number): number => {
+    const { verdi, skala } = getDesimalSomSkalertHeltall(prosent);
+    return Number((BigInt(dager) * verdi) / (skala * 10n));
+};
 
 /**
  * Reknar talet på trekkdagar for ein periode i *tideler* (heiltal).

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -11,7 +11,7 @@ import {
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { Tidsperioden, Uttaksdagen } from '@navikt/fp-utils';
+import { Tidsperioden, Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
 
 import {
     Uttaksplanperiode,
@@ -48,6 +48,52 @@ export const getAntallUttaksdagerIVinduRundtFødsel = (
     }
 
     return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
+};
+
+// virkedagar × prosent / 100, runda ned til 1 desimal og uttrykt i tideler (heiltal).
+const tidelerNedrundet = (dager: number, prosent: number): number => Math.floor((dager * prosent) / 10);
+
+/**
+ * Reknar talet på trekkdagar for ein periode i *tideler* (heiltal).
+ *
+ * Trekkdagar summerast i heiltal (tideler) i staden for desimaltal for å unngå
+ * flyttalsfeil. Eit døme: ti graderte dagar à 0,6 dag gir i flyttal
+ * 5,999999999999999 i staden for 6,0, og ein etterfølgjande `Math.floor` ville
+ * då telje 5 dagar og late ein dag stå att som «ubrukt» i telleverket.
+ *
+ * Matchar fp-sak (`no.nav.foreldrepenger.regler.uttak ... TrekkdagerUtregningUtil`
+ * / `Trekkdager`): trekkdagar = virkedagar × utbetalingsgrad / 100, runda *ned*
+ * til 1 desimal (RoundingMode.DOWN) per periode.
+ */
+export const finnAntallTidelerÅTrekke = (
+    periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt,
+    erFødsel: boolean,
+    familiehendelsedato: string,
+): number => {
+    if (erEøsUttakPeriode(periode)) {
+        // EØS-trekkdagar kjem ferdig utrekna (maks 1 desimal) frå fp-sak.
+        return Math.round(periode.trekkdager * 10);
+    }
+
+    const arbeidstidprosent = periode.gradering?.arbeidstidprosent;
+    const samtidigUttak = periode.samtidigUttak;
+    const dager = Uttaksperioden.getAntallUttaksdager(periode);
+
+    if (arbeidstidprosent) {
+        const utbetalingsgrad = 100 - arbeidstidprosent;
+        // Mor sin gradering i tidsrommet 3 veker før / 6 veker etter familiehendinga
+        // gir ikkje forlenging av stønadsperioden – dagane i vinduet trekkjast som heile.
+        if (erFødsel && periode.forelder === 'MOR') {
+            const dagerIVindu = getAntallUttaksdagerIVinduRundtFødsel(periode.fom, periode.tom, familiehendelsedato);
+            const dagerUtenforVindu = dager - dagerIVindu;
+            return dagerIVindu * 10 + tidelerNedrundet(dagerUtenforVindu, utbetalingsgrad);
+        }
+        return tidelerNedrundet(dager, utbetalingsgrad);
+    }
+    if (samtidigUttak) {
+        return tidelerNedrundet(dager, samtidigUttak);
+    }
+    return dager * 10;
 };
 
 export const erUttaksperiode = (periode: Uttaksplanperiode) => {

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -50,8 +50,21 @@ export const getAntallUttaksdagerIVinduRundtFødsel = (
     return Uttaksdagen.denneEllerNeste(overlappFom).getUttaksdagerFremTilOgMedDato(overlappTom);
 };
 
+const fjernAvsluttendeNullerFraDesimal = (tekst: string): string => {
+    if (!tekst.includes('.')) {
+        return tekst;
+    }
+
+    let slutt = tekst.length;
+    while (slutt > 0 && tekst[slutt - 1] === '0') {
+        slutt -= 1;
+    }
+
+    return tekst[slutt - 1] === '.' ? tekst.slice(0, slutt - 1) : tekst.slice(0, slutt);
+};
+
 const getDesimalSomSkalertHeltall = (verdi: number): { verdi: bigint; skala: bigint } => {
-    const tekst = verdi.toString().includes('e') ? verdi.toFixed(10).replace(/\.?0+$/, '') : verdi.toString();
+    const tekst = verdi.toString().includes('e') ? fjernAvsluttendeNullerFraDesimal(verdi.toFixed(10)) : verdi.toString();
     const [heltall, desimaler = ''] = tekst.split('.');
 
     return {


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7020

Telleverket summerte graderte trekkdagar som flyttal og golva heile summen med Math.floor. Ved gradering trekkjer t.d. ein dag med 40 % arbeid 0,6 dag, og 10 x 0,6 blir i flyttal 5,999999999999999 i staden for 6,0. Math.floor kutta då til 5, slik at éin fellesperiodedag feilaktig stod att som ubrukt (29/1 igjen i søknad mot 30/0 igjen i fp-sak).

Innfører delt hjelpefunksjon finnAntallTideleraaTrekke som reknar trekkdagar i tideler (heiltal) og rundar ned til 1 desimal per periode, eksakt slik fp-sak gjer (TrekkdagerUtregningUtil/Trekkdager med RoundingMode.DOWN). Summering skjer i heiltal for aa unngaa flyttalsfeil, og golving til heile dagar skjer foerst til slutt.