### PR TITLE
fix(foreldrepengesoknad): hold dokumentasjonssteget synleg når det fi…

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -76,7 +76,7 @@ const showFrilansOgEgenNæringOgAndreInntekter = (
 
 const harManuelleVedlegg = (vedlegg: VedleggDataType | undefined): boolean =>
     Object.values(vedlegg ?? {})
-        .flat()
+        .flatMap((attachments) => attachments ?? [])
         .some((attachment) => attachment.innsendingsType !== 'AUTOMATISK');
 
 const showManglendeDokumentasjonSteg = (

--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -6,6 +6,7 @@ import { skalViseOmsorgsovertakelseDokumentasjon } from 'steps/manglende-vedlegg
 import { skalViseTerminbekreftelseDokumentasjon } from 'steps/manglende-vedlegg/dokumentasjon/TerminbekreftelseDokumentasjon.tsx';
 import { AnnenInntektType } from 'types/AndreInntektskilder';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
+import { VedleggDataType } from 'types/VedleggDataType';
 import { isFarEllerMedmor } from 'utils/isFarEllerMedmor';
 import { kreverUttaksplanVedleggNy } from 'utils/uttaksplanInfoUtils';
 
@@ -73,6 +74,11 @@ const showFrilansOgEgenNæringOgAndreInntekter = (
     return false;
 };
 
+const harManuelleVedlegg = (vedlegg: VedleggDataType | undefined): boolean =>
+    Object.values(vedlegg ?? {})
+        .flat()
+        .some((attachment) => attachment.innsendingsType !== 'AUTOMATISK');
+
 const showManglendeDokumentasjonSteg = (
     path: SøknadRoutes,
     getData: <TYPE extends ContextDataType>(key: TYPE) => ContextDataMap[TYPE],
@@ -80,6 +86,15 @@ const showManglendeDokumentasjonSteg = (
     eksisterendeSak: FpSak_fpoversikt | undefined,
 ) => {
     if (path === SøknadRoutes.DOKUMENTASJON) {
+        // Steget skal alltid vere synleg så lenge det finst manuelt opplasta eller
+        // send-seinare vedlegg. Dokumentasjonsoppsummeringa viser «Endre svar» →
+        // DOKUMENTASJON så lenge slike vedlegg finst, og utan dette kunne ein endra
+        // uttaksplan gjere steget usynleg medan vedlegga framleis låg lagra. «Endre svar»
+        // navigerte då til eit steg utanfor steglista → Step-krasj «Ingen valgte steg funnet».
+        if (harManuelleVedlegg(getData(ContextDataType.VEDLEGG))) {
+            return true;
+        }
+
         const annenForelder = getData(ContextDataType.ANNEN_FORELDER);
         const søkersituasjon = getData(ContextDataType.SØKERSITUASJON);
         const barn = getData(ContextDataType.OM_BARNET);

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
@@ -9,8 +9,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { action } from 'storybook/actions';
 import { AndreInntektskilder, AnnenInntektType } from 'types/AndreInntektskilder';
 import { AnnenForelder } from 'types/AnnenForelder';
+import { VedleggDataType } from 'types/VedleggDataType';
 
-import { BarnType } from '@navikt/fp-constants';
+import { AttachmentType, BarnType, Skjemanummer } from '@navikt/fp-constants';
 import {
     ArbeidsforholdOgInntektFp,
     Barn,
@@ -125,6 +126,7 @@ type StoryArgs = {
     uttaksplan?: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
     arbeidsforholdOgInntekt?: ArbeidsforholdOgInntektFp;
     annenInntekt?: AndreInntektskilder[];
+    vedlegg?: VedleggDataType;
     gåTilNesteSide?: (action: Action) => void;
 } & ComponentProps<typeof ManglendeVedlegg>;
 
@@ -153,6 +155,7 @@ const meta = {
         barn = defaultBarn,
         arbeidsforholdOgInntekt = defaultArbeidsforholdOgInntekt,
         annenInntekt,
+        vedlegg,
         gåTilNesteSide = action('button-click'),
         ...rest
     }) => {
@@ -166,6 +169,7 @@ const meta = {
                         [ContextDataType.OM_BARNET]: barn,
                         [ContextDataType.ARBEIDSFORHOLD_OG_INNTEKT]: arbeidsforholdOgInntekt,
                         [ContextDataType.ANDRE_INNTEKTSKILDER]: annenInntekt,
+                        [ContextDataType.VEDLEGG]: vedlegg,
                         [ContextDataType.SØKERSITUASJON]: {
                             rolle,
                             situasjon,
@@ -500,6 +504,35 @@ export const FarTarUtFedrekvoteFørsteSeksUkerUtenSamtidigMåDokumenterMorsSykdo
                     API_URLS.trengerDokumentereMorsArbeid,
                     () => new HttpResponse(JSON.stringify(false), { status: 200 }),
                 ),
+            ],
+        },
+    },
+};
+
+// Regresjonstest: uttaksplanen krev ikkje dokumentasjon, men det ligg framleis eit manuelt
+// opplasta vedlegg i context (t.d. etter at brukaren endra planen). Steget skal då framleis
+// vere synleg slik at «Endre svar» frå oppsummeringa ikkje navigerer til eit steg utanfor
+// steglista og kastar «Ingen valgte steg funnet».
+export const KreverIngenDokumentasjonMenHarOpplastetVedlegg: Story = {
+    args: {
+        søkerInfo: defaultSøkerinfo,
+        erEndringssøknad: false,
+        mellomlagreSøknadOgNaviger: promiseAction(),
+        avbrytSøknad: action('button-click'),
+        uttaksplan: [],
+        vedlegg: {
+            [Skjemanummer.DOK_INNLEGGELSE_MOR]: [
+                {
+                    id: '1',
+                    filename: 'innleggelse.pdf',
+                    filesize: 1234,
+                    file: new File([], 'innleggelse.pdf'),
+                    pending: false,
+                    uploaded: true,
+                    type: AttachmentType.MORS_AKTIVITET_DOKUMENTASJON,
+                    skjemanummer: Skjemanummer.DOK_INNLEGGELSE_MOR,
+                    innsendingsType: 'LASTET_OPP',
+                },
             ],
         },
     },

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.test.tsx
@@ -18,6 +18,7 @@ const {
     FarSøkerMorJobberMerEnn75ProsentMåIkkeDokumentereArbeid,
     FarSøkerMorJobberMindreEnn75ProsentMåDokumentereArbeid,
     BareFarHarRettSøkerMorJobberMerEnn75ProsentMåIkkeDokumentereArbeid,
+    KreverIngenDokumentasjonMenHarOpplastetVedlegg,
 } = composeStories(stories);
 
 describe('<ManglendeVedlegg>', () => {
@@ -417,6 +418,26 @@ describe('<ManglendeVedlegg>', () => {
                 key: ContextDataType.APP_ROUTE,
                 type: 'update',
             });
+        }),
+    );
+
+    it(
+        'skal vise dokumentasjonssteget når uttaksplanen ikke krever dokumentasjon men det finnes opplastet vedlegg',
+        mswWrapper(async ({ setHandlers }) => {
+            const gåTilNesteSide = vi.fn();
+            const mellomlagreSøknadOgNaviger = vi.fn();
+
+            setHandlers(KreverIngenDokumentasjonMenHarOpplastetVedlegg.parameters.msw);
+            const screen = render(
+                <KreverIngenDokumentasjonMenHarOpplastetVedlegg
+                    gåTilNesteSide={gåTilNesteSide}
+                    mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                />,
+            );
+
+            // Steget skal rendre uten å kaste «Ingen valgte steg funnet» fordi det finnes
+            // et opplastet vedlegg, selv om uttaksplanen ikke lenger krever dokumentasjon.
+            expect(await screen.findByText('Neste steg')).toBeInTheDocument();
         }),
     );
 });

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
@@ -76,7 +76,6 @@ export const ManglendeVedlegg = ({
     foreldrepengerSaker,
 }: Props) => {
     const intl = useIntl();
-    const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad);
 
     const uttaksplan = notEmpty(useContextGetData(ContextDataType.UTTAKSPLAN));
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
@@ -90,6 +89,13 @@ export const ManglendeVedlegg = ({
     const familiehendelsedato = getFamiliehendelsedato(barn);
 
     const eksisterendeSak = foreldrepengerSaker?.find((sak) => sak.saksnummer === eksisterendeSaksnummer);
+
+    const navigator = useFpNavigator(
+        søkerInfo.arbeidsforhold,
+        mellomlagreSøknadOgNaviger,
+        erEndringssøknad,
+        eksisterendeSak,
+    );
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
 


### PR DESCRIPTION
…nst opplasta vedlegg

https://sentry.gc.nav.no/organizations/nav/issues/642168/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=4

OppsummeringSteg viser «Endre svar» → goToStep(DOKUMENTASJON) så lenge det finst eit manuelt opplasta eller send-seinare vedlegg, men showManglendeDokumentasjonSteg i useStepConfig rekna steg-synlegheit ut frå gjeldande uttaksplan utan å sjå på lagra vedlegg. Endra brukaren planen slik at dokumentasjon ikkje lenger krevst medan det framleis låg vedlegg, navigerte «Endre svar» til eit steg utanfor steglista og Step kasta «Ingen valgte steg funnet» (kvit skjerm).

Held DOKUMENTASJON synleg så lenge det finst vedlegg med innsendingsType != AUTOMATISK, slik at steg-settet held seg i synk med oppsummeringa. Sender òg eksisterendeSak til useFpNavigator i ManglendeVedlegg for konsistent stegliste mellom navigator og sida.