### PR TITLE
Legg til Faro for alle appene

### DIFF
--- a/apps/engangsstonad/src/bootstrap.tsx
+++ b/apps/engangsstonad/src/bootstrap.tsx
@@ -1,20 +1,12 @@
 import { bootstrapApp } from '@navikt/fp-app-shell';
-import { initFaro } from '@navikt/fp-observability';
 
 import { AppContainer } from './AppContainer';
 import './index.css';
 import './styles/globals.css';
 
-initFaro({
-    app: {
-        name: 'engangsstonad',
-        namespace: 'teamforeldrepenger',
-        version: import.meta.env.VITE_SENTRY_RELEASE,
-    },
-});
-
 void bootstrapApp({
     sentryDsn: 'https://e2de35941445465aae1e83fcbcc2934d@sentry.gc.nav.no/8',
+    appName: 'engangsstonad',
     availableLocales: ['nb', 'nn', 'en'],
     withPluralRulesPolyfill: false,
     app: <AppContainer />,

--- a/apps/foreldrepengeoversikt/src/bootstrap.tsx
+++ b/apps/foreldrepengeoversikt/src/bootstrap.tsx
@@ -7,6 +7,7 @@ import './index.css';
 
 void bootstrapApp({
     sentryDsn: 'https://b4fd4db97e7d4663852a5203961e3cee@sentry.gc.nav.no/6',
+    appName: 'foreldrepengeoversikt',
     basename: urlPrefiks,
     availableLocales: ['nb', 'nn', 'en'],
     registerCountryLocales: false,

--- a/apps/foreldrepengesoknad/src/bootstrap.tsx
+++ b/apps/foreldrepengesoknad/src/bootstrap.tsx
@@ -6,6 +6,7 @@ import './styles/app.css';
 
 void bootstrapApp({
     sentryDsn: 'https://8e90481464a4442db8c86bc31b9e41ad@sentry.gc.nav.no/11',
+    appName: 'foreldrepengesoknad',
     availableLocales: ['nb', 'nn'],
     app: <AppContainer />,
 });

--- a/apps/planlegger/src/bootstrap.tsx
+++ b/apps/planlegger/src/bootstrap.tsx
@@ -6,6 +6,7 @@ import './styles/global.css';
 
 void bootstrapApp({
     sentryDsn: 'https://b6072f817d64f96c64eb45747c2dfeea@sentry.gc.nav.no/181',
+    appName: 'planlegger',
     availableLocales: ['nb', 'nn', 'en'],
     withPluralRulesPolyfill: false,
     app: <AppContainer />,

--- a/apps/svangerskapspengesoknad/src/bootstrap.tsx
+++ b/apps/svangerskapspengesoknad/src/bootstrap.tsx
@@ -5,6 +5,7 @@ import './index.css';
 
 void bootstrapApp({
     sentryDsn: 'https://b28b752e32e846dd9818f2eb7a9fc013@sentry.gc.nav.no/7',
+    appName: 'svangerskapspengesoknad',
     availableLocales: ['nb', 'nn'],
     app: <AppContainer />,
 });

--- a/apps/veiviser-fp-eller-es/src/bootstrap.tsx
+++ b/apps/veiviser-fp-eller-es/src/bootstrap.tsx
@@ -6,6 +6,7 @@ import './styles/global.css';
 
 void bootstrapApp({
     sentryDsn: 'https://db0c0715bf2e0b91044c530296065174@sentry.gc.nav.no/182',
+    appName: 'veiviser-fp-eller-es',
     availableLocales: ['nb', 'nn', 'en'],
     withPluralRulesPolyfill: false,
     app: <AppContainer />,

--- a/apps/veiviser-hvor-mye/src/bootstrap.tsx
+++ b/apps/veiviser-hvor-mye/src/bootstrap.tsx
@@ -6,6 +6,7 @@ import './styles/global.css';
 
 void bootstrapApp({
     sentryDsn: 'https://4cb9a04935f48499fb83548dedbd4def@sentry.gc.nav.no/183',
+    appName: 'veiviser-hvor-mye',
     availableLocales: ['nb', 'nn', 'en'],
     withPluralRulesPolyfill: false,
     app: <AppContainer />,

--- a/packages/app-shell/src/bootstrapApp.tsx
+++ b/packages/app-shell/src/bootstrapApp.tsx
@@ -4,12 +4,14 @@ import { type ReactElement, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
-import { initSentry } from '@navikt/fp-observability';
+import { initFaro, initSentry } from '@navikt/fp-observability';
 import type { LocaleAll } from '@navikt/fp-types';
 
 export interface BootstrapAppOptions {
     /** Sentry DSN for appen. */
     sentryDsn: string;
+    /** App-navn for Faro frontend-observability. Må matche `metadata.name` i naiserator.yaml. */
+    appName: string;
     /** ID på DOM-noden React skal monteres i. Default `'app'`. */
     containerId?: string;
     /** basename til BrowserRouter. Default `import.meta.env.BASE_URL`. */
@@ -70,6 +72,7 @@ const loadPluralRulesPolyfill = async (locales: readonly LocaleAll[]) => {
 
 export const bootstrapApp = async ({
     sentryDsn,
+    appName,
     containerId = 'app',
     basename,
     availableLocales,
@@ -88,6 +91,12 @@ export const bootstrapApp = async ({
 
     dayjs.locale(defaultDayjsLocale);
     initSentry({ dsn: sentryDsn });
+    initFaro({
+        app: {
+            name: appName,
+            namespace: 'teamforeldrepenger',
+        },
+    });
 
     const container = document.getElementById(containerId);
     if (!container) {

--- a/packages/observability/src/initFaro.test.ts
+++ b/packages/observability/src/initFaro.test.ts
@@ -8,7 +8,7 @@ vi.mock('@grafana/faro-web-sdk', () => ({
     getWebInstrumentations: vi.fn(() => []),
 }));
 
-const APP = { name: 'engangsstonad', namespace: 'teamforeldrepenger', version: '1.2.3' };
+const APP = { name: 'engangsstonad', namespace: 'teamforeldrepenger' };
 
 describe('initFaro', () => {
     afterEach(() => {
@@ -18,6 +18,7 @@ describe('initFaro', () => {
     });
 
     it('bruker prod-collector i prod-miljø (www.nav.no)', () => {
+        vi.stubEnv('VITE_SENTRY_RELEASE', '1.2.3');
         vi.stubGlobal('location', { hostname: 'www.nav.no' });
 
         initFaro({ app: APP });
@@ -27,7 +28,7 @@ describe('initFaro', () => {
         expect(initializeFaro).toHaveBeenCalledWith(
             expect.objectContaining({
                 url: 'https://telemetry.nav.no/collect',
-                app: APP,
+                app: { ...APP, version: '1.2.3' },
                 paused: false,
             }),
         );

--- a/packages/observability/src/initFaro.ts
+++ b/packages/observability/src/initFaro.ts
@@ -6,8 +6,6 @@ type InitFaroOptions = {
         name: string;
         /** Må matche `metadata.namespace` i naiserator.yaml. */
         namespace: string;
-        /** Brukes til å sammenligne metrikker på tvers av deploys. */
-        version?: string;
     };
 };
 
@@ -29,7 +27,11 @@ export const initFaro = ({ app }: InitFaroOptions) => {
     initializeFaro({
         url,
         paused: globalThis.location.hostname === 'localhost',
-        app,
+        app: {
+            ...app,
+            // Brukes til å sammenligne metrikker på tvers av deploys.
+            version: import.meta.env.VITE_SENTRY_RELEASE,
+        },
         instrumentations: [...getWebInstrumentations()],
     });
 };


### PR DESCRIPTION
Legger til Faro for alle appene våres. Da får vi en del data inn i Nais APM her: https://grafana.nav.cloud.nais.io/a/nais-apm-app/services/teamforeldrepenger/engangsstonad?q=engang&environment=dev&tab=frontend

Det gir metrikker vi ikke har i sentry, så jeg tenker disse to kan leve sammen. Hvis CDN upload + sourcemaps gir god nok debuggingsmuligheter i APM kan vi vurdere å droppe Sentry på sikt.

Eneste nedsiden med å legge til Faro er økt bundle size. Har gjort noen analyser.

### Bundle size (engangsstønad, servert pre-komprimert)
Faro havner i hoved-chunken; ingen nye filer/requests.

| Format | Hele appen | Hoved-chunk (`index-*.js`) |
| --- | --- | --- |
| gzip | +30,6 kB (**+3,8 %**) | +30,6 kB (+4,5 %) |
| brotli | +25,7 kB (**+4,1 %**) | +25,7 kB (+4,8 %) |

Til sammenligning veier Faro omtrent som Sentry – ca. 14 % mer (~4 kB gzip). De er uavhengige SDK-er, så de er additive om vi kjører begge.

### Hastighet
Ekstra nedlasting av ~25,7 kB brotli (ingen ny request siden Faro bundles i eksisterende chunk):

| Nett | Ekstra lastetid |
| --- | --- |
| Slow 4G (1,6 Mbps) | ~130 ms |
| Typisk 4G (~10 Mbps) | ~20 ms |

`initFaro` kjøres etter at SDK-en er parset, så det blokkerer ikke first paint. I praksis neglisjerbart.