### PR TITLE
Chore: riktig syntax redirect

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -117,7 +117,8 @@ metadata:
   labels:
     team: teamforeldrepenger
   annotations:
-    haproxy.org/request-redirect: "code 301 location {{../ingress}}/$1"
+    haproxy.org/request-redirect: "{{../ingress}}"
+    haproxy.org/request-redirect-code: "301"
 spec:
   ingressClassName: {{ingressClassName}}
   rules:


### PR DESCRIPTION
Samme endring som for familie.nav.no 
Dropper å ta med $1 så man lander rett i foreldrepenge-oversikt-hovedsiden.