### PR TITLE
fix: filtrer bort removeChild-feil fra oversettelsesverktøy i Sentry

### DIFF
--- a/packages/observability/src/initSentry.test.ts
+++ b/packages/observability/src/initSentry.test.ts
@@ -657,6 +657,39 @@ const BROWSER_EXTENSION_SPEECH_ASSIST = {
 // Bryr oss ikke om denne, så tillater oss en "as"
 const SENTRY_HINT = {} as Sentry.EventHint;
 
+const DOM_OVERSETTELSE_FEIL = {
+    event_id: 'a1b2c3d4e5f64708a1b2c3d4e5f64708',
+    release: 'foreldrepengesoknad-2026.06.12.100730-removechild',
+    platform: 'javascript',
+    exception: {
+        values: [
+            {
+                type: 'NotFoundError',
+                value: "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+                stacktrace: {
+                    frames: [
+                        {
+                            filename: 'https://www.nav.no/foreldrepenger/soknad/assets/index-66kDgVTH.js',
+                            function: 'pl',
+                            in_app: true,
+                            lineno: 9231,
+                            colno: 24,
+                        },
+                        {
+                            filename: 'https://www.nav.no/foreldrepenger/soknad/assets/index-66kDgVTH.js',
+                            function: 'fl',
+                            in_app: true,
+                            lineno: 9156,
+                            colno: 5,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+    type: undefined,
+} satisfies Sentry.ErrorEvent;
+
 describe('initSentry', () => {
     afterEach(() => {
         const client = Sentry.getClient();
@@ -689,6 +722,21 @@ describe('initSentry', () => {
         expect(beforeSend).toBeDefined();
 
         const result = beforeSend!(BROWSER_EXTENSION_SPEECH_ASSIST, SENTRY_HINT);
+
+        expect(result).toBeNull();
+    });
+
+    it('should filter out removeChild/insertBefore errors caused by translation tools', () => {
+        vi.stubGlobal('location', { hostname: 'test.nav.no' });
+
+        initSentry({ dsn: 'https://lokal.test/1' });
+
+        const client = Sentry.getClient();
+        const beforeSend = client?.getOptions().beforeSend;
+
+        expect(beforeSend).toBeDefined();
+
+        const result = beforeSend!(DOM_OVERSETTELSE_FEIL, SENTRY_HINT);
 
         expect(result).toBeNull();
     });

--- a/packages/observability/src/initSentry.ts
+++ b/packages/observability/src/initSentry.ts
@@ -86,7 +86,7 @@ const feilFraBrowserExtensions = (event: Sentry.ErrorEvent) => {
 
 /**
  * Nettleseren sine oversettelsesverktøy (f.eks. Google Translate / Chrome "oversett siden") bytter ut tekstnoder
- * og pakker dem i egne element. Når React seinare skal avmontere subtreet, er noden ikkje lenger eit direkte barn
+ * og pakker dem i egne elementer. Når React seinare skal avmontere subtreet, er noden ikkje lenger eit direkte barn
  * av forelderen, og commit-fasen kastar "Failed to execute 'removeChild'/'insertBefore' on 'Node': The node ...
  * is not a child of this node". Dette er ikkje vår feil og kan ikkje fiksast i koden vår, så vi luker det bort.
  */

--- a/packages/observability/src/initSentry.ts
+++ b/packages/observability/src/initSentry.ts
@@ -31,6 +31,10 @@ export const initSentry = ({ dsn }: InitSentryOptions) => {
                 return null;
             }
 
+            if (feilFraDomOversettelse(event)) {
+                return null;
+            }
+
             return event;
         },
     });
@@ -78,6 +82,18 @@ const feilFraBrowserExtensions = (event: Sentry.ErrorEvent) => {
     );
 
     return harDistributorBreadcrumbs || harDistributorStacktrace;
+};
+
+/**
+ * Nettleseren sine oversettelsesverktøy (f.eks. Google Translate / Chrome "oversett siden") bytter ut tekstnoder
+ * og pakker dem i egne element. Når React seinare skal avmontere subtreet, er noden ikkje lenger eit direkte barn
+ * av forelderen, og commit-fasen kastar "Failed to execute 'removeChild'/'insertBefore' on 'Node': The node ...
+ * is not a child of this node". Dette er ikkje vår feil og kan ikkje fiksast i koden vår, så vi luker det bort.
+ */
+const DOM_OVERSETTELSE_FEIL = /(removeChild|insertBefore)[\s\S]*not a child of this node/i;
+
+const feilFraDomOversettelse = (event: Sentry.ErrorEvent) => {
+    return (event.exception?.values ?? []).some((ex) => ex.value && DOM_OVERSETTELSE_FEIL.test(ex.value));
 };
 
 /**


### PR DESCRIPTION
Nettleseren sine oversettelsesverktøy (Google Translate / Chrome) bytter ut tekstnoder React eier. Når React i commit-fasen skal avmontere subtreet, er noden ikkje lenger eit direkte barn av forelderen, og det kastar "Failed to execute 'removeChild' on 'Node'". Dette er ikkje vår feil og kan ikkje fiksast i koden vår, så vi luker det bort i beforeSend.

https://sentry.gc.nav.no/organizations/nav/issues/643628/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0