### PR TITLE
refactor: håndhev pakke-grenser via public API i stedet for /src/-imp…

### DIFF
--- a/apps/engangsstonad/src/steg/om-barnet/FødselPanel.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/FødselPanel.tsx
@@ -10,10 +10,10 @@ import {
     erI22SvangerskapsukeEllerSenere,
     isAfterOrSameAsSixMonthsAgo,
     isBeforeTodayOrToday,
+    isLessThanThreeWeeksBeforeFødsel,
     isRequired,
     isValidDate,
 } from '@navikt/fp-validation';
-import { isLessThanThreeWeeksBeforeFødsel } from '@navikt/fp-validation/src/form/dateFormValidation';
 
 export type FormValues = {
     antallBarnDropDown?: string;

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
@@ -20,8 +20,8 @@ import { EksternArbeidsforholdDto_fpoversikt, Søkerrolle, SøkersituasjonFp } f
 import {
     isBeforeTodayOrToday,
     isRequired,
-    isValidDate,
-    isValidDateString as isValidDateBoolean,
+    isValidDate as isValidDateValidator,
+    isValidDateString,
     terminbekreftelsedatoIsValid,
 } from '@navikt/fp-validation';
 
@@ -45,8 +45,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
 
     const formMethods = useFormContext<UfødtBarn>();
     const termindato = formMethods.watch('termindato');
-    const erForTidligTilÅSøkePåTermin =
-        termindato && isValidDateBoolean(termindato) ? !erIUke22Pluss3(termindato) : false;
+    const erForTidligTilÅSøkePåTermin = termindato && isValidDateString(termindato) ? !erIUke22Pluss3(termindato) : false;
 
     const søkerErFarMedmor = isFarEllerMedmor(søkersituasjon.rolle);
     const farMedMorSøkerPåTermin = søkerErFarMedmor && termindato;
@@ -75,7 +74,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
                         useStrategyAbsolute
                         validate={[
                             isRequired(intl.formatMessage({ id: 'valideringsfeil.omBarnet.termindato.duMåOppgi' })),
-                            isValidDate(
+                            isValidDateValidator(
                                 intl.formatMessage({ id: 'valideringsfeil.omBarnet.termindato.ugyldigDatoFormat' }),
                             ),
                             (termindatoVerdi) => {
@@ -121,7 +120,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
                         isRequired(
                             intl.formatMessage({ id: 'valideringsfeil.omBarnet.terminbekreftelseDato.duMåOppgi' }),
                         ),
-                        isValidDate(
+                        isValidDateValidator(
                             intl.formatMessage({
                                 id: 'valideringsfeil.omBarnet.terminbekreftelseDato.ugyldigDatoFormat',
                             }),

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/fødsel/TerminPanel.tsx
@@ -17,8 +17,13 @@ import { Alert, BodyShort, Heading, ReadMore, VStack } from '@navikt/ds-react';
 import { ISO_DATE_REGEX } from '@navikt/fp-constants';
 import { RhfDatepicker } from '@navikt/fp-form-hooks';
 import { EksternArbeidsforholdDto_fpoversikt, Søkerrolle, SøkersituasjonFp } from '@navikt/fp-types';
-import { isBeforeTodayOrToday, isRequired, isValidDate, isValidDateString as isValidDateBoolean } from '@navikt/fp-validation';
-import { terminbekreftelsedatoMåVæreUtstedetEtter22Svangerskapsuke } from '@navikt/fp-validation/src/form/dateFormValidation';
+import {
+    isBeforeTodayOrToday,
+    isRequired,
+    isValidDate,
+    isValidDateString as isValidDateBoolean,
+    terminbekreftelsedatoIsValid,
+} from '@navikt/fp-validation';
 
 import { UfødtBarn } from '../OmBarnetFormValues';
 
@@ -126,7 +131,7 @@ export const TerminPanel = ({ søkersituasjon, arbeidsforhold, søknadGjelderEtN
                                 id: 'valideringsfeil.omBarnet.terminbekreftelseDato.kanIkkeVæreFremITid',
                             }),
                         ),
-                        terminbekreftelsedatoMåVæreUtstedetEtter22Svangerskapsuke(
+                        terminbekreftelsedatoIsValid(
                             intl.formatMessage({
                                 id: 'valideringsfeil.omBarnet.terminbekreftelseDato.terminbekreftelsedatoMåVæreUtstedetEtter22Svangerskapsuke',
                             }),

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -18,9 +18,9 @@ import {
     UttakPeriode_fpoversikt,
     isAdoptertBarn,
     isFødtBarn,
+    isIkkeUtfyltTypeBarn,
     isUfødtBarn,
 } from '@navikt/fp-types';
-import { isIkkeUtfyltTypeBarn } from '@navikt/fp-types/src/Barn';
 import { Uttaksdagen, Uttaksperioden } from '@navikt/fp-utils';
 import { isRequired, notEmpty } from '@navikt/fp-validation';
 

--- a/apps/foreldrepengesoknad/src/utils/barnUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/barnUtils.ts
@@ -3,8 +3,7 @@ import utc from 'dayjs/plugin/utc';
 import { IntlShape } from 'react-intl';
 
 import { DDMMMMYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import { Barn, FpBarnDto_fpoversikt, isFødtBarn, isUfødtBarn } from '@navikt/fp-types';
-import { isIkkeUtfyltTypeBarn } from '@navikt/fp-types/src/Barn';
+import { Barn, FpBarnDto_fpoversikt, isFødtBarn, isIkkeUtfyltTypeBarn, isUfødtBarn } from '@navikt/fp-types';
 
 dayjs.extend(utc);
 

--- a/apps/planlegger/src/app-data/useStepData.ts
+++ b/apps/planlegger/src/app-data/useStepData.ts
@@ -8,7 +8,7 @@ import { HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { erFlereSøkere } from 'utils/HvemPlanleggerUtils';
 import { erBarnetAdoptert, erBarnetFødt } from 'utils/barnetUtils';
 
-import { DATE_3_YEARS_AGO } from '@navikt/fp-constants/src/dates';
+import { DATE_3_YEARS_AGO } from '@navikt/fp-constants';
 import { OmBarnetPlanlegger } from '@navikt/fp-types';
 import { ProgressStep } from '@navikt/fp-ui';
 

--- a/apps/planlegger/src/components/PeriodeRad.tsx
+++ b/apps/planlegger/src/components/PeriodeRad.tsx
@@ -2,8 +2,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Hide, Show } from '@navikt/ds-react';
 
-import { capitalizeFirstLetter } from '@navikt/fp-utils';
-import { periodFormat } from '@navikt/fp-utils/src/periodUtils';
+import { capitalizeFirstLetter, periodFormat } from '@navikt/fp-utils';
 
 interface PeriodeRadProps {
     hvem: string;

--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.tsx
@@ -15,8 +15,7 @@ import { Heading, Radio, Spacer, VStack } from '@navikt/ds-react';
 
 import { RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { Satser } from '@navikt/fp-types';
-import { formatCurrencyWithKr } from '@navikt/fp-utils';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { formatCurrencyWithKr, useScrollBehaviour } from '@navikt/fp-utils';
 import { isRequired, notEmpty } from '@navikt/fp-validation';
 
 import { AnnetInfoboks } from './info/AnnetInfoboks';

--- a/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.tsx
+++ b/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.tsx
@@ -14,8 +14,7 @@ import { BodyLong, Heading, Link, VStack } from '@navikt/ds-react';
 import { links } from '@navikt/fp-constants';
 import { OmBarnetPlanlegger } from '@navikt/fp-types';
 import { IconCircleWrapper, Infobox, StepButtons } from '@navikt/fp-ui';
-import { beregnBarnehagestartDato } from '@navikt/fp-utils';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { beregnBarnehagestartDato, useScrollBehaviour } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 export const barnehagestartDato = (barnet: OmBarnetPlanlegger): string | undefined => {

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.tsx
@@ -15,7 +15,7 @@ import { BodyShort, Box, Heading, InlineMessage, Spacer, VStack } from '@navikt/
 import { RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { FordelingPlanlegger, KontoBeregningDto } from '@navikt/fp-types';
 import { BluePanel, Infobox } from '@navikt/fp-ui';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { useScrollBehaviour } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { FordelingSlider } from '../../components/FordelingSlider';

--- a/apps/planlegger/src/steps/hvem-planlegger/HvemPlanleggerSteg.tsx
+++ b/apps/planlegger/src/steps/hvem-planlegger/HvemPlanleggerSteg.tsx
@@ -13,7 +13,7 @@ import { BodyLong, BodyShort, Link, Radio, Spacer, VStack } from '@navikt/ds-rea
 import { links } from '@navikt/fp-constants';
 import { RhfForm, RhfTextField, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { BluePanel, Infobox } from '@navikt/fp-ui';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { useScrollBehaviour } from '@navikt/fp-utils';
 import { isRequired } from '@navikt/fp-validation';
 
 import { usePlanleggerNavigator } from '../../app-data/usePlanleggerNavigator';

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.tsx
@@ -20,7 +20,7 @@ import { links } from '@navikt/fp-constants';
 import { RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { HvorLangPeriodePlanlegger, KontoBeregningDto } from '@navikt/fp-types';
 import { DekningsgradUtbetalingEksempel, Infobox } from '@navikt/fp-ui';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { useScrollBehaviour } from '@navikt/fp-utils';
 import { isRequired, notEmpty } from '@navikt/fp-validation';
 
 import { NårBareEnPartHarRettInfoboks } from './infoboks/NårBareEnPartHarRettInfoboks';

--- a/apps/planlegger/src/steps/om-barnet/OmBarnetSteg.tsx
+++ b/apps/planlegger/src/steps/om-barnet/OmBarnetSteg.tsx
@@ -13,12 +13,11 @@ import { erBarnetAdoptert, erBarnetFødt } from 'utils/barnetUtils';
 
 import { BodyShort, Heading, Link, Radio, Spacer, VStack } from '@navikt/ds-react';
 
-import { links } from '@navikt/fp-constants';
-import { DATE_3_YEARS_AGO } from '@navikt/fp-constants/src/dates';
+import { DATE_3_YEARS_AGO, links } from '@navikt/fp-constants';
 import { RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { OmBarnetPlanlegger } from '@navikt/fp-types';
 import { Infobox } from '@navikt/fp-ui';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { useScrollBehaviour } from '@navikt/fp-utils';
 import { isRequired, notEmpty } from '@navikt/fp-validation';
 
 import { BlueRadioGroup } from '../../components/form-wrappers/BlueRadioGroup';

--- a/apps/planlegger/src/steps/om-barnet/fødsel/ErFødtPanel.tsx
+++ b/apps/planlegger/src/steps/om-barnet/fødsel/ErFødtPanel.tsx
@@ -8,7 +8,7 @@ import { formatError } from 'utils/customErrorFormatter';
 
 import { BodyShort, VStack } from '@navikt/ds-react';
 
-import { DATE_3_YEARS_AGO, ISO_DATE_REGEX } from '@navikt/fp-constants/src/dates';
+import { DATE_3_YEARS_AGO, ISO_DATE_REGEX } from '@navikt/fp-constants';
 import { RhfDatepicker } from '@navikt/fp-form-hooks';
 import { OmBarnetPlanlegger } from '@navikt/fp-types';
 import { BluePanel, Infobox } from '@navikt/fp-ui';

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.tsx
@@ -9,12 +9,11 @@ import { utledHvemSomHarRett } from 'utils/hvemHarRettUtils';
 
 import { BodyShort, Box, Button, HStack, Heading, Link, LinkCard, VStack } from '@navikt/ds-react';
 
-import { links } from '@navikt/fp-constants';
-import { DATE_3_YEARS_AGO } from '@navikt/fp-constants/src/dates';
+import { DATE_3_YEARS_AGO, links } from '@navikt/fp-constants';
 import { SkyraSurvey } from '@navikt/fp-observability';
 import { KontoBeregningResultatDto, Satser } from '@navikt/fp-types';
 import { Infobox } from '@navikt/fp-ui';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { useScrollBehaviour } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { ShareDataInfobox } from '../../components/boxes/ShareDataInfobox';

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
@@ -36,8 +36,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { BluePanel, Infobox, StepButtons } from '@navikt/fp-ui';
-import { Uttaksperioden, compressToUrl, useMedia } from '@navikt/fp-utils';
-import { useScrollBehaviour } from '@navikt/fp-utils/src/hooks/useScrollBehaviour';
+import { Uttaksperioden, compressToUrl, useMedia, useScrollBehaviour } from '@navikt/fp-utils';
 import {
     FjernAltIUttaksplanModal,
     KvoteOppsummering,

--- a/apps/svangerskapspengesoknad/src/steps/arbeid-i-utlandet/ArbeidIUtlandetFieldArray.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/arbeid-i-utlandet/ArbeidIUtlandetFieldArray.tsx
@@ -11,8 +11,7 @@ import { DATE_5_MONTHS_AGO, DATE_20_YEARS_AGO } from '@navikt/fp-constants';
 import { RhfDatepicker, RhfRadioGroup, RhfSelect, RhfTextField } from '@navikt/fp-form-hooks';
 import { CountryCode } from '@navikt/fp-types';
 import { HorizontalLine } from '@navikt/fp-ui';
-import { createCountryOptions } from '@navikt/fp-utils';
-import { femMånederSiden } from '@navikt/fp-utils/src/dateUtils';
+import { createCountryOptions, femMånederSiden } from '@navikt/fp-utils';
 import {
     hasLegalChars,
     hasMaxLength,

--- a/apps/svangerskapspengesoknad/src/utils/dateUtils.ts
+++ b/apps/svangerskapspengesoknad/src/utils/dateUtils.ts
@@ -3,7 +3,7 @@ import isBetween from 'dayjs/plugin/isBetween';
 import { Barn } from 'types/Barn';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import { dagenFør, treUkerSiden } from '@navikt/fp-utils/src/dateUtils';
+import { dagenFør, treUkerSiden } from '@navikt/fp-utils';
 
 dayjs.extend(isBetween);
 

--- a/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.tsx
@@ -6,7 +6,7 @@ import { VStack } from '@navikt/ds-react';
 import { Satser } from '@navikt/fp-types';
 import { VeiviserPage } from '@navikt/fp-ui';
 import { useScrollBehaviour } from '@navikt/fp-utils';
-import { formatValue } from '@navikt/fp-validation/src/form/numberFormValidation';
+import { formatValue } from '@navikt/fp-validation';
 
 import { FpEllerEsSituasjon } from '../situasjon/SituasjonSide';
 import { HarIkkeRett } from './HarIkkeRett';

--- a/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.tsx
@@ -13,8 +13,7 @@ import { RhfForm, RhfNumericField } from '@navikt/fp-form-hooks';
 import { Satser } from '@navikt/fp-types';
 import { BluePanel, Infobox, VeiviserPage } from '@navikt/fp-ui';
 import { formatCurrencyWithKr, useScrollBehaviour } from '@navikt/fp-utils';
-import { isValidDecimal, isValidNumberForm } from '@navikt/fp-validation';
-import { formatValue } from '@navikt/fp-validation/src/form/numberFormValidation';
+import { formatValue, isValidDecimal, isValidNumberForm } from '@navikt/fp-validation';
 
 import { BlueRadioGroup } from '../BlueRadioGroup';
 

--- a/packages/config-eslint/eslint.config.mjs
+++ b/packages/config-eslint/eslint.config.mjs
@@ -43,8 +43,8 @@ export default [
     {
         rules: {
             ...vitest.configs.recommended.rules,
-            'eqeqeq': [ERROR, 'always'],
-            'curly': [ERROR, 'all'],
+            eqeqeq: [ERROR, 'always'],
+            curly: [ERROR, 'all'],
             'max-len': [ERROR, 160],
             'no-console': ERROR,
             'no-debugger': ERROR,
@@ -85,6 +85,18 @@ export default [
             'no-unused-vars': OFF,
             '@typescript-eslint/no-unused-vars': [ERROR, { ignoreRestSiblings: true }],
             'no-duplicate-imports': ERROR,
+            'no-restricted-imports': [
+                ERROR,
+                {
+                    patterns: [
+                        {
+                            group: ['@navikt/fp-*/src/*', '@navikt/fp-*/src'],
+                            message:
+                                'Importer fra pakkens public API (f.eks. @navikt/fp-utils), ikke interne /src/-stier. Mangler eksporten? Legg den til i pakkens index.ts.',
+                        },
+                    ],
+                },
+            ],
             '@typescript-eslint/array-type': [ERROR, { default: 'array-simple' }],
             '@typescript-eslint/ban-ts-comment': ERROR,
             'import-x/no-default-export': ERROR,

--- a/packages/config-eslint/eslint.config.mjs
+++ b/packages/config-eslint/eslint.config.mjs
@@ -90,10 +90,10 @@ export default [
                 {
                     patterns: [
                         {
-                            group: ['@navikt/fp-*/src/*', '@navikt/fp-*/src'],
+                            group: ['@navikt/fp-*/src', '@navikt/fp-*/src/**'],
                             message:
                                 'Importer fra pakkens public API (f.eks. @navikt/fp-utils), ikke interne /src/-stier. Mangler eksporten? Legg den til i pakkens index.ts.',
-                        },
+                        }
                     ],
                 },
             ],

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -11,8 +11,10 @@ export { OpprinneligSøkt } from './src/opprinneligSøkt';
 export { DEFAULT_SATSER } from './src/grunnbeløp';
 export {
     DATE_4_YEARS_AGO,
+    DATE_3_YEARS_AGO,
     ISO_DATE_REGEX,
     ISO_DATE_FORMAT,
+    DDMMMYY_DATE_FORMAT,
     DDMMYY_DATE_FORMAT,
     DDMMM_DATE_FORMAT,
     DDMMYYYY_DATE_FORMAT,

--- a/packages/utils/src/barnUtils.ts
+++ b/packages/utils/src/barnUtils.ts
@@ -1,7 +1,13 @@
 import dayjs from 'dayjs';
 
-import { Barn, Familiesituasjon, isFødtBarn } from '@navikt/fp-types';
-import { isAdoptertBarn, isIkkeUtfyltTypeBarn, isUfødtBarn } from '@navikt/fp-types/src/Barn';
+import {
+    Barn,
+    Familiesituasjon,
+    isAdoptertBarn,
+    isFødtBarn,
+    isIkkeUtfyltTypeBarn,
+    isUfødtBarn,
+} from '@navikt/fp-types';
 
 export const getFamiliehendelsedato = (barn: Barn): string => {
     if (isFødtBarn(barn) || isIkkeUtfyltTypeBarn(barn)) {

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
@@ -13,11 +13,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { Alert, BodyShort, Button, HStack, Heading, Spacer, Tooltip, VStack } from '@navikt/ds-react';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
-import {
-    BrukerRolleSak_fpoversikt,
-    UttakPeriode_fpoversikt,
-    UttakUtsettelseÅrsak_fpoversikt,
-} from '@navikt/fp-types/src/genererteTyper';
+import { BrukerRolleSak_fpoversikt, UttakPeriode_fpoversikt, UttakUtsettelseÅrsak_fpoversikt } from '@navikt/fp-types';
 import { CalendarPeriod } from '@navikt/fp-ui';
 import { Uttaksdagen } from '@navikt/fp-utils';
 
@@ -26,7 +22,6 @@ import { UttakPeriodeMedAntallDager } from '../../../../../kalender/redigering/u
 import { useEksisterendeValgtePeriodeAlerts } from '../../../../../regler/alert/informasjonsAlertHooks';
 import { erEøsUttakPeriode, erVanligUttakPeriode } from '../../../../../types/UttaksplanPeriode';
 import { getVarighetString } from '../../../../../utils/dateUtils';
-
 import { useKalenderRedigeringContext } from '../../../context/KalenderRedigeringContext';
 
 interface Props {
@@ -48,10 +43,7 @@ export const EksisterendeValgtePerioder = ({ perioder }: Props) => {
     return (
         <VStack gap="space-12">
             <BodyShort>
-                <FormattedMessage
-                    id="RedigeringPanel.EksisterendePerioder"
-                    values={{ antall: perioder.length }}
-                />
+                <FormattedMessage id="RedigeringPanel.EksisterendePerioder" values={{ antall: perioder.length }} />
             </BodyShort>
             {perioder.map((p, index) => {
                 const erSamtidigUttaksperiodeSomAlleredeErHåndtert =
@@ -67,11 +59,12 @@ export const EksisterendeValgtePerioder = ({ perioder }: Props) => {
 
                 const erAvslåttPeriode = erVanligUttakPeriode(p) && p.resultat?.innvilget === false;
 
-                const erPleiepengerPeriode =
-                    erAvslåttPeriode && p.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER';
+                const erPleiepengerPeriode = erAvslåttPeriode && p.resultat?.årsak === 'AVSLAG_FRATREKK_PLEIEPENGER';
 
-                const { morsAktivitetIkkeValgt: morsAktivitetIkkeValgtAlert, graderingsaktivitetIkkeValgt: graderingsaktivitetIkkeValgtAlert } =
-                    alertsForPeriode(p);
+                const {
+                    morsAktivitetIkkeValgt: morsAktivitetIkkeValgtAlert,
+                    graderingsaktivitetIkkeValgt: graderingsaktivitetIkkeValgtAlert,
+                } = alertsForPeriode(p);
 
                 return (
                     <HStack

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
@@ -4,13 +4,16 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, HGrid, HStack, Heading, Hide, Show } from '@navikt/ds-react';
 
-import { DDMMMYY_DATE_FORMAT } from '@navikt/fp-constants/src/dates';
+import { DDMMMYY_DATE_FORMAT } from '@navikt/fp-constants';
 import { Uttaksdagen } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from '../../../context/UttaksplanDataContext';
 import { Uttaksplanperiode } from '../../../types/UttaksplanPeriode';
 import { getVarighetString } from '../../../utils/dateUtils';
-import { harPeriodeDerMorsAktivitetIkkeErValgt, harPeriodeMedUkjentGraderingsaktivitet } from '../../../utils/periodeUtils';
+import {
+    harPeriodeDerMorsAktivitetIkkeErValgt,
+    harPeriodeMedUkjentGraderingsaktivitet,
+} from '../../../utils/periodeUtils';
 import {
     erUttaksplanperiodeFamiliehendelseDato,
     getFørsteUttaksplanperiodeFom,

--- a/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
+++ b/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
@@ -3,7 +3,7 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import minMax from 'dayjs/plugin/minMax';
 
-import { ISO_DATE_FORMAT } from '@navikt/fp-constants/src/dates';
+import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { Tidsperioden, Uttaksdagen } from '@navikt/fp-utils';
 
 dayjs.extend(minMax);

--- a/packages/validation/index.ts
+++ b/packages/validation/index.ts
@@ -29,6 +29,7 @@ export {
     isValidInteger,
     hasMaxValue,
     hasMinValue,
+    formatValue,
 } from './src/form/numberFormValidation';
 export { isValidNumber } from './src/other/numberValidation';
 export {
@@ -46,6 +47,7 @@ export {
     isAfterDate,
     isPeriodNotOverlappingOthers,
     isLessThanOneAndHalfYearsAgo,
+    isLessThanThreeWeeksBeforeFødsel,
     isBeforeToday,
     terminbekreftelsedatoMåVæreUtstedetEtter22Svangerskapsuke as terminbekreftelsedatoIsValid,
     isWeekday,


### PR DESCRIPTION
…orter

Apper og pakker importerte interne /src/-stier i andre workspace-pakker (25 forekomster), noko som koplar konsumentane til intern filstruktur og gjer refaktorering inne i ein pakke risikabel.

- Legg til eslint no-restricted-imports som blokkerer @navikt/fp-*/src/*
- Fyll manglande barrel-eksportar:
  - fp-constants: DATE_3_YEARS_AGO, DDMMMYY_DATE_FORMAT
  - fp-validation: formatValue, isLessThanThreeWeeksBeforeFødsel
- Bytt alle 25 deep-importar til pakkenes public API