### PR TITLE
Upgrade react-hook-form to 7.79.0 with error re-spread fix

### DIFF
--- a/apps/engangsstonad/package.json
+++ b/apps/engangsstonad/package.json
@@ -46,7 +46,7 @@
         "lodash": "4.18.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/apps/foreldrepengesoknad/package.json
+++ b/apps/foreldrepengesoknad/package.json
@@ -52,7 +52,7 @@
         "lodash": "4.18.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/apps/planlegger/package.json
+++ b/apps/planlegger/package.json
@@ -45,7 +45,7 @@
         "morgan": "1.11.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/apps/svangerskapspengesoknad/package.json
+++ b/apps/svangerskapspengesoknad/package.json
@@ -49,7 +49,7 @@
         "lodash": "4.18.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/apps/veiviser-fp-eller-es/package.json
+++ b/apps/veiviser-fp-eller-es/package.json
@@ -40,7 +40,7 @@
         "morgan": "1.11.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/apps/veiviser-hvor-mye/package.json
+++ b/apps/veiviser-hvor-mye/package.json
@@ -42,7 +42,7 @@
         "morgan": "1.11.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13",
         "react-router-dom": "7.17.0"
     },

--- a/packages/form-hooks/package.json
+++ b/packages/form-hooks/package.json
@@ -25,7 +25,7 @@
         "dayjs": "1.11.21",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/packages/form-hooks/src/form-wrappers/RhfDatepicker.tsx
+++ b/packages/form-hooks/src/form-wrappers/RhfDatepicker.tsx
@@ -1,14 +1,14 @@
 import dayjs, { Dayjs } from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import React, { ComponentProps, JSX, ReactNode, useCallback, useMemo, useState } from 'react';
-import { FieldValues, UseControllerProps, useController, useFormContext } from 'react-hook-form';
+import { FieldValues, UseControllerProps, useController } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT, TIDENES_ENDE, TIDENES_MORGEN } from '@navikt/fp-constants';
 
-import { ValidationReturnType, getError, getValidationRules } from './formUtils';
+import { ValidationReturnType, getValidationRules } from './formUtils';
 
 dayjs.extend(customParseFormat);
 
@@ -50,11 +50,8 @@ export const RhfDatepicker = <T extends FieldValues>({
     const { name, control } = controllerProps;
 
     const intl = useIntl();
-    const {
-        formState: { errors },
-    } = useFormContext();
 
-    const { field } = useController({
+    const { field, fieldState } = useController({
         name,
         control,
         rules: {
@@ -64,6 +61,8 @@ export const RhfDatepicker = <T extends FieldValues>({
 
     const defaultDate = field.value ? dayjs(field.value, ISO_DATE_FORMAT, true).format(DDMMYYYY_DATE_FORMAT) : '';
     const [fieldValue, setFieldValue] = useState<string>(() => (isValidDateString(defaultDate) ? defaultDate : ''));
+
+    const errorMessage = useMemo(() => fieldState.error?.message, [fieldState.error?.message]);
 
     const { datepickerProps, inputProps } = useDatepicker({
         onDateChange: (date) => {
@@ -123,7 +122,7 @@ export const RhfDatepicker = <T extends FieldValues>({
                 value={fieldValue}
                 label={label}
                 description={description}
-                error={customErrorFormatter ? customErrorFormatter(getError(errors, name)) : getError(errors, name)}
+                error={customErrorFormatter ? customErrorFormatter(errorMessage) : errorMessage}
                 placeholder={intl.formatMessage({ id: 'Skjema.input.dato.placeholder' })}
                 autoFocus={autofocusWhenEmpty && field.value === undefined}
             />

--- a/packages/steg-arbeidsforhold-og-inntekt/package.json
+++ b/packages/steg-arbeidsforhold-og-inntekt/package.json
@@ -27,7 +27,7 @@
         "@navikt/fp-validation": "workspace:*",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/packages/steg-egen-næring/package.json
+++ b/packages/steg-egen-næring/package.json
@@ -28,7 +28,7 @@
         "dayjs": "1.11.21",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/packages/steg-frilans/package.json
+++ b/packages/steg-frilans/package.json
@@ -26,7 +26,7 @@
         "dayjs": "1.11.21",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/packages/steg-utenlandsopphold/package.json
+++ b/packages/steg-utenlandsopphold/package.json
@@ -28,7 +28,7 @@
         "dayjs": "1.11.21",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -32,7 +32,7 @@
         "jspdf": "4.2.1",
         "lodash": "4.18.1",
         "react": "19.2.7",
-        "react-hook-form": "7.78.0",
+        "react-hook-form": "7.79.0",
         "react-intl": "10.1.13"
     },
     "devDependencies": {

--- a/patches/react-hook-form@7.79.0.patch
+++ b/patches/react-hook-form@7.79.0.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/index.esm.mjs b/dist/index.esm.mjs
+index 30d3a6f0e818bfdf7dc41076b9979918da34dc0c..ad129002bea188a039604e5d215fbdc849b178ab 100644
+--- a/dist/index.esm.mjs
++++ b/dist/index.esm.mjs
+@@ -1627,7 +1627,6 @@ function createFormControl(props = {}) {
+     };
+     const updateErrors = (name, error) => {
+         set(_formState.errors, name, error);
+-        _formState.errors = { ..._formState.errors };
+         _subjects.state.next({
+             errors: _formState.errors,
+         });
+@@ -1758,7 +1757,6 @@ function createFormControl(props = {}) {
+             error
+                 ? set(_formState.errors, name, error)
+                 : unset(_formState.errors, name);
+-            _formState.errors = { ..._formState.errors };
+         }
+         if ((error ? !deepEqual(previousFieldError, error) : previousFieldError) ||
+             !isEmptyObject(fieldState) ||
+@@ -1794,7 +1792,6 @@ function createFormControl(props = {}) {
+                         : set(_formState.errors, name, error)
+                     : unset(_formState.errors, name);
+             }
+-            _formState.errors = { ..._formState.errors };
+         }
+         else {
+             _formState.errors = errors;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   js-cookie: 3.0.7
 
+patchedDependencies:
+  react-hook-form@7.79.0:
+    hash: 9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea
+    path: patches/react-hook-form@7.79.0.patch
+
 importers:
 
   .:
@@ -112,8 +117,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -459,8 +464,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -619,8 +624,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -791,8 +796,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -933,8 +938,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -1075,8 +1080,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -1401,7 +1406,7 @@ importers:
     dependencies:
       '@hookform/error-message':
         specifier: 2.0.1
-        version: 2.0.1(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.78.0(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7))(react@19.2.7)
       '@navikt/ds-css':
         specifier: 8.12.1
         version: 8.12.1
@@ -1427,8 +1432,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -1625,8 +1630,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -1728,8 +1733,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -1825,8 +1830,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -2104,8 +2109,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -2466,8 +2471,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7
       react-hook-form:
-        specifier: 7.78.0
-        version: 7.78.0(react@19.2.7)
+        specifier: 7.79.0
+        version: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
       react-intl:
         specifier: 10.1.13
         version: 10.1.13(@types/react@19.2.17)(react@19.2.7)
@@ -6897,8 +6902,8 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-hook-form@7.78.0:
-    resolution: {integrity: sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==}
+  react-hook-form@7.79.0:
+    resolution: {integrity: sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -8484,11 +8489,11 @@ snapshots:
 
   '@hey-api/types@0.1.4': {}
 
-  '@hookform/error-message@2.0.1(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.78.0(react@19.2.7))(react@19.2.7)':
+  '@hookform/error-message@2.0.1(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7))(react@19.2.7)':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-hook-form: 7.78.0(react@19.2.7)
+      react-hook-form: 7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11940,7 +11945,7 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-hook-form@7.78.0(react@19.2.7):
+  react-hook-form@7.79.0(patch_hash=9ad78c5f59a4b0bdf6e4fe46f633c432ad5f75b2f732dfd4e2aa703b92caa7ea)(react@19.2.7):
     dependencies:
       react: 19.2.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,6 @@ packages:
   - server
   - server-uinnlogget
 
-overrides:
-  js-cookie: 3.0.7
-
 ignoredBuiltDependencies:
   - '@parcel/watcher'
   - esbuild
@@ -19,3 +16,8 @@ minimumReleaseAgeExclude:
 
 onlyBuiltDependencies:
   - msw
+
+overrides:
+  js-cookie: 3.0.7
+patchedDependencies:
+  react-hook-form@7.79.0: patches/react-hook-form@7.79.0.patch


### PR DESCRIPTION
RHF har kommet med en update som brekker noen tester. AI sitt forslag var å lage en patch for å reverte de endringene. Det vil vi trolig ikke merge. 

Usikker om jeg skal se videre etter noen fiks på det her. Eller om RHF får tilbakemeldinger om at dette ikke var en bra endring. Tenker vi venter på en versjon til får vi gjør ytterligere tiltak for fiks