### PR TITLE
fix: luk bort "hasFocus is not a function"-feil i Sentry

### DIFF
--- a/packages/observability/src/initSentry.test.ts
+++ b/packages/observability/src/initSentry.test.ts
@@ -723,6 +723,32 @@ const HAS_FOCUS_FEIL = {
     type: undefined,
 } satisfies Sentry.ErrorEvent;
 
+const LEGITIM_HAS_FOCUS_FEIL = {
+    event_id: 'c3d4e5f6a7b8491ac3d4e5f6a7b8491a',
+    release: 'foreldrepengesoknad-2026.06.15.090911-13b7685',
+    platform: 'javascript',
+    exception: {
+        values: [
+            {
+                type: 'TypeError',
+                value: 'fokusHaandterer.hasFocus is not a function',
+                stacktrace: {
+                    frames: [
+                        {
+                            filename: 'https://www.nav.no/foreldrepenger/soknad/assets/index-66kDgVTH.js',
+                            function: 'sjekkFokus',
+                            in_app: true,
+                            lineno: 42,
+                            colno: 7,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+    type: undefined,
+} satisfies Sentry.ErrorEvent;
+
 describe('initSentry', () => {
     afterEach(() => {
         const client = Sentry.getClient();
@@ -787,5 +813,20 @@ describe('initSentry', () => {
         const result = beforeSend!(HAS_FOCUS_FEIL, SENTRY_HINT);
 
         expect(result).toBeNull();
+    });
+
+    it('should keep legitimate hasFocus errors not from window/globalThis/self', () => {
+        vi.stubGlobal('location', { hostname: 'test.nav.no' });
+
+        initSentry({ dsn: 'https://lokal.test/1' });
+
+        const client = Sentry.getClient();
+        const beforeSend = client?.getOptions().beforeSend;
+
+        expect(beforeSend).toBeDefined();
+
+        const result = beforeSend!(LEGITIM_HAS_FOCUS_FEIL, SENTRY_HINT);
+
+        expect(result).not.toBeNull();
     });
 });

--- a/packages/observability/src/initSentry.test.ts
+++ b/packages/observability/src/initSentry.test.ts
@@ -690,6 +690,39 @@ const DOM_OVERSETTELSE_FEIL = {
     type: undefined,
 } satisfies Sentry.ErrorEvent;
 
+const HAS_FOCUS_FEIL = {
+    event_id: 'b2c3d4e5f6a74819b2c3d4e5f6a74819',
+    release: 'foreldrepengesoknad-2026.06.15.090911-13b7685',
+    platform: 'javascript',
+    exception: {
+        values: [
+            {
+                type: 'TypeError',
+                value: "window.hasFocus is not a function. (In 'window.hasFocus()', 'window.hasFocus' is undefined)",
+                stacktrace: {
+                    frames: [
+                        {
+                            filename: 'https://www.nav.no/foreldrepenger/soknad/assets/index-66kDgVTH.js',
+                            function: 'yt',
+                            in_app: true,
+                            lineno: 281,
+                            colno: 19,
+                        },
+                        {
+                            filename: 'https://www.nav.no/foreldrepenger/soknad/assets/index-66kDgVTH.js',
+                            function: 'Kr',
+                            in_app: true,
+                            lineno: 10325,
+                            colno: 26,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+    type: undefined,
+} satisfies Sentry.ErrorEvent;
+
 describe('initSentry', () => {
     afterEach(() => {
         const client = Sentry.getClient();
@@ -737,6 +770,21 @@ describe('initSentry', () => {
         expect(beforeSend).toBeDefined();
 
         const result = beforeSend!(DOM_OVERSETTELSE_FEIL, SENTRY_HINT);
+
+        expect(result).toBeNull();
+    });
+
+    it('should filter out "hasFocus is not a function" errors injected by browsers/in-app browsers', () => {
+        vi.stubGlobal('location', { hostname: 'test.nav.no' });
+
+        initSentry({ dsn: 'https://lokal.test/1' });
+
+        const client = Sentry.getClient();
+        const beforeSend = client?.getOptions().beforeSend;
+
+        expect(beforeSend).toBeDefined();
+
+        const result = beforeSend!(HAS_FOCUS_FEIL, SENTRY_HINT);
 
         expect(result).toBeNull();
     });

--- a/packages/observability/src/initSentry.ts
+++ b/packages/observability/src/initSentry.ts
@@ -35,6 +35,10 @@ export const initSentry = ({ dsn }: InitSentryOptions) => {
                 return null;
             }
 
+            if (feilFraHasFocus(event)) {
+                return null;
+            }
+
             return event;
         },
     });
@@ -94,6 +98,17 @@ const DOM_OVERSETTELSE_FEIL = /(removeChild|insertBefore)[\s\S]*not a child of t
 
 const feilFraDomOversettelse = (event: Sentry.ErrorEvent) => {
     return (event.exception?.values ?? []).some((ex) => ex.value && DOM_OVERSETTELSE_FEIL.test(ex.value));
+};
+
+/**
+ * Enkelte nettlesere/innebygde nettlesere (typisk Mobile Safari / webview i apper) injiserer eller kaller `window.hasFocus()`,
+ * som ikke finnes (den standardiserte er `document.hasFocus()`). Dette skjer utenfor vår kode og gir mye støy i Sentry,
+ * så vi luker det bort. Feilmeldingen varierer litt mellom nettlesere (f.eks. `window.hasFocus`/`globalThis.hasFocus`).
+ */
+const HAS_FOCUS_FEIL = /hasFocus is not a function/i;
+
+const feilFraHasFocus = (event: Sentry.ErrorEvent) => {
+    return (event.exception?.values ?? []).some((ex) => ex.value && HAS_FOCUS_FEIL.test(ex.value));
 };
 
 /**

--- a/packages/observability/src/initSentry.ts
+++ b/packages/observability/src/initSentry.ts
@@ -105,7 +105,7 @@ const feilFraDomOversettelse = (event: Sentry.ErrorEvent) => {
  * som ikke finnes (den standardiserte er `document.hasFocus()`). Dette skjer utenfor vår kode og gir mye støy i Sentry,
  * så vi luker det bort. Feilmeldingen varierer litt mellom nettlesere (f.eks. `window.hasFocus`/`globalThis.hasFocus`).
  */
-const HAS_FOCUS_FEIL = /hasFocus is not a function/i;
+const HAS_FOCUS_FEIL = /\b(window|globalThis|self)\.hasFocus is not a function/i;
 
 const feilFraHasFocus = (event: Sentry.ErrorEvent) => {
     return (event.exception?.values ?? []).some((ex) => ex.value && HAS_FOCUS_FEIL.test(ex.value));


### PR DESCRIPTION
Enkelte nettlesere/innebygde nettlesere (typisk Mobile Safari / webview i apper) kaller window.hasFocus() som ikke finnes, og det skaper mye støy i Sentry. Filtrerer disse bort i beforeSend for alle apper.

https://sentry.gc.nav.no/organizations/nav/issues/644554/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=8