### PR TITLE
TFP-7048: tillat far å søke overta mødrekvote uten egen uttaksperiode

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.test.ts
@@ -1,6 +1,6 @@
 import { UttakPeriode_fpoversikt, UttakPeriodeAnnenpartEøs_fpoversikt } from '@navikt/fp-types';
 
-import { erSammePeriodeInkludertDatoer, harBrukerKunSlettetPerioder } from './submitValidering';
+import { erSammePeriodeInkludertDatoer, harBrukerKunSlettetPerioder, harMinstEnUttaksEllerOverføringsperiode } from './submitValidering';
 
 const innvilget: UttakPeriode_fpoversikt['resultat'] = {
     innvilget: true,
@@ -127,6 +127,49 @@ describe('harBrukerKunSlettetPerioder', () => {
         it('returnerer false når perioder er undefined', () => {
             expect(harBrukerKunSlettetPerioder(undefined, [A, B])).toBe(false);
         });
+    });
+});
+
+/**
+ * harMinstEnUttaksEllerOverføringsperiode brukes i submitvalideringa for å avgjere om
+ * ein ny søknad har minst eitt reelt uttak. Far som overtek mødrekvote (overføring fordi
+ * mor er for sjuk) skal kunne søkje utan å måtte leggje inn ei ekstra uttaksperiode
+ * (regresjon: TFP-7048).
+ */
+describe('harMinstEnUttaksEllerOverføringsperiode', () => {
+    it('returnerer true for en vanlig uttaksperiode', () => {
+        expect(harMinstEnUttaksEllerOverføringsperiode([lagPeriode()])).toBe(true);
+    });
+
+    it('returnerer true når far kun har lagt inn overtakelse av mødrekvote (SYKDOM_ANNEN_FORELDER)', () => {
+        const overføring = lagPeriode({
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'MØDREKVOTE',
+            overføringÅrsak: 'SYKDOM_ANNEN_FORELDER',
+        });
+        expect(harMinstEnUttaksEllerOverføringsperiode([overføring])).toBe(true);
+    });
+
+    it('returnerer true når far kun har lagt inn overtakelse (INSTITUSJONSOPPHOLD_ANNEN_FORELDER)', () => {
+        const overføring = lagPeriode({
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'MØDREKVOTE',
+            overføringÅrsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
+        });
+        expect(harMinstEnUttaksEllerOverføringsperiode([overføring])).toBe(true);
+    });
+
+    it('returnerer false når planen kun inneholder utsettelser', () => {
+        const utsettelse = lagPeriode({ utsettelseÅrsak: 'ARBEID', resultat: undefined });
+        expect(harMinstEnUttaksEllerOverføringsperiode([utsettelse])).toBe(false);
+    });
+
+    it('returnerer false for tom plan', () => {
+        expect(harMinstEnUttaksEllerOverføringsperiode([])).toBe(false);
+    });
+
+    it('returnerer false når planen kun inneholder EØS-perioder', () => {
+        expect(harMinstEnUttaksEllerOverføringsperiode([lagEøsPeriode()])).toBe(false);
     });
 });
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -50,7 +50,7 @@ export const useFinnFørsteSubmitFeilmelding = ({
         perioder.length === 0 && !harBrukerKunSlettetPerioder(uttaksplan, opprinneligPlan);
 
     const manglerUttaksperioderForNySøknad = (perioder: UttaksplanPerioder) =>
-        !erEndringssøknad && !perioder.some((periode) => Uttaksperioden.erUttaksperiode(periode));
+        !erEndringssøknad && !harMinstEnUttaksEllerOverføringsperiode(perioder);
 
     const harOvertrukketDager = () => erAntallDagerOvertrukket;
 
@@ -148,6 +148,13 @@ export const harKunPerioderForAnnenForelder = (
 
     return perioder.every((periode) => Uttaksperioden.erEøsPeriode(periode) || periode.forelder !== søkersForelder);
 };
+
+// Ein overføringsperiode (t.d. far som overtek mødrekvote fordi mor er for sjuk) er eit
+// reelt uttak av foreldrepengar, og er ein gyldig søknad åleine på lik linje med ein uttaksperiode.
+export const harMinstEnUttaksEllerOverføringsperiode = (perioder: UttaksplanPerioder) =>
+    perioder.some(
+        (periode) => Uttaksperioden.erUttaksperiode(periode) || Uttaksperioden.erOverføringsperiode(periode),
+    );
 
 export const erKunUtsettelser = (perioder: UttaksplanPerioder) => {
     if (perioder.length === 0) {


### PR DESCRIPTION
Far som overtar mødrekvote fordi mor er for syk fikk feilmeldingen "Du må ha minst én uttaksperiode i planen." fordi en overføringsperiode ikke ble regnet som et reelt uttak i submitvalideringen.

Submitregelen godtar nå både uttaksperioder og overføringsperioder, slik at far kan søke om kun overtatt mødrekvote uten å måtte legge inn en ekstra dag av egen kvote.

https://jira.adeo.no/browse/TFP-7048