### PR TITLE
TFP-7032: fjern dokumentasjonskrav for mors aktivitet i mors søknad

### DIFF
--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.test.ts
@@ -1,0 +1,50 @@
+import { AnnenForelder } from 'types/AnnenForelder';
+
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { perioderSomKreverVedlegg } from './manglendeVedleggUtils';
+
+const annenForelder = {
+    fornavn: 'Far',
+    etternavn: 'Forelder',
+    fnr: '12345678901',
+    harRettPåForeldrepengerINorge: true,
+    erAleneOmOmsorg: false,
+    kanIkkeOppgis: false,
+} satisfies AnnenForelder;
+
+const familiehendelsedato = '2024-01-01';
+
+const lagFellesperiodeMedMorsAktivitet = (forelder: 'MOR' | 'FAR_MEDMOR'): UttakPeriode_fpoversikt => ({
+    forelder,
+    kontoType: 'FELLESPERIODE',
+    fom: '2024-06-01',
+    tom: '2024-06-30',
+    morsAktivitet: 'ARBEID',
+    samtidigUttak: 50,
+    flerbarnsdager: false,
+});
+
+describe('perioderSomKreverVedlegg - dokumentasjon av mors aktivitet', () => {
+    it('skal ikke kreve dokumentasjon for mors aktivitet i mors egen søknad ved samtidig uttak av fellesperiode', () => {
+        const perioder = perioderSomKreverVedlegg(
+            [lagFellesperiodeMedMorsAktivitet('MOR')],
+            false,
+            annenForelder,
+            familiehendelsedato,
+        );
+
+        expect(perioder).toHaveLength(0);
+    });
+
+    it('skal fortsatt kreve dokumentasjon for mors aktivitet i far/medmor sin søknad', () => {
+        const perioder = perioderSomKreverVedlegg(
+            [lagFellesperiodeMedMorsAktivitet('FAR_MEDMOR')],
+            true,
+            annenForelder,
+            familiehendelsedato,
+        );
+
+        expect(perioder).toHaveLength(1);
+    });
+});

--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
@@ -46,7 +46,7 @@ const shouldPeriodeHaveAttachment = (
     }
 
     if (Uttaksperioden.erIkkeEøsPeriode(periode) && Uttaksperioden.erUttaksperiode(periode)) {
-        return dokumentasjonBehøvesForUttaksperiode(periode, familiehendelsedato);
+        return dokumentasjonBehøvesForUttaksperiode(periode, søkerErFarEllerMedmor, familiehendelsedato);
     }
 
     return false;
@@ -65,6 +65,7 @@ const erÅrsakSykdomEllerInstitusjonsopphold = (årsak: UttakUtsettelseÅrsak_fp
 
 const dokumentasjonBehøvesForUttaksperiode = (
     periode: UttakPeriode_fpoversikt,
+    søkerErFarEllerMedmor: boolean,
     familiehendelsedato: string,
 ): boolean => {
     const harIkkeAktivitetskrav = periode.kontoType === 'FORELDREPENGER' && periode.morsAktivitet === 'IKKE_OPPGITT';
@@ -81,8 +82,11 @@ const dokumentasjonBehøvesForUttaksperiode = (
         return false;
     }
 
-    return (
-        (periode.morsAktivitet !== undefined && periode.morsAktivitet !== 'UFØRE') ||
-        erPeriodeMedFedrekvoteIFødselspermTidsrommet
-    );
+    // Dokumentasjon av mors aktivitet ("hva skal mor gjøre i denne perioden") skal kun kreves i
+    // far/medmor sin søknad. I mors egen søknad skal det aldri kreves dokumentasjon for mors
+    // aktivitet, uansett hvilken aktivitet hun velger.
+    const krevesDokumentasjonAvMorsAktivitet =
+        søkerErFarEllerMedmor && periode.morsAktivitet !== undefined && periode.morsAktivitet !== 'UFØRE';
+
+    return krevesDokumentasjonAvMorsAktivitet || erPeriodeMedFedrekvoteIFødselspermTidsrommet;
 };


### PR DESCRIPTION
Ved samtidig uttak av fellesperiode der mor velger aktivitet fra rullgardina, ble det trigget krav om dokumentasjon på mors aktivitet i mors egen søknad. Dette satte søknaden på vent fordi FP-sak ventet på dokumentasjon mor ikke skal sende.

Dokumentasjonskravet for mors aktivitet gates nå bak søkerErFarEllerMedmor, slik at kravet kun gjelder i far/medmor sin søknad. Det er far/medmor som eventuelt laster opp denne dokumentasjonen.

https://jira.adeo.no/browse/TFP-7032