### PR TITLE
fix(uttaksplan): flagg manglende graderingsaktivitet fra planleggeren

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -55,7 +55,7 @@ export const useFinnFørsteSubmitFeilmelding = ({ opprinneligPlan }: UseFinnFør
         const søkersPerioder = perioder.filter(
             (periode) => Uttaksperioden.erIkkeEøsPeriode(periode) && periode.forelder === søkersForelder,
         );
-        return harPeriodeMedUkjentGraderingsaktivitet(søkersPerioder);
+        return harPeriodeMedUkjentGraderingsaktivitet(søkersPerioder, søkersForelder);
     };
 
     const harKunPerioderForDenAndreForelderen = (perioder: UttaksplanPerioder) =>

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
@@ -17,7 +17,7 @@ describe('mapFraFormValuesTilUttakPeriode', () => {
             hvorSkalDuJobbe: '123456789',
         } satisfies LeggTilEllerEndrePeriodeFormFormValues;
 
-        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR');
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR', true);
 
         expect(periode?.gradering).toBeUndefined();
     });
@@ -31,8 +31,38 @@ describe('mapFraFormValuesTilUttakPeriode', () => {
             hvorSkalDuJobbe: 'FRILANS',
         } satisfies LeggTilEllerEndrePeriodeFormFormValues;
 
-        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'FAR_MEDMOR');
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'FAR_MEDMOR', true);
 
         expect(periode?.gradering).toBeUndefined();
+    });
+
+    it('setter gradering-aktivitet frå valgt arbeidsgiver i søknaden (kanVelgeArbeidsgiver = true)', () => {
+        const values = {
+            forelder: 'MOR',
+            kontoTypeMor: 'MØDREKVOTE',
+            skalDuKombinereArbeidOgUttakMor: true,
+            stillingsprosentMor: '50',
+            hvorSkalDuJobbe: '123456789',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR', true);
+
+        expect(periode?.gradering?.aktivitet).toEqual({
+            type: 'ORDINÆRT_ARBEID',
+            arbeidsgiver: { id: '123456789' },
+        });
+    });
+
+    it('setter gradering-aktivitet til ANNET i planleggaren (kanVelgeArbeidsgiver = false)', () => {
+        const values = {
+            forelder: 'MOR',
+            kontoTypeMor: 'MØDREKVOTE',
+            skalDuKombinereArbeidOgUttakMor: true,
+            stillingsprosentMor: '50',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR', false);
+
+        expect(periode?.gradering?.aktivitet).toEqual({ type: 'ANNET' });
     });
 });

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
@@ -65,4 +65,18 @@ describe('mapFraFormValuesTilUttakPeriode', () => {
 
         expect(periode?.gradering?.aktivitet).toEqual({ type: 'ANNET' });
     });
+
+    it('beheld ANNET når plassholdaren ANNET ligg i hvorSkalDuJobbe i søknaden (ikkje reelt valg)', () => {
+        const values = {
+            forelder: 'MOR',
+            kontoTypeMor: 'MØDREKVOTE',
+            skalDuKombinereArbeidOgUttakMor: true,
+            stillingsprosentMor: '50',
+            hvorSkalDuJobbe: 'ANNET',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR', true);
+
+        expect(periode?.gradering?.aktivitet).toEqual({ type: 'ANNET' });
+    });
 });

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -628,6 +628,7 @@ export const mapFraFormValuesTilUttakPeriode = (
     values: LeggTilEllerEndrePeriodeFormFormValues,
     periode: { fom: string; tom: string },
     søker: BrukerRolleSak_fpoversikt,
+    kanVelgeArbeidsgiver: boolean,
 ): UttakPeriode_fpoversikt[] => {
     const nye = new Array<UttakPeriode_fpoversikt>();
 
@@ -641,7 +642,7 @@ export const mapFraFormValuesTilUttakPeriode = (
             forelder: 'MOR',
             gradering:
                 !erOverføringMor && values.skalDuKombinereArbeidOgUttakMor
-                    ? getGradering(søker === 'MOR', values.stillingsprosentMor, values.hvorSkalDuJobbe)
+                    ? getGradering(søker === 'MOR', values.stillingsprosentMor, values.hvorSkalDuJobbe, kanVelgeArbeidsgiver)
                     : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentMor) : undefined,
@@ -663,7 +664,12 @@ export const mapFraFormValuesTilUttakPeriode = (
             forelder: 'FAR_MEDMOR',
             gradering:
                 !erOverføringFarMedmor && values.skalDuKombinereArbeidOgUttakFarMedmor
-                    ? getGradering(søker === 'FAR_MEDMOR', values.stillingsprosentFarMedmor, values.hvorSkalDuJobbe)
+                    ? getGradering(
+                          søker === 'FAR_MEDMOR',
+                          values.stillingsprosentFarMedmor,
+                          values.hvorSkalDuJobbe,
+                          kanVelgeArbeidsgiver,
+                      )
                     : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentFarMedmor) : undefined,
@@ -763,8 +769,10 @@ const getGradering = (
     erSøker: boolean,
     stillingsprosent: string | undefined,
     hvorSkalDuJobbe: string | undefined,
+    kanVelgeArbeidsgiver: boolean,
 ): Gradering_fpoversikt => {
-    if (erSøker) {
+    // I planleggaren (kanVelgeArbeidsgiver === false) kan ein ikkje oppi aktivitet, så vi set alltid ANNET.
+    if (erSøker && kanVelgeArbeidsgiver) {
         return {
             aktivitet: {
                 type: finnAktivitetType(hvorSkalDuJobbe),

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -772,7 +772,9 @@ const getGradering = (
     kanVelgeArbeidsgiver: boolean,
 ): Gradering_fpoversikt => {
     // I planleggaren (kanVelgeArbeidsgiver === false) kan ein ikkje oppi aktivitet, så vi set alltid ANNET.
-    if (erSøker && kanVelgeArbeidsgiver) {
+    // 'ANNET' i hvorSkalDuJobbe er ein plassholdar (typisk frå planleggar-import) – brukaren har då
+    // ikkje valt ein reell aktivitet, så vi held på ANNET slik at detektoren framleis flaggar perioden.
+    if (erSøker && kanVelgeArbeidsgiver && hvorSkalDuJobbe && hvorSkalDuJobbe !== 'ANNET') {
         return {
             aktivitet: {
                 type: finnAktivitetType(hvorSkalDuJobbe),

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -774,7 +774,7 @@ const getGradering = (
     // I planleggaren (kanVelgeArbeidsgiver === false) kan ein ikkje oppi aktivitet, så vi set alltid ANNET.
     // 'ANNET' i hvorSkalDuJobbe er ein plassholdar (typisk frå planleggar-import) – brukaren har då
     // ikkje valt ein reell aktivitet, så vi held på ANNET slik at detektoren framleis flaggar perioden.
-    if (erSøker && kanVelgeArbeidsgiver && hvorSkalDuJobbe && hvorSkalDuJobbe !== 'ANNET') {
+    if (erSøker && kanVelgeArbeidsgiver && hvorSkalDuJobbe !== 'ANNET') {
         return {
             aktivitet: {
                 type: finnAktivitetType(hvorSkalDuJobbe),

--- a/packages/uttaksplan/src/kalender/Uttaksplankalender.stories.tsx
+++ b/packages/uttaksplan/src/kalender/Uttaksplankalender.stories.tsx
@@ -1846,7 +1846,7 @@ export const MarkerPeriodeNårGraderingsaktivitetMangler: Story = {
                 samtidigUttak: 40,
                 gradering: {
                     arbeidstidprosent: 60,
-                    aktivitet: { type: 'ORDINÆRT_ARBEID' },
+                    aktivitet: { type: 'ANNET' },
                 },
                 flerbarnsdager: false,
             },

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -39,6 +39,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
         uttakPerioder,
         foreldreInfo: { søker },
         erPeriodeneTilAnnenPartLåst,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const { sammenslåtteValgtePerioder, leggTilUttaksplanPerioder, setValgtePerioder, setEndredePerioder } =
@@ -139,7 +140,7 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
     const leggIKalender = (skalForskyve: boolean) => {
         leggTilUttaksplanPerioder(
             sammenslåtteValgtePerioder.flatMap((periode) =>
-                mapFraFormValuesTilUttakPeriode(formMethods.getValues(), periode, søker),
+                mapFraFormValuesTilUttakPeriode(formMethods.getValues(), periode, søker, kanVelgeArbeidsgiver),
             ),
             skalForskyve,
         );

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
@@ -70,7 +70,8 @@ export const EksisterendeValgtePerioder = ({ perioder }: Props) => {
                 const erPleiepengerPeriode =
                     erAvslåttPeriode && p.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER';
 
-                const morsAktivitetIkkeValgtAlert = alertsForPeriode(p).morsAktivitetIkkeValgt;
+                const { morsAktivitetIkkeValgt: morsAktivitetIkkeValgtAlert, graderingsaktivitetIkkeValgt: graderingsaktivitetIkkeValgtAlert } =
+                    alertsForPeriode(p);
 
                 return (
                     <HStack
@@ -143,6 +144,16 @@ export const EksisterendeValgtePerioder = ({ perioder }: Props) => {
                                     className="mt-3 mb-1 p-2"
                                 >
                                     <BodyShort>{morsAktivitetIkkeValgtAlert.melding}</BodyShort>
+                                </Alert>
+                            )}
+
+                            {graderingsaktivitetIkkeValgtAlert && (
+                                <Alert
+                                    variant={graderingsaktivitetIkkeValgtAlert.variant}
+                                    size="small"
+                                    className="mt-3 mb-1 p-2"
+                                >
+                                    <BodyShort>{graderingsaktivitetIkkeValgtAlert.melding}</BodyShort>
                                 </Alert>
                             )}
                         </VStack>

--- a/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
+++ b/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
@@ -4,6 +4,7 @@ import { IntlShape, useIntl } from 'react-intl';
 
 import {
     Barn,
+    BrukerRolleSak_fpoversikt,
     NavnPåForeldre,
     RettighetType_fpoversikt,
     UttakPeriodeAnnenpartEøs_fpoversikt,
@@ -79,6 +80,7 @@ export const usePerioderForKalendervisning = (
                     rettighetType,
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
+                    søker,
                 ),
             ];
         }
@@ -100,6 +102,7 @@ export const usePerioderForKalendervisning = (
                     rettighetType,
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
+                    søker,
                 ),
             ];
         }
@@ -113,11 +116,12 @@ export const usePerioderForKalendervisning = (
                 color,
                 srText: getKalenderSkjermlesertekstForPeriode(periode, navnPåForeldre, intl),
                 isUpdated,
-                ...leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(
+                ...leggTilVarselikonVedManglendeObligatoriskeValg(
                     rettighetType,
                     periode,
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
+                    søker,
                 ),
             } satisfies CalendarPeriod,
         ];
@@ -356,14 +360,16 @@ const splittPeriodeITo = (
     rettighetType: RettighetType_fpoversikt,
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     kanVelgeArbeidsgiver: boolean,
+    søker: BrukerRolleSak_fpoversikt,
 ): CalendarPeriod[] => {
     const forrige = Uttaksdagen.forrige(dato).getDato();
     const neste = Uttaksdagen.neste(dato).getDato();
-    const ikonProps = leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt(
+    const ikonProps = leggTilVarselikonVedManglendeObligatoriskeValg(
         rettighetType,
         periode,
         allePerioder,
         kanVelgeArbeidsgiver,
+        søker,
     );
 
     const lagPeriode = (fom: string, tom: string): CalendarPeriod => ({
@@ -386,18 +392,19 @@ const splittPeriodeITo = (
     return [lagPeriode(periode.fom, forrige), lagPeriode(neste, periode.tom)];
 };
 
-const leggTilIkonVedPeriodeDerMorsAktivitetIkkeErValgt = (
+const leggTilVarselikonVedManglendeObligatoriskeValg = (
     rettighetType: RettighetType_fpoversikt,
     periode: UttaksplanperiodeMedKunTapteDager,
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     kanVelgeArbeidsgiver: boolean,
+    søker: BrukerRolleSak_fpoversikt,
 ) => {
     const morsPerioder = allePerioder.filter(
         (p): p is UttakPeriode_fpoversikt => erVanligUttakPeriode(p) && p.forelder === 'MOR',
     );
     if (
         harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [periode, ...morsPerioder]) ||
-        (kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode]))
+        (kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode], søker))
     ) {
         return {
             icon: <ExclamationmarkTriangleFillIcon aria-hidden color="var(--ax-warning-600)" />,

--- a/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
@@ -1092,7 +1092,7 @@ export const MarkeringNårGraderingsaktivitetMangler: Story = {
                 samtidigUttak: 40,
                 gradering: {
                     arbeidstidprosent: 60,
-                    aktivitet: { type: 'ORDINÆRT_ARBEID' },
+                    aktivitet: { type: 'ANNET' },
                 },
                 flerbarnsdager: false,
             },

--- a/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.test.tsx
@@ -168,7 +168,7 @@ describe('UttaksplanListe', () => {
                 forelder: 'MOR',
                 gradering: {
                     aktivitet: {
-                        type: 'ORDINÆRT_ARBEID',
+                        type: 'ANNET',
                     },
                     arbeidstidprosent: 50,
                 },

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -81,6 +81,7 @@ const byggEnkelHandlingPerioder = (
 ): UttakPeriode_fpoversikt[] | undefined => {
     switch (hvaVilDuGjøre) {
         case 'LEGG_TIL_FERIE':
+            // forelder settes til MOR fordi feltet er påkrevd, men ferie behandles likt for alle foreldre
             return [{ fom, tom, forelder: 'MOR', utsettelseÅrsak: 'LOVBESTEMT_FERIE', flerbarnsdager: false }];
         case 'LEGG_TIL_UTSETTELSE':
             return [{ fom, tom, forelder: søker, utsettelseÅrsak: values.utsettelseÅrsak, flerbarnsdager: false }];

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { Alert, Button, ErrorMessage, HStack, Heading, Radio, VStack } from '@navikt/ds-react';
 
 import { RhfForm, RhfRadioGroup } from '@navikt/fp-form-hooks';
-import { BrukerRolleSak_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { BrukerRolleSak_fpoversikt, UttakPeriode_fpoversikt, UttakPeriodeAnnenpartEøs_fpoversikt } from '@navikt/fp-types';
 import { Tidsperioden, omitMany } from '@navikt/fp-utils';
 import { isRequired, notEmpty } from '@navikt/fp-validation';
 
@@ -71,6 +71,52 @@ const erGradertMorsUttak = (
     hvaVilDuGjøre === 'LEGG_TIL_PERIODE' &&
     (forelder === 'MOR' || forelder === 'BEGGE') &&
     skalDuKombinereArbeidOgUttakMor === true;
+
+const byggEnkelHandlingPerioder = (
+    hvaVilDuGjøre: HvaVilDuGjøre | undefined,
+    fom: string,
+    tom: string,
+    søker: BrukerRolleSak_fpoversikt,
+    values: FormValues,
+): UttakPeriode_fpoversikt[] | undefined => {
+    switch (hvaVilDuGjøre) {
+        case 'LEGG_TIL_FERIE':
+            return [{ fom, tom, forelder: 'MOR', utsettelseÅrsak: 'LOVBESTEMT_FERIE', flerbarnsdager: false }];
+        case 'LEGG_TIL_UTSETTELSE':
+            return [{ fom, tom, forelder: søker, utsettelseÅrsak: values.utsettelseÅrsak, flerbarnsdager: false }];
+        case 'LEGG_TIL_PAUSE':
+            return [
+                {
+                    fom,
+                    tom,
+                    forelder: søker,
+                    utsettelseÅrsak: 'FRI',
+                    morsAktivitet: values.morsAktivitet || undefined,
+                    flerbarnsdager: false,
+                },
+            ];
+        default:
+            return undefined;
+    }
+};
+
+type UttakPeriodeEllerEøs = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
+
+const erOverlappendeMedEøsPerioder = (perioder: UttakPeriodeEllerEøs[], fom: string, tom: string): boolean =>
+    perioder.some(
+        (periode) => erEøsUttakPeriode(periode) && Tidsperioden.forPeriode(periode).overlapper({ fom, tom }),
+    );
+
+const skalViseEndreEllerForskyvPanel = (
+    harPeriodeDerMorsAktivitetIkkeErValgt: boolean,
+    kanKunErstatte: boolean,
+    uttakPerioder: UttakPeriodeEllerEøs[],
+    fom: string,
+    tom: string,
+): boolean =>
+    !harPeriodeDerMorsAktivitetIkkeErValgt &&
+    !kanKunErstatte &&
+    erDetEksisterendePerioderEtterValgtePerioder(uttakPerioder, [{ fom, tom }]);
 
 export const LeggTilEllerEndrePeriodeListPanel = ({
     erNyPeriodeModus,
@@ -141,22 +187,15 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const onSubmit = (values: FormValues) => {
         setFeilmelding(undefined);
 
-        const erOverlappendeMedEøsPerioder = uttakPerioder.some(
-            (periode) =>
-                erEøsUttakPeriode(periode) &&
-                Tidsperioden.forPeriode(periode).overlapper({
-                    fom: notEmpty(values.fom),
-                    tom: notEmpty(values.tom),
-                }),
-        );
-        if (erOverlappendeMedEøsPerioder) {
+        const fom = notEmpty(values.fom);
+        const tom = notEmpty(values.tom);
+
+        if (erOverlappendeMedEøsPerioder(uttakPerioder, fom, tom)) {
             setFeilmelding(intl.formatMessage({ id: 'uttaksplan.overskriderEøs' }));
             return;
         }
 
         if (hvaVilDuGjøre === 'LEGG_TIL_PERIODE') {
-            const fom = notEmpty(values.fom);
-            const tom = notEmpty(values.tom);
             const submitFeilmelding = formSubmitValidator([{ fom, tom }], values);
 
             if (submitFeilmelding) {
@@ -172,16 +211,14 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
             return;
         }
 
-        if (
-            !harPeriodeDerMorsAktivitetIkkeErValgt &&
-            !kanKunErstatte &&
-            erDetEksisterendePerioderEtterValgtePerioder(uttakPerioder, [
-                {
-                    fom: uttaksplanperiode?.fom ?? notEmpty(fomValue),
-                    tom: uttaksplanperiode?.tom ?? notEmpty(tomValue),
-                },
-            ])
-        ) {
+        const visForskyvPanel = skalViseEndreEllerForskyvPanel(
+            harPeriodeDerMorsAktivitetIkkeErValgt,
+            kanKunErstatte,
+            uttakPerioder,
+            uttaksplanperiode?.fom ?? notEmpty(fomValue),
+            uttaksplanperiode?.tom ?? notEmpty(tomValue),
+        );
+        if (visForskyvPanel) {
             setVisEndreEllerForskyvPanel(true);
         } else {
             leggIListe(false);
@@ -193,57 +230,12 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         const fom = notEmpty(values.fom);
         const tom = notEmpty(values.tom);
 
-        if (hvaVilDuGjøre === 'LEGG_TIL_FERIE') {
-            handleAddPeriode(
-                [
-                    {
-                        fom,
-                        tom,
-                        forelder: 'MOR',
-                        utsettelseÅrsak: 'LOVBESTEMT_FERIE',
-                        flerbarnsdager: false,
-                    },
-                ],
-                skalForskyve,
-            );
-        } else if (hvaVilDuGjøre === 'LEGG_TIL_UTSETTELSE') {
-            handleAddPeriode(
-                [
-                    {
-                        fom,
-                        tom,
-                        forelder: søker,
-                        utsettelseÅrsak: values.utsettelseÅrsak,
-                        flerbarnsdager: false,
-                    },
-                ],
-                skalForskyve,
-            );
-        } else if (hvaVilDuGjøre === 'LEGG_TIL_PAUSE') {
-            handleAddPeriode(
-                [
-                    {
-                        fom,
-                        tom,
-                        forelder: søker,
-                        utsettelseÅrsak: 'FRI',
-                        morsAktivitet: values.morsAktivitet || undefined,
-                        flerbarnsdager: false,
-                    },
-                ],
-                skalForskyve,
-            );
+        const enkelHandlingPerioder = byggEnkelHandlingPerioder(hvaVilDuGjøre, fom, tom, søker, values);
+        if (enkelHandlingPerioder) {
+            handleAddPeriode(enkelHandlingPerioder, skalForskyve);
         } else if (hvaVilDuGjøre === 'LEGG_TIL_OPPHOLD') {
             const nyeUttakPerioder = new UttakPeriodeBuilder(uttakPerioder, 'liste')
-                .fjernUttakPerioder(
-                    [
-                        {
-                            fom,
-                            tom,
-                        },
-                    ],
-                    false,
-                )
+                .fjernUttakPerioder([{ fom, tom }], false)
                 .getUttakPerioder();
 
             uttaksplanRedigering?.oppdaterUttaksplan?.(nyeUttakPerioder);

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -85,6 +85,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         foreldreInfo: { søker, rettighetType },
         familiehendelsedato,
         erPeriodeneTilAnnenPartLåst,
+        kanVelgeArbeidsgiver,
     } = useUttaksplanData();
 
     const [feilmelding, setFeilmelding] = useState<string | undefined>();
@@ -254,7 +255,10 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
                 return;
             }
             const mapped = omitMany(values, ['fom', 'tom', 'hvaVilDuGjøre']);
-            handleAddPeriode(mapFraFormValuesTilUttakPeriode(mapped, { fom, tom }, søker), skalForskyve);
+            handleAddPeriode(
+                mapFraFormValuesTilUttakPeriode(mapped, { fom, tom }, søker, kanVelgeArbeidsgiver),
+                skalForskyve,
+            );
         }
 
         setIsLeggTilPeriodePanelOpen(false);

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -73,7 +73,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                                             className="text-ax-danger-800"
                                         />
                                     )}
-                                    {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([p]) && (
+                                    {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([p], søker) && (
                                         <ExclamationmarkTriangleFillIcon
                                             title={intl.formatMessage({
                                                 id: 'PeriodeListeHeader.GraderingsaktivitetIkkeValgt',

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
@@ -29,7 +29,7 @@ interface Props {
 export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåForeldre, erFarEllerMedmor }: Props) => {
     const intl = useIntl();
     const {
-        foreldreInfo: { rettighetType },
+        foreldreInfo: { rettighetType, søker },
         uttakPerioder,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -59,7 +59,7 @@ export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåF
                     className="text-ax-danger-800"
                 />
             )}
-            {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode]) && (
+            {kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode], søker) && (
                 <ExclamationmarkTriangleFillIcon
                     title={intl.formatMessage({ id: 'PeriodeListeHeader.GraderingsaktivitetIkkeValgt' })}
                     fontSize="1.5rem"

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
@@ -55,7 +55,7 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
 
     const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, uttaksplanperioder);
     const harUkjentGraderingsaktivitet =
-        kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder);
+        kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder, søker);
     const harValideringsfeil = harMorsAktivitetIkkeErValgt || harUkjentGraderingsaktivitet;
     const valideringsfeilTekstId = harMorsAktivitetIkkeErValgt
         ? 'PeriodeListeHeader.MorsAktivitetIkkeValgt'

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -93,7 +93,7 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
         }),
         graderingsaktivitetIkkeValgt:
             kanVelgeArbeidsgiver && erSøkersIkkeEøsPeriode(periode, søker)
-                ? tilAktiv(GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE, { periode })
+                ? tilAktiv(GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE, { periode, søker })
                 : undefined,
     });
 };
@@ -111,6 +111,7 @@ export const useUttaksplanListeAlerts = (
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_LISTE, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
+                  søker,
               })
             : undefined,
     };
@@ -129,6 +130,7 @@ export const useUttaksplanKalenderAlerts = (
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_KALENDER, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
+                  søker,
               })
             : undefined,
     };

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
@@ -34,10 +34,12 @@ type EksisterendeValgtePeriodeKontekst = {
 
 type GraderingsaktivitetListeKontekst = {
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>;
+    søker: BrukerRolleSak_fpoversikt;
 };
 
 type GraderingsaktivitetPeriodeKontekst = {
     periode: Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager;
+    søker: BrukerRolleSak_fpoversikt;
 };
 
 export type PeriodeDetaljerKontekst = {
@@ -267,7 +269,7 @@ export const MANGLER_GRADERINGSAKTIVITET_LISTE = lagAlertregel<Graderingsaktivit
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([...ctx.perioder], ctx.søker),
 });
 
 export const MANGLER_GRADERINGSAKTIVITET_KALENDER = lagAlertregel<GraderingsaktivitetListeKontekst>({
@@ -285,7 +287,7 @@ export const MANGLER_GRADERINGSAKTIVITET_KALENDER = lagAlertregel<Graderingsakti
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([...ctx.perioder], ctx.søker),
 });
 
 export const GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<GraderingsaktivitetPeriodeKontekst>({
@@ -303,7 +305,7 @@ export const GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<Graderi
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([ctx.periode]),
+    skalVises: (ctx) => harPeriodeMedUkjentGraderingsaktivitet([ctx.periode], ctx.søker),
 });
 
 /**

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -100,7 +100,33 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
 });
 
 describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
-    it('skal returnere true når periode har gradering med ORDINÆRT_ARBEID uten arbeidsgiver', () => {
+    it('skal returnere true når søkers periode har gradering med ANNET (frå planleggaren)', () => {
+        const perioder = [
+            lagMorPeriode({
+                gradering: {
+                    arbeidstidprosent: 60,
+                    aktivitet: { type: 'ANNET' },
+                },
+            }),
+        ];
+
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(true);
+    });
+
+    it('skal returnere false når ANNET-perioden tilhøyrer annen part (ikkje søker)', () => {
+        const perioder = [
+            lagFarPeriode({
+                gradering: {
+                    arbeidstidprosent: 60,
+                    aktivitet: { type: 'ANNET' },
+                },
+            }),
+        ];
+
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(false);
+    });
+
+    it('skal returnere true når søkers periode har gradering med ORDINÆRT_ARBEID uten arbeidsgiver', () => {
         const perioder = [
             lagMorPeriode({
                 gradering: {
@@ -110,7 +136,7 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
             }),
         ];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(true);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(true);
     });
 
     it('skal returnere false når ORDINÆRT_ARBEID har gyldig arbeidsgiver', () => {
@@ -126,7 +152,7 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
             }),
         ];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(false);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(false);
     });
 
     it('skal returnere true når arbeidsgiver-id er aktivitetstype-plassholdaren ORDINÆRT_ARBEID', () => {
@@ -142,7 +168,7 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
             }),
         ];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(true);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(true);
     });
 
     it('skal returnere false for FRILANS uten arbeidsgiver', () => {
@@ -152,7 +178,7 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
             }),
         ];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(false);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(false);
     });
 
     it('skal returnere false for SELVSTENDIG_NÆRINGSDRIVENDE uten arbeidsgiver', () => {
@@ -165,16 +191,16 @@ describe('harPeriodeMedUkjentGraderingsaktivitet', () => {
             }),
         ];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(false);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(false);
     });
 
     it('skal returnere false når perioden ikke har gradering', () => {
         const perioder = [lagMorPeriode()];
 
-        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder)).toBe(false);
+        expect(harPeriodeMedUkjentGraderingsaktivitet(perioder, 'MOR')).toBe(false);
     });
 
     it('skal returnere false for tom liste', () => {
-        expect(harPeriodeMedUkjentGraderingsaktivitet([])).toBe(false);
+        expect(harPeriodeMedUkjentGraderingsaktivitet([], 'MOR')).toBe(false);
     });
 });

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -173,25 +173,35 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
 };
 
 /**
- * Sjekker om noken periode har gradering der aktivitet-typen er ORDINÆRT_ARBEID, men
- * arbeidsgiver manglar. Dette skjer typisk når ein plan kjem inn frå planleggar-appen
- * (som ikkje veit om søkjar sine arbeidsforhold) – då blir aktivitetstypen brukt som
- * orgnummer, noko som er ugyldig. Brukar må velje konkret arbeidsgiver/frilans/sjølvst.
- * før planen kan sendast inn.
+ * Sjekker om innlogga brukar (søkjar) har ein periode med gradering der aktiviteten ikkje
+ * er valt. Dette skjer typisk når ein plan kjem inn frå planleggar-appen (som ikkje veit om
+ * søkjar sine arbeidsforhold) – då blir aktivitetstypen sett til 'ANNET' som markør.
+ * Brukar må velje konkret arbeidsgiver/frilans/sjølvst. før planen kan sendast inn.
+ *
+ * Berre søkjar sine eigne periodar blir flagga – annen part sine periodar kan ein ikkje
+ * oppgi aktivitet for i skjema, og dei skal difor ikkje blokkere innsending.
  */
 export const harPeriodeMedUkjentGraderingsaktivitet = (
     perioder: UttaksplanperiodeMedKunTapteDager[] | Uttaksplanperiode[],
+    søker: BrukerRolleSak_fpoversikt,
 ) => {
     return perioder.some((periode) => {
-        if (!erVanligUttakPeriode(periode)) {
+        if (!erVanligUttakPeriode(periode) || periode.forelder !== søker) {
             return false;
         }
         const aktivitet = periode.gradering?.aktivitet;
-        if (aktivitet?.type !== 'ORDINÆRT_ARBEID') {
+        if (!aktivitet) {
             return false;
         }
-        const arbeidsgiverId = aktivitet.arbeidsgiver?.id;
-        return !arbeidsgiverId || arbeidsgiverId === aktivitet.type;
+        if (aktivitet.type === 'ANNET') {
+            return true;
+        }
+        // Defensivt for eldre/innkomande planar: ORDINÆRT_ARBEID utan gyldig arbeidsgiver.
+        if (aktivitet.type === 'ORDINÆRT_ARBEID') {
+            const arbeidsgiverId = aktivitet.arbeidsgiver?.id;
+            return !arbeidsgiverId || arbeidsgiverId === aktivitet.type;
+        }
+        return false;
     });
 };
 


### PR DESCRIPTION
Planleggeren setter nå alltid gradering-aktivitet til ANNET (den vet ikke om brukerens arbeidsforhold). Sjekken i søknaden flagger perioder der innlogget bruker har gradering med ANNET, slik at man må velge arbeidsgiver/frilans/ selvstendig før planen kan sendes inn. Detektoren er søker-scopet slik at annen parts perioder ikke feilaktig blokkerer.