### PR TITLE
TFP-7046: rett ukenummer i januar i kalenderen

### DIFF
--- a/packages/ui/src/calendar/Calendar.test.tsx
+++ b/packages/ui/src/calendar/Calendar.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 
 import * as stories from './Calendar.stories';
 
@@ -40,5 +40,16 @@ describe('<Calendar>', () => {
         expect(screen.getByText('Mai 2024')).toBeInTheDocument();
         expect(screen.getByText('Juni 2024')).toBeInTheDocument();
         expect(screen.getByText('Juli 2024')).toBeInTheDocument();
+    });
+
+    it('skal vise korrekte ukenummer i januar (skal ikke telle videre fra forrige år)', async () => {
+        render(<PeriodsThatSpanOverAYear />);
+
+        const januar2025 = await screen.findByTestId('year:2025;month:0');
+        const ukenummer = within(januar2025)
+            .getAllByTestId('ukenummer')
+            .map((el) => el.textContent);
+
+        expect(ukenummer).toEqual(['1', '2', '3', '4', '5']);
     });
 });

--- a/packages/ui/src/calendar/Month.tsx
+++ b/packages/ui/src/calendar/Month.tsx
@@ -77,7 +77,6 @@ export const Month = React.memo(
         const daysInMonth = firstDayOfMonth.daysInMonth();
         const startWeekDay = firstDayOfMonth.isoWeekday();
         const endWeekDay = firstDayOfMonth.endOf('month').isoWeekday();
-        const firstWeekNrOfMonth = firstDayOfMonth.isoWeek();
 
         const nrOfWeeks = Math.ceil((daysInMonth + (startWeekDay - 1) + (7 - endWeekDay)) / 7);
 
@@ -111,13 +110,18 @@ export const Month = React.memo(
                         </HGrid>
 
                         {Array.from({ length: nrOfWeeks }).map((_, week) => {
+                            const weekNr = firstDayOfMonth
+                                .add(week * 7 - (startWeekDay - 1), 'day')
+                                .isoWeek();
                             return (
-                                // eslint-disable-next-line @eslint-react/no-array-index-key
-                                <HGrid key={`week-${week}`} columns={nrOfColumns}>
+                                <HGrid key={`week-${weekNr}`} columns={nrOfColumns}>
                                     {showWeekNumbers && (
-                                        // eslint-disable-next-line @eslint-react/no-array-index-key
-                                        <div key={`weeknr-${week}`} className={styles.weeknr}>
-                                            {firstWeekNrOfMonth + week}
+                                        <div
+                                            key={`weeknr-${weekNr}`}
+                                            className={styles.weeknr}
+                                            data-testid="ukenummer"
+                                        >
+                                            {weekNr}
                                         </div>
                                     )}
                                     {Array.from({ length: 7 }).map((__, day) => {


### PR DESCRIPTION
Ukenummeret ble regnet ut som ISO-uke for første uke i måneden pluss et løpende indeks, slik at januar fortsatte å telle videre fra forrige års uke 52/53 (53, 54, 55 ...) i stedet for å nullstille til uke 1 ved årsskiftet. Hver ukerad regner nå ut sitt eget ISO-ukenummer.

https://jira.adeo.no/browse/TFP-7046