### PR TITLE
fix(uttaksplan): ikkje logg falske overlapp for avslåtte periodar uta…

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.test.ts
@@ -1,0 +1,143 @@
+import { renderHook } from '@testing-library/react';
+
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { useLoggOverlappIVedtak } from './useLoggOverlappIVedtak';
+
+const captureMessage = vi.hoisted(() => vi.fn());
+
+vi.mock('@navikt/fp-observability', () => ({
+    captureMessage: (...args: unknown[]) => captureMessage(...args),
+    withScope: (callback: (scope: unknown) => void) =>
+        callback({ setLevel: vi.fn(), setTag: vi.fn(), setExtra: vi.fn() }),
+}));
+
+const innvilget: UttakPeriode_fpoversikt['resultat'] = {
+    innvilget: true,
+    trekkerDager: true,
+    trekkerMinsterett: false,
+    årsak: 'ANNET',
+};
+const avslåttUtenTrekkdager: UttakPeriode_fpoversikt['resultat'] = {
+    innvilget: false,
+    trekkerDager: false,
+    trekkerMinsterett: false,
+    årsak: 'ANNET',
+};
+
+const periode = (overrides: Partial<UttakPeriode_fpoversikt>): UttakPeriode_fpoversikt => ({
+    fom: '2026-01-01',
+    tom: '2026-01-31',
+    forelder: 'MOR',
+    kontoType: 'FELLESPERIODE',
+    flerbarnsdager: false,
+    ...overrides,
+});
+
+describe('useLoggOverlappIVedtak', () => {
+    beforeEach(() => {
+        captureMessage.mockClear();
+    });
+
+    it('loggar ikkje når ein avslått periode utan trekkdagar overlappar annen part sin reelle periode', () => {
+        const morAvslått = periode({
+            fom: '2026-07-27',
+            tom: '2026-07-31',
+            forelder: 'MOR',
+            kontoType: 'FELLESPERIODE',
+            resultat: avslåttUtenTrekkdager,
+        });
+        const farReell = periode({
+            fom: '2026-07-06',
+            tom: '2026-07-31',
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FEDREKVOTE',
+            resultat: innvilget,
+        });
+
+        renderHook(() => useLoggOverlappIVedtak([morAvslått, farReell], [morAvslått], [farReell]));
+
+        expect(captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('loggar når to reelle periodar overlappar utan samtidig uttak', () => {
+        const mor = periode({
+            fom: '2026-07-27',
+            tom: '2026-07-31',
+            forelder: 'MOR',
+            kontoType: 'FELLESPERIODE',
+            resultat: innvilget,
+        });
+        const far = periode({
+            fom: '2026-07-06',
+            tom: '2026-07-31',
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FEDREKVOTE',
+            resultat: innvilget,
+        });
+
+        renderHook(() => useLoggOverlappIVedtak([mor, far], [mor], [far]));
+
+        expect(captureMessage).toHaveBeenCalledWith(
+            'Uttaksplan har ugyldig overlappande periodar etter transformasjon',
+            'warning',
+        );
+    });
+
+    it('loggar ikkje når overlappande periodar har samtidig uttak på begge partar', () => {
+        const mor = periode({
+            fom: '2025-10-14',
+            tom: '2025-10-27',
+            forelder: 'MOR',
+            kontoType: 'MØDREKVOTE',
+            samtidigUttak: 100,
+            resultat: innvilget,
+        });
+        const far = periode({
+            fom: '2025-10-14',
+            tom: '2025-10-27',
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FEDREKVOTE',
+            samtidigUttak: 100,
+            resultat: innvilget,
+        });
+
+        renderHook(() => useLoggOverlappIVedtak([mor, far], [mor], [far]));
+
+        expect(captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('loggar ikkje når søkjaren sin eigen avslåtte periode overlappar annen part', () => {
+        const farAvslått = periode({
+            fom: '2025-11-10',
+            tom: '2025-12-29',
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FEDREKVOTE',
+            resultat: avslåttUtenTrekkdager,
+        });
+        const morMødrekvote = periode({
+            fom: '2025-11-10',
+            tom: '2025-11-24',
+            forelder: 'MOR',
+            kontoType: 'MØDREKVOTE',
+            resultat: innvilget,
+        });
+        const morFellesperiode = periode({
+            fom: '2025-11-25',
+            tom: '2026-03-06',
+            forelder: 'MOR',
+            kontoType: 'FELLESPERIODE',
+            resultat: innvilget,
+        });
+
+        renderHook(() =>
+            useLoggOverlappIVedtak(
+                [farAvslått, morMødrekvote, morFellesperiode],
+                [farAvslått],
+                [morMødrekvote, morFellesperiode],
+            ),
+        );
+
+        expect(captureMessage).not.toHaveBeenCalled();
+    });
+});

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
@@ -25,7 +25,9 @@ export const useLoggOverlappIVedtak = (
         }
         lastCheckedFingerprint.current = fingerprint;
 
-        const perioderUttaksplan = uttaksplan.filter((p): p is UttakPeriode_fpoversikt => 'forelder' in p);
+        const perioderUttaksplan = uttaksplan
+            .filter((p): p is UttakPeriode_fpoversikt => 'forelder' in p)
+            .filter(okkupererTid);
         const ugyldigeOverlapp = finnUgyldigeOverlapp(perioderUttaksplan);
         if (ugyldigeOverlapp.length > 0) {
             withScope((scope) => {
@@ -50,6 +52,12 @@ export const useLoggOverlappIVedtak = (
 
 const erOverlappande = (a: UttakPeriode_fpoversikt, b: UttakPeriode_fpoversikt): boolean =>
     dayjs(a.fom).isSameOrBefore(b.tom, 'day') && dayjs(b.fom).isSameOrBefore(a.tom, 'day');
+
+// Avslåtte periodar utan trekkdagar okkuperer ikkje tid i planen og blir filtrert vekk før visning
+// (sjå filtrerBortPerioderUtenTrekkdager i UttaksplanDataContext). Dei skal difor ikkje reknast som
+// ugyldige overlapp her, sjølv om dei overlappar annen part sin reelle periode i mellomresultatet.
+const okkupererTid = (periode: UttakPeriode_fpoversikt): boolean =>
+    !(periode.resultat?.innvilget === false && periode.resultat?.trekkerDager === false);
 
 const finnUgyldigeOverlapp = (
     perioder: UttakPeriode_fpoversikt[],


### PR DESCRIPTION
…n trekkdagar

Avslåtte periodar utan trekkdagar (innvilget=false && trekkerDager=false) okkuperer ikkje tid i planen og blir filtrert vekk av filtrerBortPerioderUtenTrekkdager før visning. Etter at okkupererTid-sjekken vart lagt til i fjernOverlappUtenSamtidigUttak (be1bca09c), blir annen part / søkjaren sin reelle periode med rette behaldt sjølv om ein slik avslått periode overlappar. useLoggOverlappIVedtak køyrde likevel overlapp-sjekken på mellomresultatet og flagga desse som ugyldige overlapp, sjølv om den rendra planen ikkje har noko overlapp.

Filtrer difor vekk avslåtte periodar utan trekkdagar før overlapp-sjekken, slik at logginga ser same datasett som den rendra planen.