### PR TITLE
TFP-6971: rett falsk endringsfeil når far sletter innvilget fellesperiode

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
@@ -75,6 +75,14 @@ describe('harBrukerKunSlettetPerioder', () => {
             const perioder = [A, eøs];
             expect(harBrukerKunSlettetPerioder(perioder, opprinneligPlan)).toBe(true);
         });
+
+        it('returnerer true når gjenværende perioder er verdilike, men ikke referanselike (regresjon: TFP-6971)', () => {
+            // I praksis blir opprinneligPlan rekna ut på nytt (nye objekt) via prosesserPerioderForVisning
+            // ved kvar render, så dei gjenverande periodane i den redigerte planen er ikkje referanselike.
+            const opprinneligPlan = [A, B, C];
+            const perioder = [{ ...A }, { ...B }];
+            expect(harBrukerKunSlettetPerioder(perioder, opprinneligPlan)).toBe(true);
+        });
     });
 
     describe('bruker har lagt til eller endret perioder', () => {

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
@@ -77,8 +77,6 @@ describe('harBrukerKunSlettetPerioder', () => {
         });
 
         it('returnerer true når gjenværende perioder er verdilike, men ikke referanselike (regresjon: TFP-6971)', () => {
-            // I praksis blir opprinneligPlan rekna ut på nytt (nye objekt) via prosesserPerioderForVisning
-            // ved kvar render, så dei gjenverande periodane i den redigerte planen er ikkje referanselike.
             const opprinneligPlan = [A, B, C];
             const perioder = [{ ...A }, { ...B }];
             expect(harBrukerKunSlettetPerioder(perioder, opprinneligPlan)).toBe(true);

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -10,6 +10,7 @@ import {
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
 import {
+    erPerioderEkslFomTomLike,
     harPeriodeDerMorsAktivitetIkkeErValgt,
     harPeriodeMedUkjentGraderingsaktivitet,
     useErAntallDagerOvertrukketIUttaksplan,
@@ -119,14 +120,22 @@ export const harBrukerKunSlettetPerioder = (
     );
 
     if (erKunSaksperioder) {
+        // Samanlikn på verdi, ikkje referanse: opprinneligPlan blir rekna ut på nytt (nye objekt)
+        // ved kvar render via prosesserPerioderForVisning, så referanselikheit held ikkje i praksis.
         const harSlettetPeriode = perioder
-            ? perioder.length < opprinneligPlan.length && perioder.every((periode) => opprinneligPlan.includes(periode))
+            ? perioder.length < opprinneligPlan.length &&
+              perioder.every((periode) =>
+                  opprinneligPlan.some((opprinnelig) => erSammePeriodeInkludertDatoer(periode, opprinnelig)),
+              )
             : false;
         return harSlettetPeriode;
     }
 
     return false;
 };
+
+const erSammePeriodeInkludertDatoer = (a: UttaksplanPerioder[number], b: UttaksplanPerioder[number]) =>
+    a.fom === b.fom && a.tom === b.tom && erPerioderEkslFomTomLike(a, b);
 
 export const harKunPerioderForAnnenForelder = (
     erSøkerFarEllerMedmor: boolean,

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -120,8 +120,6 @@ export const harBrukerKunSlettetPerioder = (
     );
 
     if (erKunSaksperioder) {
-        // Samanlikn på verdi, ikkje referanse: opprinneligPlan blir rekna ut på nytt (nye objekt)
-        // ved kvar render via prosesserPerioderForVisning, så referanselikheit held ikkje i praksis.
         const harSlettetPeriode = perioder
             ? perioder.length < opprinneligPlan.length &&
               perioder.every((periode) =>

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -29,6 +29,7 @@ export {
     harPeriodeMedUkjentGraderingsaktivitet,
     getAntallUttaksdagerIVinduRundtFødsel,
     finnAntallTidelerÅTrekke,
+    erPerioderEkslFomTomLike,
 } from './src/utils/periodeUtils';
 export { prosesserPerioderForVisning } from './src/utils/prosesserPerioderForVisning';
 export { deltUttak } from './src/utils/forslag/deltUttak';


### PR DESCRIPTION
## Problem

Far har tidlegare teke ut fedrekvoten og fått innvilga 8 veker fellesperiode, men ombestemmer seg. Når han sletter dei innvilga vekene i planen og sender inn endringssøknaden, får han feilmeldinga **«Du må gjøre en endring for å kunne søke om endring»** og kjem ikkje vidare.

Jira-sak: saknsr. 152285431.

## Årsak

`harBrukerKunSlettetPerioder` samanlikna dei gjenverande periodane mot `opprinneligPlan` med **referanselikheit** (`opprinneligPlan.includes(periode)`). `opprinneligPlan` blir rekna ut på nytt (nye objekt) ved kvar render via `prosesserPerioderForVisning`, så referansane matchar aldri i praksis. «Kun slettet»-deteksjonen feila difor, og den falske feilmeldinga blei vist sjølv om brukaren berre hadde sletta innvilga saksperiodar.

Den førre fiksen (#5654) passerte i test berre fordi testane delte objektreferansar, noko som maskerte feilen i praksis.

## Løysing

- Samanlikn på **verdi** (`fom`, `tom` og `erPerioderEkslFomTomLike`) i staden for referanse.
- Eksporter `erPerioderEkslFomTomLike` frå `@navikt/fp-uttaksplan`.
- Legg til regresjonstest for verdilike, men ikkje referanselike periodar.

## Verifisering

- `submitValidering.test.ts`: 14/14 grøn
- `UttaksplanSteg.test.tsx`: grøn
- `tsc` + `eslint` for `foreldrepengesoknad` og `@navikt/fp-uttaksplan`: 0 feil

https://jira.adeo.no/browse/TFP-6971