### PR TITLE
TFP-7027(foreldrepengesoknad): behold overført plan ved tilbakestilling

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
@@ -15,6 +15,7 @@ import {
     Dekningsgrad,
     FpPersonopplysningerDto_fpoversikt,
     SøkersituasjonFp,
+    UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import {
@@ -76,9 +77,10 @@ type StoryArgs = {
     barnet: Barn;
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     dekningsgrad: Dekningsgrad;
-    fordeling: Fordeling;
+    fordeling?: Fordeling;
     valgtEksisterendeSaksnr?: string;
-    uttaksplan?: UttakPeriode_fpoversikt[];
+    uttaksplan?: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
+    kommerFraPlanlegger?: boolean;
 } & ComponentProps<typeof UttaksplanSteg>;
 
 const meta = {
@@ -103,6 +105,7 @@ const meta = {
         erEndringssøknad,
         valgtEksisterendeSaksnr,
         uttaksplan,
+        kommerFraPlanlegger,
     }) => {
         return (
             <MemoryRouter initialEntries={[SøknadRoutes.UTTAKSPLAN]}>
@@ -121,6 +124,7 @@ const meta = {
                         [ContextDataType.PERIODE_MED_FORELDREPENGER]: dekningsgrad,
                         [ContextDataType.VALGT_EKSISTERENDE_SAKSNR]: valgtEksisterendeSaksnr,
                         [ContextDataType.UTTAKSPLAN]: uttaksplan,
+                        [ContextDataType.KOMMER_FRA_PLANLEGGER]: kommerFraPlanlegger,
                     }}
                 >
                     <UttaksplanSteg
@@ -717,5 +721,49 @@ export const NySøknadFørVedtakMedEksisterendeSak: Story = {
         erEndringssøknad: false,
         valgtEksisterendeSaksnr: '123456789',
         uttaksplan: INNVILGET_PLAN_FRA_EKSISTERENDE_SAK,
+    },
+};
+
+// Søknad overført frå planleggeren: uttaksplanen ligg i context, men fordeling manglar (planleggeren
+// sender ikkje med fordeling). Brukast for å verifisere at "Tilbakestill plan" hentar opp den overførte
+// planen igjen etter "Fjern alt".
+const planleggerUttaksplan = [
+    {
+        forelder: 'MOR',
+        kontoType: 'FORELDREPENGER_FØR_FØDSEL',
+        fom: '2024-06-10',
+        tom: '2024-06-28',
+        flerbarnsdager: false,
+    },
+    {
+        forelder: 'MOR',
+        kontoType: 'MØDREKVOTE',
+        fom: '2024-07-01',
+        tom: '2024-09-06',
+        flerbarnsdager: false,
+    },
+    {
+        forelder: 'MOR',
+        kontoType: 'FELLESPERIODE',
+        fom: '2024-09-09',
+        tom: '2024-11-15',
+        flerbarnsdager: false,
+    },
+    {
+        forelder: 'FAR_MEDMOR',
+        kontoType: 'FEDREKVOTE',
+        fom: '2024-11-18',
+        tom: '2025-01-24',
+        flerbarnsdager: false,
+    },
+] satisfies UttakPeriode_fpoversikt[];
+
+export const FødselMorOgFarBeggeHarRettOverførtFraPlanlegger: Story = {
+    parameters: FødselMorOgFarBeggeHarRett.parameters,
+    args: {
+        ...FødselMorOgFarBeggeHarRett.args,
+        fordeling: undefined,
+        uttaksplan: planleggerUttaksplan,
+        kommerFraPlanlegger: true,
     },
 };

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
@@ -19,6 +19,7 @@ const {
     FødselMorOgFarKunMorHarRett,
     FødselFarBeggeHarRettStarterPåTermin,
     NySøknadFørVedtakMedEksisterendeSak,
+    FødselMorOgFarBeggeHarRettOverførtFraPlanlegger,
 } = composeStories(stories);
 
 describe('<UttaksplanSteg>', () => {
@@ -263,6 +264,48 @@ describe('<UttaksplanSteg>', () => {
             expect(
                 await screen.findByText('Du må gjøre en endring for å kunne søke om endring'),
             ).toBeInTheDocument();
+        }),
+    );
+
+    it(
+        'skal hente opp den overførte planen frå planleggeren igjen med "Tilbakestill plan" etter "Fjern alt"',
+        mswWrapper(async ({ setHandlers }) => {
+            const gåTilNesteSide = vi.fn();
+            const mellomlagreSøknadOgNaviger = vi.fn();
+            setHandlers(FødselMorOgFarBeggeHarRettOverførtFraPlanlegger.parameters.msw);
+
+            render(
+                <FødselMorOgFarBeggeHarRettOverførtFraPlanlegger
+                    gåTilNesteSide={gåTilNesteSide}
+                    mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                />,
+            );
+
+            // Den overførte planen er vist (ikkje tom)
+            expect(await screen.findAllByText('Din plan med foreldrepenger')).toHaveLength(2);
+
+            // Gå til redigeringsmodus og ekspander mobilpanelet
+            await userEvent.click(screen.getByText('Start redigering'));
+            await userEvent.click(screen.getAllByText('Du kan velge datoer i kalenderen')[0]!);
+
+            // Den overførte planen er utgangspunktet, så "Tilbakestill plan" er deaktivert frå start
+            expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).toBeDisabled();
+
+            // Fjern alt tømmer planen og aktiverer "Tilbakestill plan"
+            await userEvent.click(screen.getByText('Fjern alt'));
+            expect(await screen.findByText('Ønsker du å fjerne alt som er lagt til?')).toBeInTheDocument();
+            const fjernAltModal = screen.getByRole('dialog');
+            await userEvent.click(within(fjernAltModal).getByText('Fjern alt'));
+
+            expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).not.toBeDisabled();
+
+            // Tilbakestill plan skal hente opp den overførte planen igjen
+            await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill plan' }));
+            expect(await screen.findByText('Ønsker du å tilbakestille planen?')).toBeInTheDocument();
+            await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill' }));
+
+            // Planen er tilbake til utgangspunktet, så "Tilbakestill plan" er deaktivert igjen
+            expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).toBeDisabled();
         }),
     );
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -58,7 +58,13 @@ export const UttaksplanSteg = ({
     const dekningsgrad = notEmpty(useContextGetData(ContextDataType.PERIODE_MED_FORELDREPENGER));
     const uttaksplan = useContextGetData(ContextDataType.UTTAKSPLAN);
     const eksisterendeSaksnummer = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
+    const kommerFraPlanlegger = !!useContextGetData(ContextDataType.KOMMER_FRA_PLANLEGGER);
     const oppdaterUttaksplan = useContextSaveData(ContextDataType.UTTAKSPLAN);
+
+    // Når søknaden er overført fra planleggeren ligg den overførte planen i uttaksplan-context, men
+    // den kan ikkje reknast ut på nytt her (planleggeren sender ikkje med fordeling). Me tar difor vare
+    // på den opprinnelege planen slik at "Tilbakestill plan" kan hente han opp igjen etter "Fjern alt".
+    const [opprinneligPlanleggerplan] = useState(() => (kommerFraPlanlegger ? uttaksplan : undefined));
 
     const eksisterendeSak = foreldrepengerSaker?.find((sak) => sak.saksnummer === eksisterendeSaksnummer);
 
@@ -129,7 +135,7 @@ export const UttaksplanSteg = ({
             ? annenPartVedtakQuery.data.perioder
             : undefined;
     const tidligereUttaksperioder = uttaksplanForEksisterendeSak ?? annenPartsPerioderEllerUndefined;
-    const defaultUttaksperioder = tidligereUttaksperioder ?? nyttUttaksplanForslag;
+    const defaultUttaksperioder = opprinneligPlanleggerplan ?? tidligereUttaksperioder ?? nyttUttaksplanForslag;
 
     const erPlanenEndret =
         uttaksplan !== undefined &&


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-7027

Når søknaden er overført fra planleggeren tok "Tilbakestill plan" livet av den overførte planen på same måte som "Fjern alt", og planen kunne ikkje hentast opp igjen. Årsaka var at tilbakestilling-grunnlaget (defaultUttaksperioder) vart rekna ut på nytt til ein tom plan fordi planleggeren ikkje sender med fordeling. Me tar no vare på den opprinnelege overførte planen og brukar han som grunnlag, slik at "Tilbakestill plan" hentar han opp igjen etter "Fjern alt".