### PR TITLE
fix(uttaksplan): unngå krasj ved to overlappende perioder uten samtid…

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -748,7 +748,7 @@ export const useLoggUgyldigSamtidigUttakVedRedigering = (
         foreldreInfo: { søker },
         erPeriodeneTilAnnenPartLåst,
     } = useUttaksplanData();
-    const sistLoggetFingerprintRef = useRef<string | null>(null);
+    const loggedeFingerprintsRef = useRef<Set<string>>(new Set());
 
     useEffect(() => {
         if (!valgtPeriode) {
@@ -766,10 +766,10 @@ export const useLoggUgyldigSamtidigUttakVedRedigering = (
         }
 
         const fingerprint = `${valgtPeriode.fom}:${valgtPeriode.tom}`;
-        if (sistLoggetFingerprintRef.current === fingerprint) {
+        if (loggedeFingerprintsRef.current.has(fingerprint)) {
             return;
         }
-        sistLoggetFingerprintRef.current = fingerprint;
+        loggedeFingerprintsRef.current.add(fingerprint);
 
         withScope((scope) => {
             scope.setLevel('warning');

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -717,17 +717,16 @@ export const finnUgyldigSamtidigUttakOverlapp = (
     erPeriodeneTilAnnenPartLåst: boolean,
 ): [UttakPeriode_fpoversikt, UttakPeriode_fpoversikt] | undefined => {
     const eksisterendePerioder = finnPerioderSomOmslutterValgtPeriode(uttaksplanperioder, valgtPeriode);
+    const harToOmsluttendePerioder = eksisterendePerioder.length === 2;
 
-    if (
-        eksisterendePerioder.length !== 2 ||
-        !eksisterendePerioder.every(erVanligUttakPeriode) ||
-        eksisterendePerioder.some((p) => p.utsettelseÅrsak === 'LOVBESTEMT_FERIE') ||
-        eksisterendePerioder.some((p) => erPeriodeneTilAnnenPartLåst && p.forelder !== søker)
-    ) {
+    if (!harToOmsluttendePerioder || !eksisterendePerioder.every(erVanligUttakPeriode)) {
         return undefined;
     }
 
-    if (finnGyldigSamtidigUttakPar(eksisterendePerioder)) {
+    const harLovbestemtFerie = eksisterendePerioder.some((p) => p.utsettelseÅrsak === 'LOVBESTEMT_FERIE');
+    const harLåstPeriodeFraAnnenPart = eksisterendePerioder.some((p) => erPeriodeneTilAnnenPartLåst && p.forelder !== søker);
+
+    if (harLovbestemtFerie || harLåstPeriodeFraAnnenPart || finnGyldigSamtidigUttakPar(eksisterendePerioder)) {
         return undefined;
     }
 

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -19,7 +19,7 @@ import type {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { getFloatFromString } from '@navikt/fp-utils';
-import { isRequired, notEmpty } from '@navikt/fp-validation';
+import { isRequired } from '@navikt/fp-validation';
 
 import { useUttaksplanData } from '../context/UttaksplanDataContext';
 import { getStønadskvoteNavnSimple } from '../liste/utils/uttaksplanListeUtils';
@@ -704,11 +704,12 @@ export const lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm = (
 
     if (eksisterendePerioder.length === 2) {
         const erSamtidigUttak = eksisterendePerioder.every((p) => !!p.samtidigUttak);
-        if (!erSamtidigUttak) {
-            throw new Error('Forventer to perioder ved samtidig uttak.');
+        const morsPeriode = eksisterendePerioder.find((p) => p.forelder === 'MOR');
+        const farMedmorPeriode = eksisterendePerioder.find((p) => p.forelder === 'FAR_MEDMOR');
+
+        if (!erSamtidigUttak || !morsPeriode || !farMedmorPeriode) {
+            return undefined;
         }
-        const morsPeriode = notEmpty(eksisterendePerioder.find((p) => p.forelder === 'MOR'));
-        const farMedmorPeriode = notEmpty(eksisterendePerioder.find((p) => p.forelder === 'FAR_MEDMOR'));
 
         const søkersPeriode = søker === 'MOR' ? morsPeriode : farMedmorPeriode;
 

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -1,13 +1,14 @@
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Alert, BodyShort, InlineMessage, Radio, VStack } from '@navikt/ds-react';
 
 import { RhfNumericField, RhfRadioGroup, RhfSelect } from '@navikt/fp-form-hooks';
+import { captureMessage, withScope } from '@navikt/fp-observability';
 import type {
     AktivitetType_fpoversikt,
     BrukerRolleSak_fpoversikt,
@@ -29,6 +30,7 @@ import { useForelderValgSynlighet } from '../regler/synlighet/forelderValg';
 import { ForelderValg } from '../regler/synlighet/types';
 import { erVanligUttakPeriode } from '../types/UttaksplanPeriode';
 import { getAktivitetskravOptions, getAktivitetskravTekst } from '../utils/periodeUtils';
+import { periodeTilLoggObjekt } from '../utils/UttakPeriodeBuilder';
 import { prosentValideringGradering, valideringSamtidigUttak } from './uttaksplanValidatorer';
 
 dayjs.extend(isSameOrBefore);
@@ -680,17 +682,120 @@ export const mapFraFormValuesTilUttakPeriode = (
     return nye;
 };
 
+const finnPerioderSomOmslutterValgtPeriode = (
+    uttaksplanperioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    valgtPeriode: { fom: string; tom: string },
+): Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt> =>
+    uttaksplanperioder.filter(
+        (periode) =>
+            dayjs(valgtPeriode.fom).isSameOrAfter(dayjs(periode.fom), 'day') &&
+            dayjs(valgtPeriode.tom).isSameOrBefore(dayjs(periode.tom), 'day'),
+    );
+
+const finnGyldigSamtidigUttakPar = (
+    eksisterendePerioder: UttakPeriode_fpoversikt[],
+): { morsPeriode: UttakPeriode_fpoversikt; farMedmorPeriode: UttakPeriode_fpoversikt } | undefined => {
+    const erSamtidigUttak = eksisterendePerioder.every((p) => !!p.samtidigUttak);
+    const morsPeriode = eksisterendePerioder.find((p) => p.forelder === 'MOR');
+    const farMedmorPeriode = eksisterendePerioder.find((p) => p.forelder === 'FAR_MEDMOR');
+
+    if (!erSamtidigUttak || !morsPeriode || !farMedmorPeriode) {
+        return undefined;
+    }
+
+    return { morsPeriode, farMedmorPeriode };
+};
+
+// Returnerer dei to overlappande periodane når dei omsluttar valgtPeriode, men ikkje utgjer
+// eit gyldig samtidig-uttak-par. Datakilda (prosesserPerioderForVisning av backend-vedtak) er
+// midlertidig stillas som ikkje garanterer rein uttaksplan, så slike ugyldige overlapp kan
+// førekomme – jf. useLoggOverlappIVedtak som loggar dei på plannivå.
+export const finnUgyldigSamtidigUttakOverlapp = (
+    uttaksplanperioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
+    valgtPeriode: { fom: string; tom: string },
+    søker: BrukerRolleSak_fpoversikt,
+    erPeriodeneTilAnnenPartLåst: boolean,
+): [UttakPeriode_fpoversikt, UttakPeriode_fpoversikt] | undefined => {
+    const eksisterendePerioder = finnPerioderSomOmslutterValgtPeriode(uttaksplanperioder, valgtPeriode);
+
+    if (
+        eksisterendePerioder.length !== 2 ||
+        !eksisterendePerioder.every(erVanligUttakPeriode) ||
+        eksisterendePerioder.some((p) => p.utsettelseÅrsak === 'LOVBESTEMT_FERIE') ||
+        eksisterendePerioder.some((p) => erPeriodeneTilAnnenPartLåst && p.forelder !== søker)
+    ) {
+        return undefined;
+    }
+
+    if (finnGyldigSamtidigUttakPar(eksisterendePerioder)) {
+        return undefined;
+    }
+
+    return [eksisterendePerioder[0]!, eksisterendePerioder[1]!];
+};
+
+/**
+ * Loggar til Sentry når brukaren redigerer ein valgtPeriode som omsluttast av to overlappande
+ * periodar som ikkje utgjer eit gyldig samtidig-uttak-par. Dette er rotårsaka bak at skjemaet
+ * ikkje kan forhåndsutfyllast (og som tidlegare kasta «Forventer to perioder ved samtidig uttak.»).
+ * Loggar éin gong per distinkt valgtPeriode for å unngå støy ved re-rendering.
+ */
+export const useLoggUgyldigSamtidigUttakVedRedigering = (
+    valgtPeriode: { fom: string; tom: string } | undefined,
+): void => {
+    const {
+        uttakPerioder,
+        foreldreInfo: { søker },
+        erPeriodeneTilAnnenPartLåst,
+    } = useUttaksplanData();
+    const sistLoggetFingerprintRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!valgtPeriode) {
+            return;
+        }
+
+        const ugyldigOverlapp = finnUgyldigSamtidigUttakOverlapp(
+            uttakPerioder,
+            valgtPeriode,
+            søker,
+            erPeriodeneTilAnnenPartLåst,
+        );
+        if (!ugyldigOverlapp) {
+            return;
+        }
+
+        const fingerprint = `${valgtPeriode.fom}:${valgtPeriode.tom}`;
+        if (sistLoggetFingerprintRef.current === fingerprint) {
+            return;
+        }
+        sistLoggetFingerprintRef.current = fingerprint;
+
+        withScope((scope) => {
+            scope.setLevel('warning');
+            scope.setTag('feiltype', 'uttaksplan-ugyldig-samtidig-ved-redigering');
+            scope.setExtra('valgtPeriode', valgtPeriode);
+            scope.setExtra('erPeriodeneTilAnnenPartLåst', erPeriodeneTilAnnenPartLåst);
+            scope.setExtra('ugyldigOverlappPar', {
+                a: periodeTilLoggObjekt(ugyldigOverlapp[0]),
+                b: periodeTilLoggObjekt(ugyldigOverlapp[1]),
+            });
+            scope.setExtra('uttakPerioder', uttakPerioder.map(periodeTilLoggObjekt));
+            captureMessage(
+                'Forventet samtidig uttak ved redigering, men de to overlappende periodene utgjør ikke et gyldig samtidig-uttak-par',
+                'warning',
+            );
+        });
+    }, [valgtPeriode, uttakPerioder, søker, erPeriodeneTilAnnenPartLåst]);
+};
+
 export const lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm = (
     uttaksplanperioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     valgtPeriode: { fom: string; tom: string },
     søker: BrukerRolleSak_fpoversikt,
     erPeriodeneTilAnnenPartLåst: boolean,
 ): LeggTilEllerEndrePeriodeFormFormValues | undefined => {
-    const eksisterendePerioder = uttaksplanperioder.filter(
-        (periode) =>
-            dayjs(valgtPeriode.fom).isSameOrAfter(dayjs(periode.fom), 'day') &&
-            dayjs(valgtPeriode.tom).isSameOrBefore(dayjs(periode.tom), 'day'),
-    );
+    const eksisterendePerioder = finnPerioderSomOmslutterValgtPeriode(uttaksplanperioder, valgtPeriode);
 
     if (
         eksisterendePerioder.length === 0 ||
@@ -703,14 +808,17 @@ export const lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm = (
     }
 
     if (eksisterendePerioder.length === 2) {
-        const erSamtidigUttak = eksisterendePerioder.every((p) => !!p.samtidigUttak);
-        const morsPeriode = eksisterendePerioder.find((p) => p.forelder === 'MOR');
-        const farMedmorPeriode = eksisterendePerioder.find((p) => p.forelder === 'FAR_MEDMOR');
+        const samtidigUttakPar = finnGyldigSamtidigUttakPar(eksisterendePerioder);
 
-        if (!erSamtidigUttak || !morsPeriode || !farMedmorPeriode) {
+        // Datakilden (prosesserPerioderForVisning av backend-vedtak) garanterer ikke at to
+        // overlappande periodar utgjer eit gyldig samtidig-uttak-par. Når dei ikkje gjer det,
+        // kan vi ikkje forhåndsutfylle skjemaet – sjå useLoggUgyldigSamtidigUttakVedRedigering
+        // som loggar tilfellet til Sentry.
+        if (!samtidigUttakPar) {
             return undefined;
         }
 
+        const { morsPeriode, farMedmorPeriode } = samtidigUttakPar;
         const søkersPeriode = søker === 'MOR' ? morsPeriode : farMedmorPeriode;
 
         return {

--- a/packages/uttaksplan/src/felles/finnUgyldigSamtidigUttakOverlapp.test.ts
+++ b/packages/uttaksplan/src/felles/finnUgyldigSamtidigUttakOverlapp.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+
+import { finnUgyldigSamtidigUttakOverlapp } from './LeggTilEllerEndrePeriodeFellesForm';
+
+const morsPeriode = (overstyr: Partial<UttakPeriode_fpoversikt> = {}): UttakPeriode_fpoversikt => ({
+    fom: '2026-05-01',
+    tom: '2026-05-31',
+    forelder: 'MOR',
+    kontoType: 'MØDREKVOTE',
+    flerbarnsdager: false,
+    ...overstyr,
+});
+
+const farsPeriode = (overstyr: Partial<UttakPeriode_fpoversikt> = {}): UttakPeriode_fpoversikt => ({
+    fom: '2026-05-01',
+    tom: '2026-05-31',
+    forelder: 'FAR_MEDMOR',
+    kontoType: 'FEDREKVOTE',
+    flerbarnsdager: false,
+    ...overstyr,
+});
+
+const valgtPeriode = { fom: '2026-05-10', tom: '2026-05-20' };
+
+describe('finnUgyldigSamtidigUttakOverlapp', () => {
+    it('returnerer undefined for eit gyldig samtidig-uttak-par (begge samtidigUttak, mor + far)', () => {
+        const perioder = [morsPeriode({ samtidigUttak: 50 }), farsPeriode({ samtidigUttak: 50 })];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false)).toBeUndefined();
+    });
+
+    it('flaggar to overlappande periodar der berre éin har samtidigUttak', () => {
+        const perioder = [morsPeriode({ samtidigUttak: 50 }), farsPeriode()];
+
+        const resultat = finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false);
+
+        expect(resultat).toEqual([perioder[0], perioder[1]]);
+    });
+
+    it('flaggar to overlappande periodar der ingen har samtidigUttak', () => {
+        const perioder = [morsPeriode(), farsPeriode()];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false)).toEqual([
+            perioder[0],
+            perioder[1],
+        ]);
+    });
+
+    it('flaggar to overlappande periodar for same forelder sjølv om begge har samtidigUttak', () => {
+        const perioder = [morsPeriode({ samtidigUttak: 50 }), morsPeriode({ samtidigUttak: 50 })];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false)).toEqual([
+            perioder[0],
+            perioder[1],
+        ]);
+    });
+
+    it('returnerer undefined når berre éin periode omsluttar valgtPeriode', () => {
+        const perioder = [morsPeriode()];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false)).toBeUndefined();
+    });
+
+    it('returnerer undefined når annen parts periodar er låste (handterast ikkje som redigerbart par)', () => {
+        const perioder = [morsPeriode(), farsPeriode()];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', true)).toBeUndefined();
+    });
+
+    it('flaggar ikkje periodar som ikkje omsluttar heile valgtPeriode', () => {
+        const perioder = [
+            morsPeriode({ tom: '2026-05-15' }),
+            farsPeriode({ tom: '2026-05-15' }),
+        ];
+
+        expect(finnUgyldigSamtidigUttakOverlapp(perioder, valgtPeriode, 'MOR', false)).toBeUndefined();
+    });
+});

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodeForm.tsx
@@ -16,6 +16,7 @@ import {
     LeggTilEllerEndrePeriodeFormFormValues,
     lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm,
     mapFraFormValuesTilUttakPeriode,
+    useLoggUgyldigSamtidigUttakVedRedigering,
 } from '../../../../felles/LeggTilEllerEndrePeriodeFellesForm';
 import { LeggTilPeriodeForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel';
 import { useVisForskyvEllerErstattPanel } from '../../../../felles/forskyvEllerErstatt/useVisForskyvEllerErstattPanel';
@@ -46,6 +47,8 @@ export const LeggTilEllerEndrePeriodeForm = ({ lukkRedigeringsmodus }: Props) =>
         useKalenderRedigeringContext();
 
     const [feilmelding, setFeilmelding] = useState<string | undefined>();
+
+    useLoggUgyldigSamtidigUttakVedRedigering(sammenslåtteValgtePerioder[0]);
 
     const { visEndreEllerForskyvPanel, setVisEndreEllerForskyvPanel } =
         useVisForskyvEllerErstattPanel(sammenslåtteValgtePerioder);

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -18,6 +18,7 @@ import {
     LeggTilEllerEndrePeriodeFormFormValues,
     lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm,
     mapFraFormValuesTilUttakPeriode,
+    useLoggUgyldigSamtidigUttakVedRedigering,
 } from '../../felles/LeggTilEllerEndrePeriodeFellesForm';
 import { LeggTilPeriodeForskyvEllerErstattPanel } from '../../felles/forskyvEllerErstatt/LeggTilPeriodeForskyvEllerErstattPanel';
 import { useVisForskyvEllerErstattPanel } from '../../felles/forskyvEllerErstatt/useVisForskyvEllerErstattPanel';
@@ -138,6 +139,8 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
     const [feilmelding, setFeilmelding] = useState<string | undefined>();
 
     const uttaksplanRedigering = useUttaksplanRedigering();
+
+    useLoggUgyldigSamtidigUttakVedRedigering(uttaksplanperiode);
 
     const defaultValues = uttaksplanperiode
         ? leggTilDatoOgHvaVilDuGjøre(

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -437,14 +437,12 @@ const leggTilDatoOgHvaVilDuGjøre = (
         };
     }
 
-    return periode
-        ? {
-              ...periode,
-              fom: uttaksplanperiode.fom,
-              tom: uttaksplanperiode.tom,
-              hvaVilDuGjøre: 'LEGG_TIL_PERIODE',
-          }
-        : undefined;
+    return {
+        ...periode,
+        fom: uttaksplanperiode.fom,
+        tom: uttaksplanperiode.tom,
+        hvaVilDuGjøre: 'LEGG_TIL_PERIODE',
+    };
 };
 
 const lagHvaVilDuGjøreAlternativer = (


### PR DESCRIPTION
…ig uttak

https://sentry.gc.nav.no/organizations/nav/issues/640884/?project=11&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=3

lagDefaultValuesLeggTilEllerEndrePeriodeFellesForm kastet "Forventer to perioder ved samtidig uttak." når nøyaktig to vanlige uttaksperioder overlappet den valgte perioden uten å være et gyldig samtidig-uttak-par (begge med samtidigUttak satt, én MOR og én FAR_MEDMOR). En lengre periode fra én forelder kan overlappe en kortere samtidig-periode fra den andre, og da krasjet form-renderingen (Sentry).

Faller nå tilbake til undefined (ingen forhåndsutfylling) i stedet for å kaste, i tråd med hvordan resten av uttaksplanen behandler ugyldige overlapp. Begge kallere håndterer allerede undefined.