### PR TITLE
fix: unngå jsPDF-krasj på tomme/blanke canvas i kalender-PDF

### DIFF
--- a/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
+++ b/packages/uttaksplan/src/kalender/pdf/genererKalenderPdf.ts
@@ -132,6 +132,14 @@ const inlineIkonFargar = (original: HTMLElement, klone: HTMLElement): void => {
 const høgdeForBredde = (bildeBredde: number, bildeHøgde: number, bredde: number): number =>
     (bredde * bildeHøgde) / bildeBredde;
 
+// Eit canvas med 0 i breidde eller høgde gir NaN/Infinity når vi reknar ut
+// høgda (vi deler på breidda), og toDataURL() på det gir ein ugyldig data-URL.
+// Begge delar får jsPDF.addImage til å kaste «Invalid argument passed to
+// jsPDF.scale». Slike canvas kan oppstå om eit månadselement er tomt/kollapsa,
+// eller om html2canvas treff nettlesaren si canvas-grense på svært lange planar
+// og returnerer eit blankt canvas. Vi hoppar difor over dei i staden for å krasje.
+const erGyldigCanvas = (canvas: HTMLCanvasElement): boolean => canvas.width > 0 && canvas.height > 0;
+
 // html2canvas (1.4.1) sentrerer ikkje tekst loddrett slik flexbox/grid gjer –
 // det plasserer teksten etter line-boksen, og teiknar han difor litt for langt
 // ned. Resultatet er at dagtala sig ned i cellene og legend-teksten hamnar lågt
@@ -275,6 +283,12 @@ export const genererKalenderPdf = async ({
     let y = MARGIN_MM;
 
     const leggTilBilete = (canvas: HTMLCanvasElement, x: number, øvst: number, bredde: number, høgde: number): void => {
+        // Siste vern mot ugyldige argument til jsPDF: utan dette kastar addImage
+        // «Invalid argument passed to jsPDF.scale» dersom ein dimensjon er NaN,
+        // Infinity eller ≤ 0 (t.d. frå eit blankt/tomt canvas).
+        if (!erGyldigCanvas(canvas) || !Number.isFinite(bredde) || !Number.isFinite(høgde) || bredde <= 0 || høgde <= 0) {
+            return;
+        }
         pdf.addImage(canvas.toDataURL('image/jpeg', JPEG_KVALITET), 'JPEG', x, øvst, bredde, høgde);
     };
 
@@ -284,14 +298,21 @@ export const genererKalenderPdf = async ({
     // Canvasa blir brukte og sleppte med ein gong, slik at vi ikkje held alle
     // månadscanvasa i minnet samtidig.
     const tegnRad = (radCanvaser: HTMLCanvasElement[]): void => {
+        // Hopp over canvas utan gyldige dimensjonar, så vi ikkje får NaN-høgder
+        // (og dermed ein jsPDF-krasj) frå tomme/blanke fangingar.
+        const gyldigeCanvaser = radCanvaser.filter(erGyldigCanvas);
+        if (gyldigeCanvaser.length === 0) {
+            return;
+        }
+
         // Skaler ned heile raden dersom den høgaste månaden er høgare enn ei side.
         const naturligRadHøgde = Math.max(
-            ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, kolonneBredde)),
+            ...gyldigeCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, kolonneBredde)),
         );
         const radBredde =
             naturligRadHøgde > maksInnhaldsHøgd ? (kolonneBredde * maksInnhaldsHøgd) / naturligRadHøgde : kolonneBredde;
         const radHøgde = Math.max(
-            ...radCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, radBredde)),
+            ...gyldigeCanvaser.map((canvas) => høgdeForBredde(canvas.width, canvas.height, radBredde)),
         );
 
         if (y + radHøgde > sideBunn) {
@@ -299,7 +320,7 @@ export const genererKalenderPdf = async ({
             y = MARGIN_MM;
         }
 
-        radCanvaser.forEach((canvas, kolonne) => {
+        gyldigeCanvaser.forEach((canvas, kolonne) => {
             const x = MARGIN_MM + kolonne * (kolonneBredde + KOLONNE_GAP_MM);
             leggTilBilete(canvas, x, y, radBredde, høgdeForBredde(canvas.width, canvas.height, radBredde));
         });
@@ -321,14 +342,16 @@ export const genererKalenderPdf = async ({
         sentrerTekstForFanging(legendKlone);
 
         const legendCanvas = await fangContainer(legendContainer);
-        const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
-        const legendBredde =
-            legendNaturligHøgd > maksInnhaldsHøgd
-                ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
-                : tilgjengeligBredde;
-        const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
-        leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
-        y += legendHøgd + RAD_GAP_MM;
+        if (erGyldigCanvas(legendCanvas)) {
+            const legendNaturligHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, tilgjengeligBredde);
+            const legendBredde =
+                legendNaturligHøgd > maksInnhaldsHøgd
+                    ? (tilgjengeligBredde * maksInnhaldsHøgd) / legendNaturligHøgd
+                    : tilgjengeligBredde;
+            const legendHøgd = høgdeForBredde(legendCanvas.width, legendCanvas.height, legendBredde);
+            leggTilBilete(legendCanvas, MARGIN_MM, y, legendBredde, legendHøgd);
+            y += legendHøgd + RAD_GAP_MM;
+        }
     } finally {
         legendContainer.remove();
     }


### PR DESCRIPTION
Eit canvas med 0 i breidde/høgde gav NaN-høgde (vi deler på breidda) og ein ugyldig data-URL, som fekk jsPDF.addImage til å kaste «Invalid argument passed to jsPDF.scale». Slike canvas kan oppstå når eit månadselement er tomt eller når html2canvas treff nettlesaren si canvas-grense på lange planar. Hoppar no over ugyldige canvas i staden for å krasje.

https://sentry.gc.nav.no/organizations/nav/issues/645043/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=10