### PR TITLE
fix(planlegger): vis minsteInntekt (halvt G) uten desimaler

### DIFF
--- a/apps/planlegger/src/AppContainer.test.tsx
+++ b/apps/planlegger/src/AppContainer.test.tsx
@@ -61,7 +61,7 @@ describe('<AppContainer>', () => {
             expect(screen.getByText('Steg 4 av 9')).toBeInTheDocument();
             await userEvent.click(
                 screen.getByText(
-                    'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 274,50 kr eller mer det siste året',
+                    'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 275 kr eller mer det siste året',
                 ),
             );
             await userEvent.click(screen.getByText('Ja'));

--- a/apps/planlegger/src/Planlegger.test.tsx
+++ b/apps/planlegger/src/Planlegger.test.tsx
@@ -249,7 +249,7 @@ describe('<Planlegger>', () => {
             expect(screen.getByText('Steg 3 av 8')).toBeInTheDocument();
             await userEvent.click(
                 screen.getByText(
-                    'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 274,50 kr eller mer det siste året',
+                    'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 275 kr eller mer det siste året',
                 ),
             );
             await userEvent.click(screen.getByText('Ja'));

--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
@@ -38,7 +38,7 @@ describe('<ArbeidssituasjonSteg>', () => {
 
         await userEvent.click(
             screen.getByText(
-                `Har jobbet minst 6 av de siste 10 månedene og har tjent 68 274,50 kr eller mer det siste året`,
+                `Har jobbet minst 6 av de siste 10 månedene og har tjent 68 275 kr eller mer det siste året`,
             ),
         );
 
@@ -71,7 +71,7 @@ describe('<ArbeidssituasjonSteg>', () => {
 
         await userEvent.click(
             screen.getByText(
-                'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 274,50 kr eller mer det siste året',
+                'Har jobbet minst 6 av de siste 10 månedene og har tjent 68 275 kr eller mer det siste året',
             ),
         );
 

--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.tsx
@@ -78,7 +78,7 @@ export const ArbeidssituasjonSteg = ({ satser }: Props) => {
 
     const { ref, scrollToBottom } = useScrollBehaviour();
 
-    const minsteInntekt = formatCurrencyWithKr(finnSisteGrunnbeløp(satser) / 2);
+    const minsteInntekt = formatCurrencyWithKr(Math.round(finnSisteGrunnbeløp(satser) / 2));
 
     return (
         <PlanleggerStepPage ref={ref} steps={stepConfig} goToStep={navigator.goToNextStep}>

--- a/apps/planlegger/src/steps/arbeidssituasjon/info/AnnetInfoboks.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/info/AnnetInfoboks.tsx
@@ -46,7 +46,7 @@ export const AnnetInfoboks = ({ erAlenesøker, fornavn, erSøker2 = false, erFar
                 <BodyShort>
                     <FormattedMessage
                         id="Arbeidssituasjon.Ingen.Infoboks.ManHarIkkeRett"
-                        values={{ minsteInntekt: formatCurrencyWithKr(finnSisteGrunnbeløp(satser) / 2) }}
+                        values={{ minsteInntekt: formatCurrencyWithKr(Math.round(finnSisteGrunnbeløp(satser) / 2)) }}
                     />
                 </BodyShort>
                 {!erSøker2 && !erFarOgFar && (

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -40,7 +40,7 @@ describe('<OppsummeringSteg>', () => {
         expect(screen.getByText('Arbeidssituasjon')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Både Klara og Espen har jobbet minst 6 av de siste 10 månedene, og har tjent 68 274,50 kr eller mer det siste året.',
+                'Både Klara og Espen har jobbet minst 6 av de siste 10 månedene, og har tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
 
@@ -66,7 +66,7 @@ describe('<OppsummeringSteg>', () => {
         expect(screen.getByText('Arbeidssituasjon')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Både Klara og Esther har jobbet minst 6 av de siste 10 månedene, og har tjent 68 274,50 kr eller mer det siste året.',
+                'Både Klara og Esther har jobbet minst 6 av de siste 10 månedene, og har tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
 
@@ -108,12 +108,12 @@ describe('<OppsummeringSteg>', () => {
         expect(screen.getByText('Arbeidssituasjon')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Klara har jobbet minst 6 av de siste 10 månedene og tjent 68 274,50 kr eller mer det siste året.',
+                'Klara har jobbet minst 6 av de siste 10 månedene og tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Espen har ikke jobbet minst 6 av de siste 10 månedene og tjent 68 274,50 kr eller mer det siste året.',
+                'Espen har ikke jobbet minst 6 av de siste 10 månedene og tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
 
@@ -140,12 +140,12 @@ describe('<OppsummeringSteg>', () => {
         expect(screen.getByText('Arbeidssituasjon')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Espen har ikke jobbet minst 6 av de siste 10 månedene og tjent 68 274,50 kr eller mer det siste året.',
+                'Espen har ikke jobbet minst 6 av de siste 10 månedene og tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Hugo har jobbet minst 6 av de siste 10 månedene og tjent 68 274,50 kr eller mer det siste året.',
+                'Hugo har jobbet minst 6 av de siste 10 månedene og tjent 68 275 kr eller mer det siste året.',
             ),
         ).toBeInTheDocument();
 

--- a/apps/planlegger/src/steps/oppsummering/expansion-cards/OppgittInformasjon.tsx
+++ b/apps/planlegger/src/steps/oppsummering/expansion-cards/OppgittInformasjon.tsx
@@ -82,7 +82,7 @@ export const OppgittInformasjon = ({
 
     const erFarOgFarFødsel = hvemPlanlegger.type === HvemPlanleggerType.FAR_OG_FAR && !erAdoptert;
 
-    const minsteInntekt = formatCurrencyWithKr(finnSisteGrunnbeløp(satser) / 2);
+    const minsteInntekt = formatCurrencyWithKr(Math.round(finnSisteGrunnbeløp(satser) / 2));
 
     return (
         <VStack gap="space-40">

--- a/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.test.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.test.tsx
@@ -180,11 +180,9 @@ describe('<ArbeidssituasjonSide>', () => {
         expect(screen.getByText('Gjennomsnittlig årslønn')).toBeInTheDocument();
         expect(screen.getByText('12 000 kr')).toBeInTheDocument();
 
-        expect(
-            screen.getByText('Med årslønn under 68 274,50 kr har du ikke rett til foreldrepenger'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Med årslønn under 68 275 kr har du ikke rett til foreldrepenger')).toBeInTheDocument();
         expect(screen.getByText(/12 000 kr i året/)).toBeInTheDocument();
-        expect(screen.getByText(/68 274,50 kr i året/)).toBeInTheDocument();
+        expect(screen.getByText(/68 275 kr i året/)).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Se resultatet'));
 

--- a/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.test.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.test.tsx
@@ -72,11 +72,9 @@ describe('<OppsummeringSide>', () => {
 
         expect(await screen.findByText('Oppsummering')).toBeInTheDocument();
 
-        expect(
-            screen.getByText('Med årslønn under 68 274,50 kr har du ikke rett til foreldrepenger'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Med årslønn under 68 275 kr har du ikke rett til foreldrepenger')).toBeInTheDocument();
         expect(screen.getByText(/12 000 kr i året/)).toBeInTheDocument();
-        expect(screen.getByText(/68 274,50 kr i året/)).toBeInTheDocument();
+        expect(screen.getByText(/68 275 kr i året/)).toBeInTheDocument();
         expect(screen.getByText('Hva er engangsstønad?')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Beskrivelse

G = 136 549 kr gir G/2 = 68 274,5 kr, som vistes som «68 274,50 kr» i planleggeren.

Siden planleggeren er et estimeringsverktøy er avrunding passende. `Math.round()` sikrer at verdien alltid vises som heltall.

## Endringer
- `ArbeidssituasjonSteg.tsx` — avrunder minsteInntekt
- `AnnetInfoboks.tsx` — avrunder minsteInntekt
- `OppgittInformasjon.tsx` — avrunder minsteInntekt

Løser: TFP-6143