### PR TITLE
TFP-6210: rett skrivefeil i forslagstekst bare far/medmor har rett

### DIFF
--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -69,7 +69,7 @@
     "uttaksplan.periodeListeContent.periodeUtenUttak": "Skal ikke ha foreldrepenger",
     "uttaksplan.periodeListeContent.tapteDager": "Dager man kan miste",
     "uttaksplan.tapteDager.forklaring.beggeRettFørsteSeksUker": "Mor må ha foreldrepenger de første seks ukene etter fødsel. Hun kan utsette dagene, men bare hvis hun er innlagt eller for syk til å ta vare på barnet, eller hvis barnet er innlagt på sykehus.",
-    "uttaksplan.tapteDager.forklaring.bareFarMedmorRett": "Hvis mora ikke fyller aktivitetskravet, blir dagene trukket fra det du kan få av foreldrepenger med aktivitetskrav. Hvis mora er i en godkjent aktivitet, kan du legge inn en pause. Da kan du spare foreldrepenger med aktivitetskrav til senere.",
+    "uttaksplan.tapteDager.forklaring.bareFarMedmorRett": "Hvis mor ikke fyller aktivitetskravet, blir dagene trukket fra det du kan få av foreldrepenger med aktivitetskrav. Hvis mor er i en godkjent aktivitet, kan du legge inn en pause. Da kan du spare foreldrepenger med aktivitetskrav til senere.",
     "uttaksplan.periodeListeContent.morsAktivitet.Arbeid": "Mor er i arbeid",
     "uttaksplan.periodeListeContent.morsAktivitet.ArbeidOgUtdanning": "Mor er i arbeid og utdanning",
     "uttaksplan.periodeListeContent.morsAktivitet.Innlagt": "Mor er innlagt på helseinstitusjon",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -69,7 +69,7 @@
     "uttaksplan.periodeListeContent.periodeUtenUttak": "Skal ikkje ha foreldrepengar",
     "uttaksplan.periodeListeContent.tapteDager": "Dagar ein kan miste",
     "uttaksplan.tapteDager.forklaring.beggeRettFørsteSeksUker": "Mor må ha foreldrepengar dei første seks vekene etter fødselen. Ho kan utsetje dagane, men berre viss ho er innlagd eller for sjuk til å ta vare på barnet, eller viss barnet er innlagt på sjukehus.",
-    "uttaksplan.tapteDager.forklaring.bareFarMedmorRett": "Viss mora ikkje fyller aktivitetskravet, blir dagane trekte frå det du kan få av foreldrepengar med aktivitetskrav. Viss mor er i ein godkjend aktivitet, kan du leggje inn ein pause. Då kan du spare foreldrepengar med aktivitetskrav til seinare.",
+    "uttaksplan.tapteDager.forklaring.bareFarMedmorRett": "Viss mor ikkje fyller aktivitetskravet, blir dagane trekte frå det du kan få av foreldrepengar med aktivitetskrav. Viss mor er i ein godkjend aktivitet, kan du leggje inn ein pause. Då kan du spare foreldrepengar med aktivitetskrav til seinare.",
     "uttaksplan.periodeListeContent.morsAktivitet.Arbeid": "Mor er i arbeid",
     "uttaksplan.periodeListeContent.morsAktivitet.ArbeidOgUtdanning": "Mor er i arbeid og utdanning",
     "uttaksplan.periodeListeContent.morsAktivitet.Innlagt": "Mor er innlagt på helseinstitusjon",


### PR DESCRIPTION
Endrer bestemt form "mora" til "mor" i bokmål og nynorsk for forklaringsteksten om aktivitetskrav.

https://jira.adeo.no/browse/TFP-6210