### PR TITLE
TFP-7041: tillat desimaler i graderingsfelt på mobil

### DIFF
--- a/packages/form-hooks/src/form-wrappers/RhfNumericField.tsx
+++ b/packages/form-hooks/src/form-wrappers/RhfNumericField.tsx
@@ -15,6 +15,7 @@ type Props<T extends FieldValues> = {
     maxLength?: number;
     className?: string;
     style?: CSSProperties;
+    inputMode?: 'numeric' | 'decimal';
     control: UseControllerProps<T>['control'];
 } & Omit<UseControllerProps<T>, 'control'>;
 
@@ -28,6 +29,7 @@ export const RhfNumericField = <T extends FieldValues>({
     maxLength,
     className,
     style,
+    inputMode = 'numeric',
     ...controllerProps
 }: Props<T>) => {
     const { name, control, disabled } = controllerProps;
@@ -61,7 +63,7 @@ export const RhfNumericField = <T extends FieldValues>({
             label={label}
             description={description}
             type="text"
-            inputMode="numeric"
+            inputMode={inputMode}
             error={getError(errors, name)}
             autoFocus={autoFocus}
             autoComplete="off"

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -447,6 +447,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                         name="samtidigUttaksprosentMor"
                         validate={[valideringSamtidigUttak(intl, stillingsprosentMor)]}
                         maxLength={5}
+                        inputMode="decimal"
                     />
                     <RhfNumericField
                         control={formMethods.control}
@@ -460,6 +461,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                         name="samtidigUttaksprosentFarMedmor"
                         validate={[valideringSamtidigUttak(intl, stillingsprosentFarMedmor)]}
                         maxLength={5}
+                        inputMode="decimal"
                     />
                 </>
             )}
@@ -503,6 +505,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                                     })}
                                     validate={[prosentValideringGradering(intl, samtidigUttaksprosentMor)]}
                                     maxLength={5}
+                                    inputMode="decimal"
                                 />
                                 {aktiveArbeidsforhold !== undefined && søker === 'MOR' && (
                                     <RhfRadioGroup
@@ -583,6 +586,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                                     )}
                                     validate={[prosentValideringGradering(intl, samtidigUttaksprosentFarMedmor)]}
                                     maxLength={5}
+                                    inputMode="decimal"
                                 />
 
                                 {aktiveArbeidsforhold !== undefined && søker === 'FAR_MEDMOR' && (


### PR DESCRIPTION
Graderingsfeltene (stillingsprosent og samtidig uttaksprosent) brukte inputMode="numeric", som på iOS gir et talltastatur uten desimalskilletegn. Brukere som skal jobbe f.eks. 2,67 % kunne derfor ikke skrive komma på mobil.

Legger til en valgfri inputMode-prop på RhfNumericField (default "numeric") og setter inputMode="decimal" på prosentfeltene i uttaksplanen, slik at iOS viser desimaltastatur. Parsing og validering håndterer allerede både komma og punktum.

https://jira.adeo.no/browse/TFP-7041