### PR TITLE
fix: ikkje flagg samtidig uttak rundt fødsel som ugyldig overlapp

### DIFF
--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.spec.ts
@@ -435,6 +435,26 @@ describe('UttakPeriodeBuilder.getUttakPerioder - validering av ugyldig overlapp'
         expect(captureMessageMock).not.toHaveBeenCalled();
     });
 
+    it('loggar ikkje for samtidig uttak rundt fødsel (ulik forelder, utan samtidigUttak satt)', () => {
+        captureMessageMock.mockClear();
+        setExtraMock.mockClear();
+        // Mor sin mødrekvote og far/medmor sin fedrekvote går parallelt rundt fødsel. Desse periodane
+        // ber ikkje `samtidigUttak`-flagget, men er likevel ein gyldig overlappande tilstand.
+        const builder = new UttakPeriodeBuilder(
+            [
+                { ...lagPeriode('2026-05-04', '2026-05-15'), kontoType: 'MØDREKVOTE' },
+                { ...lagNyPeriode('2026-05-04', '2026-05-15'), kontoType: 'FEDREKVOTE' },
+            ],
+            'kalender',
+        );
+
+        builder.leggTilUttakPerioder([{ ...lagNyPeriode('2026-12-07', '2026-12-18'), kontoType: 'FEDREKVOTE' }], false);
+
+        builder.getUttakPerioder();
+
+        expect(captureMessageMock).not.toHaveBeenCalled();
+    });
+
     it('loggar når planen inneheld ein FERIE og ein FELLES på same dag, med full diagnostikk', () => {
         captureMessageMock.mockClear();
         setExtraMock.mockClear();

--- a/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
+++ b/packages/uttaksplan/src/utils/UttakPeriodeBuilder.ts
@@ -169,13 +169,14 @@ const erGyldigSamtidigUttak = (a: AlleUttakPerioder, b: AlleUttakPerioder): bool
         // EØS-periodar er annen-part og kan eksistere parallelt med søkers periodar
         return true;
     }
+    // Periodar på ulik forelder kan gå parallelt (samtidig uttak). Dette gjeld òg samtidig uttak
+    // rundt fødsel, der far/medmor og mor har overlappande periodar utan at `samtidigUttak` er sett.
+    // Utsetjing og opphald kan derimot aldri skje samtidig med ein annan periode.
     return (
         a.utsettelseÅrsak === undefined &&
         b.utsettelseÅrsak === undefined &&
         a.oppholdÅrsak === undefined &&
         b.oppholdÅrsak === undefined &&
-        a.samtidigUttak !== undefined &&
-        b.samtidigUttak !== undefined &&
         a.forelder !== b.forelder
     );
 };


### PR DESCRIPTION
UttakPeriodeBuilder sin overlappvalidering kravde at begge periodar hadde `samtidigUttak` sett for å rekne overlapp på ulik forelder som gyldig. Samtidig uttak rundt fødsel (t.d. mor sin mødrekvote og far/medmor sin fedrekvote på same datoar) ber ikkje dette flagget, så ein gyldig plan vart feilrapportert til Sentry som "produserte ugyldig overlappende perioder".

Periodar på ulik forelder utan utsetjing/opphald reknast no som gyldig parallell tilstand uavhengig av `samtidigUttak`-flagget.

https://sentry.gc.nav.no/organizations/nav/issues/642168/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=4