### PR TITLE
TFP-7030: aktiver «ferdig, legg til plan» ved justering med pluss/min…

### DIFF
--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/TidsperiodeSpørsmål.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/TidsperiodeSpørsmål.tsx
@@ -43,7 +43,7 @@ export const TidsperiodeSpørsmål = () => {
             if (dayjs(nyTom).isAfter(dayjs(maxDate))) {
                 return;
             }
-            setValue('tom', nyTom);
+            setValue('tom', nyTom, { shouldDirty: true });
             void trigger('tom');
             void trigger('fom');
         },


### PR DESCRIPTION
…us i listevisning

Pluss/minus-knappene for uker/dager oppdaterte tom-datoen uten å markere skjemaet som endret, slik at submit-knappen forble disablet. Setter shouldDirty ved oppdatering av tom.

https://jira.adeo.no/browse/TFP-7030