### PR TITLE
fix: avrund halvt G til nærmeste krone på SVP-forsiden

### DIFF
--- a/apps/svangerskapspengesoknad/src/pages/forside/Forside.test.tsx
+++ b/apps/svangerskapspengesoknad/src/pages/forside/Forside.test.tsx
@@ -46,6 +46,14 @@ describe('<Forside>', () => {
         expect(mellomlagreSøknadOgNaviger).toHaveBeenCalledOnce();
     });
 
+    it('skal vise avrundet minimumOpptjening uten desimaler', async () => {
+        render(<Default />);
+
+        const punkt = await screen.findByText(/Du må ha tjent minst/);
+        expect(punkt).toBeInTheDocument();
+        expect(punkt.textContent).not.toMatch(/,\d\d/);
+    });
+
     it('skal vise info om åpenbehandling', async () => {
         const setHarGodkjentVilkår = vi.fn();
         const gåTilNesteSide = vi.fn();

--- a/apps/svangerskapspengesoknad/src/pages/forside/Forside.tsx
+++ b/apps/svangerskapspengesoknad/src/pages/forside/Forside.tsx
@@ -22,7 +22,7 @@ export const Forside = ({ mellomlagreSøknadOgNaviger, setHarGodkjentVilkår, ha
 
     const oppdaterAppRoute = useContextSaveData(ContextDataType.APP_ROUTE);
 
-    const minimumOpptjening = DEFAULT_SATSER.grunnbeløp[0]!.verdi * 0.5;
+    const minimumOpptjening = Math.round(DEFAULT_SATSER.grunnbeløp[0]!.verdi * 0.5);
 
     const [isError, setIsError] = useState(false);
     const [isChecked, setIsChecked] = useState(harGodkjentVilkår);


### PR DESCRIPTION
## Endring

Avrunder `minimumOpptjening` (0,5 × grunnbeløp) med `Math.round` slik at beløpet vises uten desimaler på forsiden av svangerskapspengesøknaden.

**Eksempel:** `136 549 × 0,5 = 68 274,50 kr` → vises nå som `68 275 kr`

## Test

Lagt til test som verifiserer at beløpet ikke inneholder desimaler (f.eks. `,50`).