### PR TITLE
TFP-7035: ikke krev dokumentasjon for allerede innvilgede perioder

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -8,10 +8,10 @@ import { AnnenInntektType } from 'types/AndreInntektskilder';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
 import { VedleggDataType } from 'types/VedleggDataType';
 import { isFarEllerMedmor } from 'utils/isFarEllerMedmor';
+import { finnPerioderSomInngårISøknaden } from 'utils/manglendeVedleggUtils';
 import { kreverUttaksplanVedleggNy } from 'utils/uttaksplanInfoUtils';
 
 import { EksternArbeidsforholdDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
-import { Uttaksperioden } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { getFamiliehendelsedato } from '../utils/barnUtils';
@@ -115,26 +115,8 @@ const showManglendeDokumentasjonSteg = (
         });
         const skalHaAdopsjonDokumentasjon = skalViseOmsorgsovertakelseDokumentasjon(søkersituasjon);
 
-        const uttaksplanUtenAnnenPartsOgUendredePerioder = uttaksplan
-            ?.filter(
-                (periode) =>
-                    Uttaksperioden.erIkkeEøsPeriode(periode) &&
-                    periode.forelder === (erFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
-            )
-            .filter((periode) => {
-                return eksisterendeSak
-                    ? Uttaksperioden.erIkkeEøsPeriode(periode) && periode.resultat === undefined
-                    : true;
-            });
-
-        const perioderSomSkalSjekkes = uttaksplanUtenAnnenPartsOgUendredePerioder
-            ? uttaksplanUtenAnnenPartsOgUendredePerioder.filter((periode) => {
-                  if (Uttaksperioden.erEøsPeriode(periode)) {
-                      return false;
-                  }
-
-                  return eksisterendeSak ? periode.resultat === undefined : true;
-              })
+        const perioderSomSkalSjekkes = uttaksplan
+            ? finnPerioderSomInngårISøknaden(uttaksplan, erFarEllerMedmor, !!eksisterendeSak)
             : [];
 
         const skalHaUttakDok =

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
@@ -4,7 +4,7 @@ import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { GyldigeSkjemanummer } from 'types/GyldigeSkjemanummer';
-import { perioderSomKreverVedlegg } from 'utils/manglendeVedleggUtils';
+import { finnPerioderSomInngårISøknaden, perioderSomKreverVedlegg } from 'utils/manglendeVedleggUtils';
 import { getErSøkerFarEllerMedmor, getNavnPåForeldre } from 'utils/personUtils';
 
 import { Alert, BodyLong, Heading, VStack } from '@navikt/ds-react';
@@ -13,7 +13,7 @@ import { Skjemanummer } from '@navikt/fp-constants';
 import { RhfForm, StepButtonsHookForm } from '@navikt/fp-form-hooks';
 import { Attachment, FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { SkjemaRotLayout, Step } from '@navikt/fp-ui';
-import { Uttaksperioden, getFamiliehendelsedato } from '@navikt/fp-utils';
+import { getFamiliehendelsedato } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { ManglendeVedleggFormData } from './ManglendeVedleggFormData';
@@ -100,12 +100,8 @@ export const ManglendeVedlegg = ({
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
 
     const erFarEllerMedmor = getErSøkerFarEllerMedmor(søkersituasjon.rolle);
-    const uttaksplanUtenAnnenPartsPerioder = uttaksplan?.filter(
-        (periode) =>
-            Uttaksperioden.erIkkeEøsPeriode(periode) && periode.forelder === (erFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR'),
-    );
     const perioderSomManglerVedlegg = perioderSomKreverVedlegg(
-        uttaksplanUtenAnnenPartsPerioder || [],
+        finnPerioderSomInngårISøknaden(uttaksplan, erFarEllerMedmor, !!eksisterendeSak),
         erFarEllerMedmor,
         annenForelder,
         familiehendelsedato,

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonOppsummering.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonOppsummering.tsx
@@ -2,7 +2,7 @@ import { API_URLS } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import { FormattedMessage } from 'react-intl';
 import { VedleggDataType } from 'types/VedleggDataType';
-import { perioderSomKreverVedlegg } from 'utils/manglendeVedleggUtils';
+import { finnPerioderSomInngårISøknaden, perioderSomKreverVedlegg } from 'utils/manglendeVedleggUtils';
 import { getErSøkerFarEllerMedmor } from 'utils/personUtils';
 
 import { Alert, BodyLong, BodyShort, FormSummary, Heading, Link, VStack } from '@navikt/ds-react';
@@ -27,11 +27,12 @@ export const DokumentasjonOppsummering = ({ onVilEndreSvar, navnPåForeldre }: P
     const alleVedlegg = useContextGetData(ContextDataType.VEDLEGG);
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));
     const barn = notEmpty(useContextGetData(ContextDataType.OM_BARNET));
+    const eksisterendeSaksnummer = useContextGetData(ContextDataType.VALGT_EKSISTERENDE_SAKSNR);
 
     const erSøkerFarEllerMedmor = getErSøkerFarEllerMedmor(søkersituasjon.rolle);
     const familiehendelsedato = getFamiliehendelsedato(barn);
     const uttaksperioderSomManglerVedlegg = perioderSomKreverVedlegg(
-        uttaksplan || [],
+        finnPerioderSomInngårISøknaden(uttaksplan || [], erSøkerFarEllerMedmor, !!eksisterendeSaksnummer),
         erSøkerFarEllerMedmor,
         annenForelder,
         familiehendelsedato,

--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.test.ts
@@ -1,8 +1,8 @@
 import { AnnenForelder } from 'types/AnnenForelder';
 
-import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { UttakPeriode_fpoversikt, UttakPeriodeResultat_fpoversikt } from '@navikt/fp-types';
 
-import { perioderSomKreverVedlegg } from './manglendeVedleggUtils';
+import { finnPerioderSomInngårISøknaden, perioderSomKreverVedlegg } from './manglendeVedleggUtils';
 
 const annenForelder = {
     fornavn: 'Far',
@@ -25,6 +25,40 @@ const lagFellesperiodeMedMorsAktivitet = (forelder: 'MOR' | 'FAR_MEDMOR'): Uttak
     flerbarnsdager: false,
 });
 
+const innvilgetResultat: UttakPeriodeResultat_fpoversikt = {
+    innvilget: true,
+    trekkerDager: true,
+    trekkerMinsterett: false,
+    årsak: 'ANNET',
+};
+
+const innvilgetFellesperiodeMorSyk: UttakPeriode_fpoversikt = {
+    fom: '2024-01-01',
+    tom: '2024-01-31',
+    flerbarnsdager: false,
+    forelder: 'FAR_MEDMOR',
+    kontoType: 'FELLESPERIODE',
+    morsAktivitet: 'TRENGER_HJELP',
+    resultat: innvilgetResultat,
+};
+
+const nyFellesperiodeMorJobber: UttakPeriode_fpoversikt = {
+    fom: '2024-02-01',
+    tom: '2024-02-28',
+    flerbarnsdager: false,
+    forelder: 'FAR_MEDMOR',
+    kontoType: 'FELLESPERIODE',
+    morsAktivitet: 'ARBEID',
+};
+
+const morsPeriode: UttakPeriode_fpoversikt = {
+    fom: '2023-12-01',
+    tom: '2023-12-31',
+    flerbarnsdager: false,
+    forelder: 'MOR',
+    kontoType: 'MØDREKVOTE',
+};
+
 describe('perioderSomKreverVedlegg - dokumentasjon av mors aktivitet', () => {
     it('skal ikke kreve dokumentasjon for mors aktivitet i mors egen søknad ved samtidig uttak av fellesperiode', () => {
         const perioder = perioderSomKreverVedlegg(
@@ -46,5 +80,38 @@ describe('perioderSomKreverVedlegg - dokumentasjon av mors aktivitet', () => {
         );
 
         expect(perioder).toHaveLength(1);
+    });
+});
+
+describe('finnPerioderSomInngårISøknaden', () => {
+    it('utelater allerede innvilgede perioder i en endringssøknad mot en eksisterende sak', () => {
+        const resultat = finnPerioderSomInngårISøknaden(
+            [innvilgetFellesperiodeMorSyk, nyFellesperiodeMorJobber],
+            true,
+            true,
+        );
+
+        expect(resultat).toEqual([nyFellesperiodeMorJobber]);
+    });
+
+    it('beholder alle søkerens perioder i en førstegangssøknad uten eksisterende sak', () => {
+        const periodeUtenResultat: UttakPeriode_fpoversikt = {
+            ...nyFellesperiodeMorJobber,
+            morsAktivitet: 'TRENGER_HJELP',
+        };
+
+        const resultat = finnPerioderSomInngårISøknaden(
+            [periodeUtenResultat, nyFellesperiodeMorJobber],
+            true,
+            false,
+        );
+
+        expect(resultat).toEqual([periodeUtenResultat, nyFellesperiodeMorJobber]);
+    });
+
+    it('filtrerer bort annen parts perioder', () => {
+        const resultat = finnPerioderSomInngårISøknaden([morsPeriode, nyFellesperiodeMorJobber], true, false);
+
+        expect(resultat).toEqual([nyFellesperiodeMorJobber]);
     });
 });

--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
@@ -8,6 +8,29 @@ import {
 import { Uttaksperioden } from '@navikt/fp-utils';
 import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
 
+/**
+ * Finner periodene som faktisk inngår i denne søknaden, og som derfor kan kreve dokumentasjon.
+ *
+ * Filtrerer bort annen parts perioder, og – i en endringssøknad mot en eksisterende sak –
+ * perioder som allerede er innvilget (de har et `resultat`). Uten dette ville søknaden f.eks.
+ * be far om sykdomsdokumentasjon for fellesperiode mor syk som allerede er innvilget, selv om
+ * han kun endrer/legger til en ny periode.
+ */
+export const finnPerioderSomInngårISøknaden = (
+    uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    erFarEllerMedmor: boolean,
+    harEksisterendeSak: boolean,
+): UttakPeriode_fpoversikt[] => {
+    return uttaksplan.filter((periode): periode is UttakPeriode_fpoversikt => {
+        if (!Uttaksperioden.erIkkeEøsPeriode(periode)) {
+            return false;
+        }
+        const erSøkersPeriode = periode.forelder === (erFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR');
+        const erDelAvSøknaden = harEksisterendeSak ? periode.resultat === undefined : true;
+        return erSøkersPeriode && erDelAvSøknaden;
+    });
+};
+
 export const perioderSomKreverVedlegg = (
     uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     erFarEllerMedmor: boolean,

--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
@@ -22,7 +22,7 @@ export const finnPerioderSomInngårISøknaden = (
     harEksisterendeSak: boolean,
 ): UttakPeriode_fpoversikt[] => {
     return uttaksplan.filter((periode): periode is UttakPeriode_fpoversikt => {
-        if (!Uttaksperioden.erIkkeEøsPeriode(periode)) {
+        if (Uttaksperioden.erEøsPeriode(periode)) {
             return false;
         }
         const erSøkersPeriode = periode.forelder === (erFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR');


### PR DESCRIPTION
I en endringssøknad ble dokumentasjonskravet regnet ut fra hele uttaksplanen, slik at far ble bedt om sykdomsdokumentasjon for fellesperiode mor syk som allerede var innvilget, i tillegg til arbeidsdokumentasjon for den nye perioden.

Innfører delt hjelpefunksjon finnPerioderSomInngårISøknaden som filtrerer bort annen parts perioder og allerede innvilgede perioder (når det finnes en eksisterende sak), og tar den i bruk i ManglendeVedlegg, DokumentasjonOppsummering og useStepConfig slik at logikken ikke kan divergere.

https://jira.adeo.no/browse/TFP-7035