### PR TITLE
fix: unngå krasj i uttaksplanforslag når FORELDREPENGER-konto mangler

### DIFF
--- a/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.test.ts
+++ b/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.test.ts
@@ -214,3 +214,57 @@ describe('ikkeDeltUttak - Adopsjon', () => {
         expect(forslag[1]!.tom).toEqual('2023-01-13');
     });
 });
+
+describe('ikkeDeltUttak - mangler FORELDREPENGER-konto', () => {
+    const famDato = '2022-08-08';
+    // Kvotesett som hører til delt uttak (begge har rett) inneholder ikke FORELDREPENGER.
+    const deltUttakKvoter = [
+        { konto: 'FORELDREPENGER_FØR_FØDSEL', dager: 15 },
+        { konto: 'MØDREKVOTE', dager: 75 },
+        { konto: 'FEDREKVOTE', dager: 75 },
+        { konto: 'FELLESPERIODE', dager: 80 },
+    ] satisfies KontoDto[];
+
+    it('skal returnere tom plan i stedet for å krasje når FORELDREPENGER-konto mangler ved fødsel', () => {
+        expect(() =>
+            ikkeDeltUttak({
+                situasjon: 'fødsel',
+                famDato,
+                erFarEllerMedmor: false,
+                tilgjengeligeStønadskvoter: deltUttakKvoter,
+                erMorUfør: false,
+                bareFarMedmorHarRett: false,
+                erAleneOmOmsorg: false,
+                farOgFar: false,
+            }),
+        ).not.toThrow();
+
+        const forslag = ikkeDeltUttak({
+            situasjon: 'fødsel',
+            famDato,
+            erFarEllerMedmor: false,
+            tilgjengeligeStønadskvoter: deltUttakKvoter,
+            erMorUfør: false,
+            bareFarMedmorHarRett: false,
+            erAleneOmOmsorg: false,
+            farOgFar: false,
+        });
+
+        expect(forslag).toEqual([]);
+    });
+
+    it('skal returnere tom plan i stedet for å krasje når FORELDREPENGER-konto mangler ved adopsjon', () => {
+        const forslag = ikkeDeltUttak({
+            situasjon: 'adopsjon',
+            famDato,
+            erFarEllerMedmor: false,
+            tilgjengeligeStønadskvoter: deltUttakKvoter,
+            erMorUfør: false,
+            bareFarMedmorHarRett: false,
+            erAleneOmOmsorg: false,
+            farOgFar: false,
+        });
+
+        expect(forslag).toEqual([]);
+    });
+});

--- a/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.ts
+++ b/packages/uttaksplan/src/utils/forslag/ikkeDeltUttak.ts
@@ -355,11 +355,18 @@ export const ikkeDeltUttak = ({
     );
     const aktivitetsfriKvote = tilgjengeligeStønadskvoter.find((konto) => konto.konto === 'AKTIVITETSFRI_KVOTE');
 
+    // Uten en FORELDREPENGER-konto finnes det ikke grunnlag for å lage et ikke-delt forslag.
+    // Dette skjer f.eks. når kvotesettet egentlig hører til delt uttak (MØDREKVOTE/FEDREKVOTE/FELLESPERIODE).
+    // Returner en tom plan i stedet for å krasje på konto.dager.
+    if (foreldrepengerKonto === undefined) {
+        return [];
+    }
+
     if (situasjon === 'adopsjon') {
         return ikkeDeltUttakAdopsjon({
             famDato,
             erFarEllerMedmor,
-            foreldrepengerKonto: foreldrepengerKonto!,
+            foreldrepengerKonto,
             erMorUfør,
             aktivitetsfriKvote,
             bareFarMedmorHarRett,
@@ -369,7 +376,7 @@ export const ikkeDeltUttak = ({
     return ikkeDeltUttakFødsel({
         famDato,
         erFarEllerMedmor,
-        foreldrepengerKonto: foreldrepengerKonto!,
+        foreldrepengerKonto,
         foreldrePengerFørFødselKonto,
         erMorUfør,
         aktivitetsfriKvote,


### PR DESCRIPTION
https://sentry.gc.nav.no/organizations/nav/issues/644937/?project=181&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=7

Sentry rapporterte "undefined is not an object (evaluating 't.dager')" fra ikkeDeltUttak.ts. Krasjet oppsto fordi ikkeDeltUttak slo opp FORELDREPENGER-kvoten og sendte den videre med non-null assertion (foreldrepengerKonto!). Når kvotesettet ikke inneholder en FORELDREPENGER-konto ble verdien undefined, og oppslaget foreldrepengerKonto.dager kastet TypeError.

Dette skjer når et kvotesett som egentlig hører til delt uttak (begge har rett: MØDREKVOTE/FEDREKVOTE/FELLESPERIODE, uten FORELDREPENGER) blir rutet inn i den ikke-delte forslagsbygget i planleggeren.

Fix: legg inn en guard i fellesinngangen ikkeDeltUttak. Når det ikke finnes en FORELDREPENGER-konto kan vi ikke bygge et ikke-delt forslag, så vi returnerer en tom plan i stedet for å krasje. Dette speiler hvordan søsterfunksjonen deltUttak allerede håndterer manglende kvoter defensivt, og de utrygge non-null assertionsene er fjernet siden den tidlige returen nå innsnevrer typen.

Fikset i det delte biblioteket (chokepoint) slik at både planlegger og foreldrepengesoknad beskyttes. foreldrepengesoknad har alltid en FORELDREPENGER-konto i den ikke-delte stien, så atferden der er uendret.

Lagt til tester som verifiserer at fødsel og adopsjon med et kvotesett uten FORELDREPENGER ikke lenger kaster, men returnerer en tom plan.