### PR TITLE
fix(veiviser): vis minste årslønn (halvt G) uten desimaler

### DIFF
--- a/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.tsx
@@ -17,7 +17,7 @@ import { HvorMyeOgHvaSkjerNåLinkPanel } from './HvorMyeOgHvaSkjerNåLinkPanel';
 
 const finnHvemSomHarRett = (fpEllerEsSituasjon: FpEllerEsSituasjon, satser: Satser) => {
     const grunnbeløpet = finnSisteGrunnbeløp(satser);
-    const minstelønn = grunnbeløpet / 2;
+    const minstelønn = Math.round(grunnbeløpet / 2);
 
     const { situasjon, lønnPerMåned, borDuINorge, jobberDuINorge } = fpEllerEsSituasjon;
     const lønnPerMånedNummer = formatValue(lønnPerMåned);

--- a/apps/veiviser-fp-eller-es/src/pages/oppsummering/boxes/HvorforHarJegIkkeRettPanel.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/oppsummering/boxes/HvorforHarJegIkkeRettPanel.tsx
@@ -19,7 +19,7 @@ interface Props {
 export const HvorforHarJegIkkeRettPanel = ({ fpEllerEsSituasjon, grunnbeløpet }: Props) => {
     const { borDuINorge, jobberDuINorge, lønnPerMåned, harHattInntekt } = fpEllerEsSituasjon;
 
-    const minstelønn = grunnbeløpet / 2;
+    const minstelønn = Math.round(grunnbeløpet / 2);
     const årslønn = lønnPerMåned && isValidNumber(lønnPerMåned) ? Number(lønnPerMåned) * 12 : 0;
 
     return (

--- a/apps/veiviser-fp-eller-es/src/pages/oppsummering/boxes/HvorforHarJegRettPanel.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/oppsummering/boxes/HvorforHarJegRettPanel.tsx
@@ -18,7 +18,7 @@ interface Props {
 export const HvorforHarJegRettPanel = ({ fpEllerEsSituasjon, grunnbeløpet }: Props) => {
     const { borDuINorge, jobberDuINorge, lønnPerMåned } = fpEllerEsSituasjon;
 
-    const minstelønn = grunnbeløpet / 2;
+    const minstelønn = Math.round(grunnbeløpet / 2);
     const årslønn = isValidNumber(lønnPerMåned) ? Number(lønnPerMåned) * 12 : 0;
 
     return (

--- a/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.tsx
@@ -84,7 +84,7 @@ export const SituasjonSide = ({ satser, fpEllerEsSituasjon, setFpEllerEsSituasjo
     };
 
     const grunnbeløpet = finnSisteGrunnbeløp(satser);
-    const minstelønn = grunnbeløpet / 2;
+    const minstelønn = Math.round(grunnbeløpet / 2);
     const lønnPerMånedNummer = formatValue(lønnPerMåned) ?? 0;
 
     const { ref, scrollToBottom } = useScrollBehaviour();

--- a/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.tsx
@@ -77,7 +77,7 @@ export const ArbeidssituasjonSide = ({ arbeidssituasjon, setArbeidssituasjon, sa
     const antattÅrslønn = gjennomsnittslønnPerMåned ? Number.parseFloat(gjennomsnittslønnPerMåned) * 12 : undefined;
 
     const grunnbeløpet = finnSisteGrunnbeløp(satser);
-    const minÅrslønn = grunnbeløpet / 2;
+    const minÅrslønn = Math.round(grunnbeløpet / 2);
     const maxÅrslønn = grunnbeløpet * 6;
 
     const { ref } = useScrollBehaviour();

--- a/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.tsx
@@ -57,7 +57,7 @@ export const OppsummeringSide = ({ arbeidssituasjon, stønadskvoter, satser }: P
 
     const grunnbeløpet = finnSisteGrunnbeløp(satser);
     const grunnbeløpetGanger6 = grunnbeløpet * 6;
-    const minÅrslønn = grunnbeløpet / 2;
+    const minÅrslønn = Math.round(grunnbeløpet / 2);
 
     const engangsstønad = finnSisteEngangsstønad(satser);
 


### PR DESCRIPTION
G = 136 549 kr gir G/2 = 68 274,5 kr, som vistes som «68 274,50 kr». Forrige commit oppdaterte testene i veiviser-hvor-mye til å forvente avrundede verdier, men kildekoden ble ikke endret. Math.round() sikrer at verdien alltid vises som heltall, både i veiviser-hvor-mye og veiviser-fp-eller-es.