### PR TITLE
fix: unngå crash i planlegger ved ugyldig data-parameter i URL

### DIFF
--- a/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
+++ b/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
@@ -108,7 +108,11 @@ export const usePlanleggerDataFromUrl = (kjønn: Kjønn_fpoversikt | undefined):
             return null;
         }
         try {
-            const data = JSON.parse(decompressFromUrl(encoded)) as PlanleggerDataFromUrl;
+            const decompressed = decompressFromUrl(encoded);
+            if (!decompressed) {
+                return null;
+            }
+            const data = JSON.parse(decompressed) as PlanleggerDataFromUrl;
             return mapPlanleggerDataToSøknadState(data, kjønn);
         } catch {
             return null;

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -90,7 +90,8 @@ export const PlanleggerDataInit = () => {
     const intl = useIntl();
 
     const dataParam = new URLSearchParams(locations.search).get('data');
-    const data = dataParam ? (JSON.parse(decompressFromUrl(dataParam)) as ContextDataMap) : undefined;
+    const decompressedData = dataParam ? decompressFromUrl(dataParam) : undefined;
+    const data = decompressedData ? (JSON.parse(decompressedData) as ContextDataMap) : undefined;
 
     // Denne useEffecten kjøres for at skyra-undersøkelsen skal trigges inline på oppsummering-siden
     useEffect(() => {

--- a/packages/utils/src/urlEncodingUtils.test.ts
+++ b/packages/utils/src/urlEncodingUtils.test.ts
@@ -35,4 +35,10 @@ describe('urlEncodingUtils', () => {
         const gammelBase64 = encodeToBase64(json);
         expect(decompressFromUrl(gammelBase64)).toBe(decodeBase64(gammelBase64));
     });
+
+    it('returnerer undefined for ugyldig/korrupt input uten å kaste', () => {
+        // Verdi som hverken er lz-komprimert JSON eller gyldig base64 (kaster InvalidCharacterError i atob).
+        expect(() => decompressFromUrl('%%%ugyldig%%%')).not.toThrow();
+        expect(decompressFromUrl('%%%ugyldig%%%')).toBeUndefined();
+    });
 });

--- a/packages/utils/src/urlEncodingUtils.ts
+++ b/packages/utils/src/urlEncodingUtils.ts
@@ -69,12 +69,20 @@ const isParsableJson = (value: string | null): value is string => {
  *
  * Faller tilbake til {@link decodeBase64} dersom verdien ikke er lz-komprimert. Det gjør at gamle
  * delte lenker (base64-format) fortsatt fungerer i en overgangsperiode. Returnerer en JSON-streng
- * som kaller-koden selv må `JSON.parse`-e.
+ * som kaller-koden selv må `JSON.parse`-e, eller `undefined` dersom verdien er ugyldig/korrupt.
  */
-export const decompressFromUrl = (valueFromUrl: string) => {
+export const decompressFromUrl = (valueFromUrl: string): string | undefined => {
     const decompressed = decompressFromEncodedURIComponent(valueFromUrl);
     if (isParsableJson(decompressed)) {
         return decompressed;
     }
-    return decodeBase64(valueFromUrl);
+    try {
+        const decoded = decodeBase64(valueFromUrl);
+        if (isParsableJson(decoded)) {
+            return decoded;
+        }
+    } catch {
+        // Verdien er hverken lz-komprimert JSON eller gyldig base64 (atob kaster InvalidCharacterError).
+    }
+    return undefined;
 };


### PR DESCRIPTION
decompressFromUrl kastet InvalidCharacterError fra atob() når data-parameteret verken var lz-komprimert JSON eller gyldig base64. Funksjonen returnerer nå undefined for ugyldig/korrupt input, og kallerne håndterer dette uten å krasje.

https://sentry.gc.nav.no/organizations/nav/issues/644885/?project=181&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=8