### PR TITLE
TFP-7023(uttaksplan): skill foreldrepenger med/uten aktivitetskrav i endre…

### DIFF
--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -11,7 +11,11 @@ import { formatDate } from '@navikt/fp-utils';
 import { useUttaksplanData } from '../../../context/UttaksplanDataContext';
 import { genererPeriodeKey, getStønadskvoteNavn } from '../../../liste/utils/uttaksplanListeUtils';
 import { Uttaksplanperiode, erEøsUttakPeriode, erVanligUttakPeriode } from '../../../types/UttaksplanPeriode';
-import { harPeriodeDerMorsAktivitetIkkeErValgt, harPeriodeMedUkjentGraderingsaktivitet } from '../../../utils/periodeUtils';
+import {
+    erAvslåttPeriode,
+    harPeriodeDerMorsAktivitetIkkeErValgt,
+    harPeriodeMedUkjentGraderingsaktivitet,
+} from '../../../utils/periodeUtils';
 
 interface Props {
     perioder: Uttaksplanperiode[];
@@ -89,6 +93,8 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                                             erEøsPeriode: erEøsUttakPeriode(p),
                                             morsAktivitet,
                                             konto: erVanligUttakPeriode(p) ? p.kontoType : undefined,
+                                            erAleneOmOmsorg: rettighetType === 'ALENEOMSORG',
+                                            erAvslått: erAvslåttPeriode(p),
                                         })}`}
                                 </HStack>
                             </Radio>


### PR DESCRIPTION
… periode

https://jira.adeo.no/browse/TFP-7023

Velg periode-steget i endre-panelet listet bare-far-har-rett-perioder som kun "Foreldrepenger". getStønadskvoteNavn viser med/uten aktivitetskrav først når erAleneOmOmsorg og erAvslått sendes inn, slik listevisningen og slett-panelet gjør. Sender nå de samme verdiene fra VelgPeriodePanelStep.