### PR TITLE
chore: erstatt @formatjs/cli-lib med egen TS-AST-ekstraktor i intl-test

### DIFF
--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -16,14 +16,14 @@
         "tsc:watch": "tsc --noEmit --watch"
     },
     "dependencies": {
-        "@formatjs/cli-lib": "8.6.0",
         "@navikt/ds-react": "8.12.1",
         "@navikt/fp-types": "workspace:*",
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-query-devtools": "5.101.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-intl": "10.1.13"
+        "react-intl": "10.1.13",
+        "typescript": "6.0.3"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",
@@ -37,7 +37,6 @@
         "jsdom": "29.1.1",
         "mockdate": "3.0.5",
         "storybook": "10.4.4",
-        "typescript": "6.0.3",
         "vite": "8.0.16",
         "vitest": "4.1.8"
     },

--- a/packages/utils-test/src/intl/extractMessageIds.ts
+++ b/packages/utils-test/src/intl/extractMessageIds.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 /**
  * Henter ut statiske i18n-nøkler (`id`) som koden refererer til, via TypeScript sin AST.
@@ -21,7 +21,7 @@ export const extractMessageIds = (files: string[]): string[] => {
         const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, scriptKind);
         visit(sourceFile, ids);
     }
-    return ids;
+    return [...new Set(ids)];
 };
 
 const visit = (node: ts.Node, ids: string[]): void => {

--- a/packages/utils-test/src/intl/extractMessageIds.ts
+++ b/packages/utils-test/src/intl/extractMessageIds.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+/**
+ * Henter ut statiske i18n-nøkler (`id`) som koden refererer til, via TypeScript sin AST.
+ *
+ * Erstatter `extract` fra `@formatjs/cli-lib`. Vi bruker aldri auto-genererte ID-er
+ * (alle meldinger har eksplisitte streng-ID-er), så vi trenger kun å plukke ut `id` fra:
+ * - `formatMessage({ id: '...' })` (typisk `intl.formatMessage(...)`)
+ * - `<FormattedMessage id="..." />`
+ * - `defineMessages({ ... })`
+ *
+ * Dynamiske ID-er (template-literaler med innsetting, f.eks. `` `ettersendelse.${x}` ``)
+ * ignoreres – akkurat som FormatJS gjorde.
+ */
+export const extractMessageIds = (files: string[]): string[] => {
+    const ids: string[] = [];
+    for (const file of files) {
+        const content = readFileSync(file).toString();
+        const scriptKind = file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+        const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, scriptKind);
+        visit(sourceFile, ids);
+    }
+    return ids;
+};
+
+const visit = (node: ts.Node, ids: string[]): void => {
+    if (ts.isCallExpression(node)) {
+        const fnName = getCalleeName(node.expression);
+        const firstArgument = node.arguments[0];
+        if (firstArgument !== undefined) {
+            if (fnName === 'formatMessage') {
+                collectIdFromObject(firstArgument, ids);
+            } else if (fnName === 'defineMessages') {
+                collectIdsFromMessagesObject(firstArgument, ids);
+            }
+        }
+    } else if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+        if (getJsxTagName(node.tagName) === 'FormattedMessage') {
+            collectIdFromJsxAttributes(node.attributes, ids);
+        }
+    }
+    ts.forEachChild(node, (child) => visit(child, ids));
+};
+
+/** Returnerer funksjonsnavnet for `foo()` og `obj.foo()`. */
+const getCalleeName = (expression: ts.Expression): string | undefined => {
+    if (ts.isIdentifier(expression)) {
+        return expression.text;
+    }
+    if (ts.isPropertyAccessExpression(expression)) {
+        return expression.name.text;
+    }
+    return undefined;
+};
+
+/** Returnerer JSX-tagnavnet, f.eks. `FormattedMessage` for `<Intl.FormattedMessage>`. */
+const getJsxTagName = (tagName: ts.JsxTagNameExpression): string | undefined => {
+    if (ts.isIdentifier(tagName)) {
+        return tagName.text;
+    }
+    if (ts.isPropertyAccessExpression(tagName)) {
+        return tagName.name.text;
+    }
+    return undefined;
+};
+
+/** Plukker ut `id` fra et meldingsdeskriptor-objekt: `{ id: '...' }`. */
+const collectIdFromObject = (node: ts.Node, ids: string[]): void => {
+    if (!ts.isObjectLiteralExpression(node)) {
+        return;
+    }
+    for (const property of node.properties) {
+        if (
+            ts.isPropertyAssignment(property) &&
+            getPropertyName(property.name) === 'id'
+        ) {
+            const id = getStaticString(property.initializer);
+            if (id !== undefined) {
+                ids.push(id);
+            }
+        }
+    }
+};
+
+/** Plukker ut `id` fra hvert deskriptor-objekt i `defineMessages({ a: {...}, b: {...} })`. */
+const collectIdsFromMessagesObject = (node: ts.Node, ids: string[]): void => {
+    if (!ts.isObjectLiteralExpression(node)) {
+        return;
+    }
+    for (const property of node.properties) {
+        if (ts.isPropertyAssignment(property)) {
+            collectIdFromObject(property.initializer, ids);
+        }
+    }
+};
+
+/** Plukker ut `id="..."` eller `id={'...'}` fra JSX-attributter. */
+const collectIdFromJsxAttributes = (attributes: ts.JsxAttributes, ids: string[]): void => {
+    for (const attribute of attributes.properties) {
+        if (
+            ts.isJsxAttribute(attribute) &&
+            attribute.name.getText() === 'id' &&
+            attribute.initializer !== undefined
+        ) {
+            const id = getJsxAttributeString(attribute.initializer);
+            if (id !== undefined) {
+                ids.push(id);
+            }
+        }
+    }
+};
+
+const getPropertyName = (name: ts.PropertyName): string | undefined => {
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+        return name.text;
+    }
+    return undefined;
+};
+
+const getJsxAttributeString = (
+    initializer: ts.JsxAttributeValue,
+): string | undefined => {
+    if (ts.isStringLiteral(initializer)) {
+        return initializer.text;
+    }
+    if (ts.isJsxExpression(initializer) && initializer.expression !== undefined) {
+        return getStaticString(initializer.expression);
+    }
+    return undefined;
+};
+
+/** Returnerer verdien for statiske strenger, men ignorerer dynamiske template-literaler. */
+const getStaticString = (node: ts.Expression): string | undefined => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+        return node.text;
+    }
+    return undefined;
+};

--- a/packages/utils-test/src/intl/intlMessagesTest.ts
+++ b/packages/utils-test/src/intl/intlMessagesTest.ts
@@ -1,6 +1,7 @@
-import { extract } from '@formatjs/cli-lib';
 import { globSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+
+import { extractMessageIds } from './extractMessageIds';
 
 type Messages = Record<string, string>;
 
@@ -60,18 +61,16 @@ const loggManglendeNøkler = (fra: Locale, til: Locale): string[] => {
     return mangler;
 };
 
-const hentKodeNøkler = async (
+const hentKodeNøkler = (
     sourceGlob: string,
     extractAdditionalCodeKeys?: (fileContent: string) => string[],
-): Promise<string[]> => {
+): string[] => {
     const files = globSync(sourceGlob);
-    const foundTranslations = await extract(files, {
-        idInterpolationPattern: '[sha512:contenthash:base64:6]',
-    });
+    const nøkler = extractMessageIds(files);
     const ekstraNøkler = extractAdditionalCodeKeys
         ? files.flatMap((fileLoc) => extractAdditionalCodeKeys(readFileSync(fileLoc).toString()))
         : [];
-    return [...Object.keys(JSON.parse(foundTranslations) as Messages), ...ekstraNøkler];
+    return [...nøkler, ...ekstraNøkler];
 };
 
 /**
@@ -109,8 +108,8 @@ export const createIntlMessagesTest = ({
             });
         }
 
-        it(`i18n-strenger i koden skal finnes i ${referanseNavn}`, async () => {
-            const kodeNøkler = await hentKodeNøkler(sourceGlob, extractAdditionalCodeKeys);
+        it(`i18n-strenger i koden skal finnes i ${referanseNavn}`, () => {
+            const kodeNøkler = hentKodeNøkler(sourceGlob, extractAdditionalCodeKeys);
             const referanseNøkler = new Set(Object.keys(referanse));
             const mangler = kodeNøkler.filter((key) => !referanseNøkler.has(key));
             for (const key of mangler) {
@@ -120,8 +119,8 @@ export const createIntlMessagesTest = ({
             expect(mangler.length).toBe(0);
         });
 
-        it(`alle i18n-strenger i ${referanseNavn} skal finnes i koden`, async () => {
-            const kodeNøkler = new Set(await hentKodeNøkler(sourceGlob, extractAdditionalCodeKeys));
+        it(`alle i18n-strenger i ${referanseNavn} skal finnes i koden`, () => {
+            const kodeNøkler = new Set(hentKodeNøkler(sourceGlob, extractAdditionalCodeKeys));
             const mangler = Object.keys(referanse).filter(
                 (key) => !(ignoreReferenceKey?.(key) ?? false) && !kodeNøkler.has(key),
             );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,9 +2350,6 @@ importers:
 
   packages/utils-test:
     dependencies:
-      '@formatjs/cli-lib':
-        specifier: 8.6.0
-        version: 8.6.0
       '@navikt/ds-react':
         specifier: 8.12.1
         version: 8.12.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2374,6 +2371,9 @@ importers:
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
     devDependencies:
       '@navikt/fp-config-eslint':
         specifier: workspace:*
@@ -2408,9 +2408,6 @@ importers:
       storybook:
         specifier: 10.4.4
         version: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -3310,61 +3307,14 @@ packages:
   '@formatjs/bigdecimal@0.2.6':
     resolution: {integrity: sha512-aPzKsGQOkQRHUEbyO/ZtYfr4EqaBQnSs6U4tzTla1xBnIdEHgY2GqEqso28UMwWRkzKqqTj5+/6BmuOsRkfn2A==}
 
-  '@formatjs/cli-lib@8.6.0':
-    resolution: {integrity: sha512-yFBeAGG95b6QnvUhfwcOvcDm4MB0/mgU/mWHwfu4vt11kwqtjnjTfC3Z032Y0g6oB6wKGP/zMeBjxkikVnEILw==}
-    engines: {node: '>= 20.12.0'}
-    peerDependencies:
-      '@glimmer/env': '*'
-      '@glimmer/reference': '*'
-      '@glimmer/syntax': ^0.84.3 || ^0.95.0
-      '@glimmer/validator': '*'
-      '@vue/compiler-core': ^3.5.0
-      content-tag: ^4.1.0
-      svelte: ^5.0.0
-      vue: ^3.5.0
-    peerDependenciesMeta:
-      '@glimmer/env':
-        optional: true
-      '@glimmer/reference':
-        optional: true
-      '@glimmer/syntax':
-        optional: true
-      '@glimmer/validator':
-        optional: true
-      '@vue/compiler-core':
-        optional: true
-      content-tag:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-
-  '@formatjs/cli-native-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-ygEpFpmRjbAKanWaeto/eUItyuK18667mdDzpDg3CTzc15WYzjZKnwJNFUuPFvFA4hiod1tnhXT1eiXmc1wWNg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@formatjs/cli-native-linux-x64@1.1.0':
-    resolution: {integrity: sha512-AxORf5LR14HvXU4ov9gnhLrNIS2DYKqKMkRkprUhuh+ljba1riF05msK8KzslEPYQoeYKc5A0OZp57poh4xz/g==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@formatjs/fast-memoize@3.1.6':
     resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
 
   '@formatjs/icu-messageformat-parser@3.5.11':
     resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
 
-  '@formatjs/icu-messageformat-parser@3.5.8':
-    resolution: {integrity: sha512-uZLvzLFN7iV2l8cbDdROwgKGtdELeLI4bpnsuz1DnyscHDxn8TdDE0anHzcfjtWK66XYCllGLV3Mi3CYcEPg/g==}
-
   '@formatjs/icu-skeleton-parser@2.1.10':
     resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
-
-  '@formatjs/icu-skeleton-parser@2.1.8':
-    resolution: {integrity: sha512-iX5i0O15gPf69l1WqmLFYwn7wq53lauvytvWFnHamIfX/5Ta56gpFj6fdeHRcKTV58IhrKv8QOvWfTYZYm7f+g==}
 
   '@formatjs/intl-localematcher@0.8.10':
     resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
@@ -3374,15 +3324,6 @@ packages:
 
   '@formatjs/intl@4.1.13':
     resolution: {integrity: sha512-dufOl09iREq8V+laVdlGuyoqNmuzqDvyeA3O3k+0XQfvKJgK8bBWFKqYYWejFMKeOij/4LuPKJA+LsshpXQ4sw==}
-
-  '@formatjs/ts-transformer@4.4.8':
-    resolution: {integrity: sha512-L1QP73tO2hzjGQtDrSw4tI263b7j/vxbpstANP89XwYZTaBURe93MO9hp+8FnTORIYopBZHaa4nveC/XDBzKlg==}
-    engines: {node: '>= 20.12.0'}
-    peerDependencies:
-      ts-jest: ^29
-    peerDependenciesMeta:
-      ts-jest:
-        optional: true
 
   '@grafana/faro-core@2.7.1':
     resolution: {integrity: sha512-qJOp0sPBAEsmUxhs11nVdGx5Dk+VJ4CN/4s9ek99m33FfzybmjQ9nPXLHWhwEeNJNiEwQdDl4HsNUlXBGT5YEw==}
@@ -3580,18 +3521,6 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -4707,9 +4636,6 @@ packages:
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -4719,9 +4645,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
-
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
@@ -4730,9 +4653,6 @@ packages:
 
   '@types/morgan@1.9.10':
     resolution: {integrity: sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==}
-
-  '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
@@ -5112,10 +5032,6 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
-  array-find-index@1.0.2:
-    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
-    engines: {node: '>=0.10.0'}
-
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
@@ -5321,10 +5237,6 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
-
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
@@ -5408,10 +5320,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  currently-unhandled@0.4.1:
-    resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
-    engines: {node: '>=0.10.0'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -5816,10 +5724,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -5840,9 +5744,6 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -5913,10 +5814,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
-    engines: {node: '>=14.14'}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5971,10 +5868,6 @@ packages:
   giget@3.3.0:
     resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
     hasBin: true
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -6331,20 +6224,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stable-stringify@1.3.0:
-    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
-    engines: {node: '>= 0.4'}
-
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  jsonfile@6.2.1:
-    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
-
-  jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jspdf@4.2.1:
     resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
@@ -6480,10 +6363,6 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
-  loud-rejection@2.2.0:
-    resolution: {integrity: sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==}
-    engines: {node: '>=8'}
-
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -6518,10 +6397,6 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6860,9 +6735,6 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
 
@@ -6986,10 +6858,6 @@ packages:
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -7009,9 +6877,6 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -7119,9 +6984,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -7468,9 +7330,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -7480,10 +7339,6 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
-
-  universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -8361,45 +8216,13 @@ snapshots:
 
   '@formatjs/bigdecimal@0.2.6': {}
 
-  '@formatjs/cli-lib@8.6.0':
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 3.5.8
-      '@formatjs/icu-skeleton-parser': 2.1.8
-      '@formatjs/ts-transformer': 4.4.8
-      '@types/estree': 1.0.9
-      '@types/fs-extra': 11.0.4
-      '@types/node': 24.13.2
-      commander: 14.0.3
-      fast-glob: 3.3.3
-      fs-extra: 11.3.5
-      json-stable-stringify: 1.3.0
-      loud-rejection: 2.2.0
-      typescript: 6.0.3
-    optionalDependencies:
-      '@formatjs/cli-native-darwin-arm64': 1.1.0
-      '@formatjs/cli-native-linux-x64': 1.1.0
-    transitivePeerDependencies:
-      - ts-jest
-
-  '@formatjs/cli-native-darwin-arm64@1.1.0':
-    optional: true
-
-  '@formatjs/cli-native-linux-x64@1.1.0':
-    optional: true
-
   '@formatjs/fast-memoize@3.1.6': {}
 
   '@formatjs/icu-messageformat-parser@3.5.11':
     dependencies:
       '@formatjs/icu-skeleton-parser': 2.1.10
 
-  '@formatjs/icu-messageformat-parser@3.5.8':
-    dependencies:
-      '@formatjs/icu-skeleton-parser': 2.1.8
-
   '@formatjs/icu-skeleton-parser@2.1.10': {}
-
-  '@formatjs/icu-skeleton-parser@2.1.8': {}
 
   '@formatjs/intl-localematcher@0.8.10':
     dependencies:
@@ -8415,13 +8238,6 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.6
       '@formatjs/icu-messageformat-parser': 3.5.11
       intl-messageformat: 11.2.8
-
-  '@formatjs/ts-transformer@4.4.8':
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 3.5.8
-      '@types/node': 24.13.2
-      json-stable-stringify: 1.3.0
-      typescript: 6.0.3
 
   '@grafana/faro-core@2.7.1':
     dependencies:
@@ -8648,18 +8464,6 @@ snapshots:
       express: 5.2.1
 
   '@noble/hashes@1.8.0': {}
-
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -9507,11 +9311,6 @@ snapshots:
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
 
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 25.9.3
-
   '@types/http-errors@2.0.5': {}
 
   '@types/jsdom@28.0.3':
@@ -9523,10 +9322,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 25.9.3
-
   '@types/lodash@4.17.24': {}
 
   '@types/methods@1.1.4': {}
@@ -9534,10 +9329,6 @@ snapshots:
   '@types/morgan@1.9.10':
     dependencies:
       '@types/node': 25.9.3
-
-  '@types/node@24.13.2':
-    dependencies:
-      undici-types: 7.18.2
 
   '@types/node@25.9.3':
     dependencies:
@@ -9924,8 +9715,6 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
-  array-find-index@1.0.2: {}
-
   array-includes@3.1.9:
     dependencies:
       call-bind: 1.0.9
@@ -10158,8 +9947,6 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@14.0.3: {}
-
   commander@15.0.0: {}
 
   comment-parser@1.4.6: {}
@@ -10220,10 +10007,6 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
-
-  currently-unhandled@0.4.1:
-    dependencies:
-      array-find-index: 1.0.2
 
   damerau-levenshtein@1.0.8: {}
 
@@ -10803,14 +10586,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -10832,10 +10607,6 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fd-package-json@2.0.0:
     dependencies:
@@ -10908,12 +10679,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-extra@11.3.5:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
   fsevents@2.3.2:
     optional: true
 
@@ -10970,10 +10735,6 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   giget@3.3.0: {}
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -11319,23 +11080,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stable-stringify@1.3.0:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-
   json5@2.2.3: {}
-
-  jsonfile@6.2.1:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
-  jsonify@0.0.1: {}
 
   jspdf@4.2.1:
     dependencies:
@@ -11481,11 +11226,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
-  loud-rejection@2.2.0:
-    dependencies:
-      currently-unhandled: 0.4.1
-      signal-exit: 3.0.7
-
   loupe@3.2.1: {}
 
   lru-cache@11.3.6: {}
@@ -11509,8 +11249,6 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
-
-  merge2@1.4.1: {}
 
   methods@1.1.2: {}
 
@@ -11887,8 +11625,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  queue-microtask@1.2.3: {}
-
   raf@3.4.1:
     dependencies:
       performance-now: 2.1.0
@@ -12036,8 +11772,6 @@ snapshots:
 
   rettime@0.11.11: {}
 
-  reusify@1.1.0: {}
-
   rfdc@1.4.1: {}
 
   rgbcolor@1.0.1:
@@ -12075,10 +11809,6 @@ snapshots:
       - supports-color
 
   run-applescript@7.1.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -12209,8 +11939,6 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
-
-  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -12586,15 +12314,11 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.18.2: {}
-
   undici-types@7.24.6: {}
 
   undici-types@7.25.0: {}
 
   undici@7.25.0: {}
-
-  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
@formatjs/cli-lib ble kun brukt til å plukke statiske i18n-nøkler fra koden i intl.test-helperen, men måtte oppgraderes ofte og brakk stadig. Kodebasen bruker alltid eksplisitte streng-ID-er (ingen auto-genererte innholdshash-ID-er), så biblioteket var unødvendig tungt.

Erstatter extract() med en liten TS compiler-API-ekstraktor (extractMessageIds) som henter statiske id-strenger fra formatMessage, FormattedMessage og defineMessages. Dynamiske template-ID-er ignoreres som før. Offentlig API er uendret, så ingen intl.test.ts-filer trengte endring.