### PR TITLE
fix: unngå krasj i ikkeDeltUttak når aktivitetsfri kvote mangler for …

### DIFF
--- a/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.test.ts
+++ b/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.test.ts
@@ -158,6 +158,57 @@ describe('ikkeDeltUttak - Fødsel - Far aleneOmOmsorg', () => {
     });
 });
 
+describe('ikkeDeltUttak - Far/Far uten aktivitetsfri kvote', () => {
+    beforeAll(() => {
+        MockDate.set('2022-08-02');
+    });
+
+    afterAll(() => {
+        MockDate.reset();
+    });
+
+    const famDato = '2022-08-08';
+    const foreldrepenger = { konto: 'FORELDREPENGER', dager: 75 } satisfies KontoDto;
+
+    it('skal gi én sammenhengende foreldrepengeperiode ved fødsel når aktivitetsfri kvote mangler', () => {
+        const forslag = ikkeDeltUttak({
+            situasjon: 'fødsel',
+            famDato,
+            erFarEllerMedmor: true,
+            tilgjengeligeStønadskvoter: [foreldrepenger],
+            erMorUfør: false,
+            bareFarMedmorHarRett: false,
+            erAleneOmOmsorg: false,
+            farOgFar: true,
+        });
+
+        expect(forslag.length).toEqual(1);
+        expect(forslag[0]!.kontoType).toEqual('FORELDREPENGER');
+        expect(forslag[0]!.forelder).toEqual('FAR_MEDMOR');
+        expect(forslag[0]!.fom).toEqual('2022-08-08');
+        expect(forslag[0]!.tom).toEqual('2022-11-18');
+    });
+
+    it('skal gi én sammenhengende foreldrepengeperiode ved adopsjon når aktivitetsfri kvote mangler', () => {
+        const forslag = ikkeDeltUttak({
+            situasjon: 'adopsjon',
+            famDato,
+            erFarEllerMedmor: true,
+            tilgjengeligeStønadskvoter: [foreldrepenger],
+            erMorUfør: false,
+            bareFarMedmorHarRett: false,
+            erAleneOmOmsorg: false,
+            farOgFar: true,
+        });
+
+        expect(forslag.length).toEqual(1);
+        expect(forslag[0]!.kontoType).toEqual('FORELDREPENGER');
+        expect(forslag[0]!.forelder).toEqual('FAR_MEDMOR');
+        expect(forslag[0]!.fom).toEqual('2022-08-08');
+        expect(forslag[0]!.tom).toEqual('2022-11-18');
+    });
+});
+
 describe('ikkeDeltUttak - Adopsjon', () => {
     beforeAll(() => {
         MockDate.set('2022-08-02');

--- a/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.ts
+++ b/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.ts
@@ -42,13 +42,13 @@ const ikkeDeltUttakAdopsjonFarMedmor = ({
             flerbarnsdager: false,
         };
         perioder.push(aktivitetskravPeriode);
-    } else if (farOgFar) {
+    } else if (farOgFar && aktivitetsfriKvote) {
         const periode: UttakPeriode_fpoversikt = {
             forelder: 'FAR_MEDMOR',
             kontoType: 'FORELDREPENGER',
             morsAktivitet: 'IKKE_OPPGITT',
-            fom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).fom,
-            tom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote!.dager).tom,
+            fom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote.dager).fom,
+            tom: getTidsperiodeString(førsteUttaksdag, aktivitetsfriKvote.dager).tom,
             flerbarnsdager: false,
         };
         perioder.push(periode);
@@ -240,13 +240,13 @@ const ikkeDeltUttakFødselFarMedmor = ({
             perioder.push(aktivitetskravPeriode);
         }
     } else {
-        if (farOgFar && !erAleneOmOmsorg) {
+        if (farOgFar && !erAleneOmOmsorg && aktivitetsfriKvote) {
             const periode: UttakPeriode_fpoversikt = {
                 forelder: 'FAR_MEDMOR',
                 kontoType: 'FORELDREPENGER',
                 morsAktivitet: 'IKKE_OPPGITT',
-                fom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).fom,
-                tom: getTidsperiodeString(startDato, aktivitetsfriKvote!.dager).tom,
+                fom: getTidsperiodeString(startDato, aktivitetsfriKvote.dager).fom,
+                tom: getTidsperiodeString(startDato, aktivitetsfriKvote.dager).tom,
                 flerbarnsdager: false,
             };
             perioder.push(periode);


### PR DESCRIPTION
…far/far

https://sentry.gc.nav.no/organizations/nav/issues/644931/?project=181&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1

Far/far-grenene antok at AKTIVITETSFRI_KVOTE alltid finnes og brukte aktivitetsfriKvote!.dager. Når kontoresponsen ikke inneholder kvoten ble aktivitetsfriKvote undefined og ga "Cannot read properties of undefined (reading 'dager')" i Sentry. Grenene faller nå tilbake til vanlig foreldrepenger-logikk når kvoten mangler.