### PR TITLE
fix: hindre uendelig oppdateringsløkke i uttaksplankalender

### DIFF
--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.tsx
@@ -68,8 +68,13 @@ export const UttaksplanKalender = ({ readOnly, barnehagestartdato, scrollToKvote
     const setRedigeringAktivOgValgtePerioder = useCallback<React.Dispatch<React.SetStateAction<CalendarPeriod[]>>>(
         (perioder) => {
             setErRedigeringAktiv(true);
-            setValgtePerioder(perioder);
-            setEndredePerioder([]);
+            // Behold same referanse når valet allereie er tomt, slik at gjentekne kall med ein tom
+            // liste ikkje planlegg unødvendige re-renders. Det hindrar «Maximum update depth exceeded».
+            setValgtePerioder((forrige) => {
+                const neste = typeof perioder === 'function' ? perioder(forrige) : perioder;
+                return forrige.length === 0 && neste.length === 0 ? forrige : neste;
+            });
+            setEndredePerioder((forrige) => (forrige.length === 0 ? forrige : []));
         },
         [],
     );
@@ -162,9 +167,9 @@ export const UttaksplanKalender = ({ readOnly, barnehagestartdato, scrollToKvote
                 {!readOnly && !erRedigeringInaktiv && (
                     <RadioGroup
                         legend={<FormattedMessage id="UttaksplanKalender.VelgDagEllerPeriode" />}
-                        onChange={() => {
+                        onChange={(erValgtPeriode: boolean) => {
                             setRedigeringAktivOgValgtePerioder([]);
-                            setIsRangeSelection(!isRangeSelection);
+                            setIsRangeSelection(erValgtPeriode);
                         }}
                         value={isRangeSelection}
                     >


### PR DESCRIPTION
RadioGroup-onChange var ikke idempotent: den toggla isRangeSelection blindt og allokerte nye tomme arrays ved hvert kall, slik at en gjeninntreden aldri stabiliserte seg og kunne gi «Maximum update depth exceeded». onChange bruker nå radioens value-parameter, og setRedigeringAktivOgValgtePerioder beholder forrige referanse når valget allerede er tomt.

https://sentry.gc.nav.no/organizations/nav/issues/645179/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=6