### PR TITLE
fix: fest offscreen-kontainerar til document.body for å unngå "cloned…

### DIFF
--- a/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
+++ b/packages/uttaksplan/src/kalender/pdf/KalenderPdf.tsx
@@ -45,6 +45,9 @@ export const KalenderPdf = ({
                 antallKolonner,
                 filename: 'Min foreldrepengeplan.pdf',
             });
+        } catch {
+            // Generering feila (t.d. fordi dialogen blei lukka undervegs).
+            // Brukaren ser berre at lastestatus forsvinn – ingen krasj.
         } finally {
             setIsCreatingPdf(false);
         }

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -200,7 +200,11 @@ const veljSkala = (breddePx: number, høgdePx: number): number => {
     return Math.max(MAKS_CANVAS_KANT_PX / maksKant, 0.1);
 };
 
-const lagOffscreenContainer = (forelder: HTMLElement): HTMLDivElement => {
+// Aksel set CSS-variablane på :root, så document.body arvar dei alltid.
+// Vi fester containarane til document.body slik at dei aldri blir fråkopla
+// dokumentet dersom dialogen blir avmontert medan generering pågår – noko som
+// elles får html2canvas til å kaste "Unable to find element in cloned iframe".
+const lagOffscreenContainer = (): HTMLDivElement => {
     const container = document.createElement('div');
     container.className = OFFSCREEN_KLASSE;
     container.style.position = 'fixed';
@@ -208,9 +212,7 @@ const lagOffscreenContainer = (forelder: HTMLElement): HTMLDivElement => {
     container.style.top = '0';
     container.style.backgroundColor = '#ffffff';
     container.style.width = 'max-content';
-    // Lagt under same forelder som originalen, slik at CSS-variablar (Aksel-tema)
-    // blir arva og fargane blir rett løyste.
-    forelder.appendChild(container);
+    document.body.appendChild(container);
     return container;
 };
 
@@ -311,7 +313,7 @@ export const genererKalenderPdf = async ({
     // (≈ to månadskolonnar) i staden for max-content, slik at etikettane brett seg
     // over fleire linjer og får same tekststorleik som månadane når biletet blir
     // skalert til sidebreidda.
-    const legendContainer = lagOffscreenContainer(legendElement.parentElement ?? document.body);
+    const legendContainer = lagOffscreenContainer();
     legendContainer.style.width = `${LEGEND_BREDDE_PX}px`;
     legendContainer.style.padding = `${LEGEND_PADDING_PX}px 0`;
     try {
@@ -341,7 +343,7 @@ export const genererKalenderPdf = async ({
     // container og bit-canvas sleppt før neste bit.
     for (let i = 0; i < månedElementer.length; i += månederPerBit) {
         const bitElementer = månedElementer.slice(i, i + månederPerBit);
-        const container = lagOffscreenContainer(kalenderElement.parentElement ?? document.body);
+        const container = lagOffscreenContainer();
         container.style.display = 'grid';
         container.style.gridTemplateColumns = `repeat(${antallKolonner}, ${MND_BREDDE_PX}px)`;
         container.style.columnGap = `${MND_GAP_PX}px`;

--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -212,6 +212,9 @@ const lagOffscreenContainer = (): HTMLDivElement => {
     container.style.top = '0';
     container.style.backgroundColor = '#ffffff';
     container.style.width = 'max-content';
+    container.style.pointerEvents = 'none';
+    container.setAttribute('aria-hidden', 'true');
+    container.setAttribute('inert', '');
     document.body.appendChild(container);
     return container;
 };


### PR DESCRIPTION
… iframe"-feil

html2canvas klonar heile dokumentet til ein iframe og leitar etter mål-elementet der. Dersom brukaren lukkar dialogen medan PDF-generering pågår, blir offscreen-kontainarane (som låg under dialogen sin DOM) fråkopla dokumentet – og html2canvas kasta
"Unable to find element in cloned iframe".

- lagOffscreenContainer: fest alltid til document.body i staden for foreldreelementet til dialogen. Aksel sine CSS-variablar er definerte på :root og blir arva av document.body, så fargeoppløysing er uendra.
- lastNedPdf: legg til catch-blokk slik at avviste promises aldri blir uhåndterte og dukkar opp i Sentry.

https://sentry.gc.nav.no/organizations/nav/issues/644642/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0