### PR TITLE
Try improve cls i planlegger

### DIFF
--- a/apps/engangsstonad/index.html
+++ b/apps/engangsstonad/index.html
@@ -12,6 +12,15 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>

--- a/apps/foreldrepengeoversikt/index.html
+++ b/apps/foreldrepengeoversikt/index.html
@@ -13,6 +13,15 @@
             content="Her finner du alt om din sak om foreldrepenger, svangerskapspenger eller engangssøknad. Du kan sende inn ny søknad eller ettersende vedlegg"
         />
         <script type="text/json" id="nav:appSettings">{{{APP_SETTINGS}}}</script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <main id="app"></main>

--- a/apps/foreldrepengesoknad/index.html
+++ b/apps/foreldrepengesoknad/index.html
@@ -12,6 +12,15 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>

--- a/apps/planlegger/index.html
+++ b/apps/planlegger/index.html
@@ -11,6 +11,19 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint. Uten dette er #app tom og lav inntil JS-bundlen (med
+               global.css) og SPA-innholdet lastes ~340 ms senere. Da blir den
+               server-injiserte dekoratør-footeren først tegnet inne i viewporten og
+               deretter dyttet under folden når innholdet fyller #app, noe som gir en
+               stor layout shift (CLS ~0.42). Ved å reservere høyden her havner
+               footeren under folden fra start, slik at forskyvningen skjer utenfor
+               skjermen og ikke teller mot CLS. */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>

--- a/apps/svangerskapspengesoknad/index.html
+++ b/apps/svangerskapspengesoknad/index.html
@@ -6,6 +6,15 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>

--- a/apps/veiviser-fp-eller-es/index.html
+++ b/apps/veiviser-fp-eller-es/index.html
@@ -11,6 +11,15 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>

--- a/apps/veiviser-hvor-mye/index.html
+++ b/apps/veiviser-hvor-mye/index.html
@@ -11,6 +11,15 @@
         <script type="text/json" id="nav:appSettings">
             {{{APP_SETTINGS}}}
         </script>
+        <style>
+            /* Kritisk CSS: reserver full viewport-høyde for app-roten allerede ved
+               første paint, før JS-bundlen (med global CSS) og SPA-innholdet lastes.
+               Hindrer at den server-injiserte dekoratør-footeren først tegnes inne i
+               viewporten og deretter dyttes under folden – en stor layout shift (CLS). */
+            #app {
+                min-height: 100vh;
+            }
+        </style>
     </head>
     <body>
         <div id="app"></div>


### PR DESCRIPTION
Hindrer "layout shift" når appen laster. Denne css'n må hardkodes inn i html'en fordi bundlet css lastes etter at html serveres. Tydeligjøres i Nais APM her (CLS): https://grafana.nav.cloud.nais.io/a/nais-apm-app/services/teamforeldrepenger/planlegger?namespace=teamforeldrepenger&q=planleg&environment=prod&tab=frontend