### PR TITLE
ci: stabiliser headless browser-testar

### DIFF
--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -73,7 +73,10 @@ jobs:
           PACKAGES_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Kjør browser tests
-        run: pnpm exec turbo run test:browser --filter=./apps/* --only --continue
+        # --concurrency=1: kjør én app av gangen. Headless chromium i CI (2 vCPU) blir
+        # CPU-svelta når alle appane sine browser-suiter køyrer samtidig, noko som gjev
+        # timeouts (også på screenshots) og userEvent-flytar som ikkje fullfører.
+        run: pnpm exec turbo run test:browser --filter=./apps/* --only --continue --concurrency=1
 
   knip-it:
     name: Kjør Knip

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.test.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
@@ -41,6 +41,10 @@ describe('<DokumentasjonSteg>', () => {
         const fileInput = screen.getByLabelText('Last opp bekreftelse på termindato');
 
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare, elles
+        // sender vi steget med eit uferdig vedlegg. Opplastinga er ekte async i browser-modus.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 
@@ -95,6 +99,9 @@ describe('<DokumentasjonSteg>', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Bekreftelse på adopsjon');
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
@@ -85,6 +85,9 @@ describe('<ManglendeVedlegg>', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Dokumentasjon av termindato');
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 
@@ -179,6 +182,9 @@ describe('<ManglendeVedlegg>', () => {
         const fileInput = screen.getByLabelText('Dokumentasjon om omsorgsovertakelse');
         await userEvent.upload(fileInput, file);
 
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
+
         await userEvent.click(screen.getByText('Neste steg'));
 
         expect(gåTilNesteSide).toHaveBeenCalledTimes(2);
@@ -271,6 +277,9 @@ describe('<ManglendeVedlegg>', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Dokumentasjon av aleneomsorg');
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/FpDataContext';
 
@@ -50,6 +50,10 @@ describe('<UttaksplanSteg>', () => {
         expect(await screen.findByText('Ønsker du å fjerne alt som er lagt til?')).toBeInTheDocument();
         const modal = screen.getByRole('dialog');
         await userEvent.click(within(modal).getByText('Fjern alt'));
+
+        // Vent til modalen er heilt lukka. Medan ho animerer ut er bakgrunnen
+        // aria-hidden, så knappar/element bak modalen finst ikkje i tilgjengelegheitstreet.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 
@@ -143,12 +147,18 @@ describe('<UttaksplanSteg>', () => {
         const fjernAltModal = screen.getByRole('dialog');
         await userEvent.click(within(fjernAltModal).getByText('Fjern alt'));
 
+        // Vent til 'Fjern alt'-modalen er heilt lukka før vi klikkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
         // Klikk på 'Tilbakestill plan'
         await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill plan' }));
         expect(await screen.findByText('Ønsker du å tilbakestille planen?')).toBeInTheDocument();
 
         // Avbryt lukker modalen uten å tilbakestille
         await userEvent.click(screen.getByText('Avbryt'));
+
+        // Vent til modalen er heilt lukka før vi sjekkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
         // Tilbakestill-knappen er fortsatt aktiv (planen er ikke tilbakestilt)
         expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).not.toBeDisabled();
@@ -178,12 +188,18 @@ describe('<UttaksplanSteg>', () => {
         const fjernAltModal2 = screen.getByRole('dialog');
         await userEvent.click(within(fjernAltModal2).getByText('Fjern alt'));
 
+        // Vent til 'Fjern alt'-modalen er heilt lukka før vi klikkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
         // Klikk på 'Tilbakestill plan'
         await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill plan' }));
         expect(await screen.findByText('Ønsker du å tilbakestille planen?')).toBeInTheDocument();
 
         // Bekreft tilbakestilling
         await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill' }));
+
+        // Vent til modalen er heilt lukka før vi sjekkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
         // Tilbakestill-knappen er nå deaktivert (planen er tilbakestilt til standardforslaget)
         expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).toBeDisabled();
@@ -263,12 +279,18 @@ describe('<UttaksplanSteg>', () => {
         const fjernAltModal = screen.getByRole('dialog');
         await userEvent.click(within(fjernAltModal).getByText('Fjern alt'));
 
+        // Vent til 'Fjern alt'-modalen er heilt lukka før vi sjekkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
         expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).not.toBeDisabled();
 
         // Tilbakestill plan skal hente opp den overførte planen igjen
         await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill plan' }));
         expect(await screen.findByText('Ønsker du å tilbakestille planen?')).toBeInTheDocument();
         await userEvent.click(screen.getByRole('button', { name: 'Tilbakestill' }));
+
+        // Vent til modalen er heilt lukka før vi sjekkar bakgrunnsknappen.
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
         // Planen er tilbake til utgangspunktet, så "Tilbakestill plan" er deaktivert igjen
         expect(screen.getByRole('button', { name: 'Tilbakestill plan' })).toBeDisabled();

--- a/apps/svangerskapspengesoknad/src/AppContainer.test.tsx
+++ b/apps/svangerskapspengesoknad/src/AppContainer.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
 
@@ -58,6 +58,10 @@ describe('<AppContainer>', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Last opp skjema for risiko og tilrettelegging i svangerskapet');
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
+
         await userEvent.click(screen.getByText('Neste steg'));
 
         expect(await screen.findByText('Steg 6 av 8')).toBeInTheDocument();

--- a/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.test.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-vite';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/SvpDataContext';
 import { SøknadRoute, addTilretteleggingIdToRoute } from 'appData/routes';
@@ -31,6 +31,9 @@ describe('<SkjemaSteg>', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Last opp skjema for risiko og tilrettelegging i svangerskapet');
         await userEvent.upload(fileInput, file);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
         expect(screen.queryByText('Du må laste opp minst ett dokument')).not.toBeInTheDocument();
@@ -103,6 +106,9 @@ describe('<SkjemaSteg>', () => {
         const file1 = new File(['hello'], 'hello.png', { type: 'image/png' });
         const fileInput = screen.getByLabelText('Last opp skjema for risiko og tilrettelegging i svangerskapet');
         await userEvent.upload(fileInput, file1);
+
+        // Vent til opplastinga er ferdig (pending = false) før vi går vidare.
+        await waitFor(() => expect(screen.queryByText('Laster opp...')).not.toBeInTheDocument());
 
         await userEvent.click(screen.getByText('Neste steg'));
 

--- a/packages/config-vite/vite.config.mjs
+++ b/packages/config-vite/vite.config.mjs
@@ -78,6 +78,10 @@ const createConfig = (setupFileDirName) => {
                     extends: true,
                     test: {
                         name: 'browser',
+                        // Headless chromium i CI er tregare enn jsdom. Gje litt høgare
+                        // timeout slik at userEvent-flytar (opplasting, skriving av
+                        // datoar, fleirstegs-flytar) rekk å fullføre.
+                        testTimeout: 30000,
                         exclude: [
                             '**/intl.test.ts',
                             '**/node_modules/**',


### PR DESCRIPTION
Browser tests-jobben feila konsekvent fordi turbo køyrde alle appane sine browser-suiter parallelt. På ein 2-vCPU GitHub-runner gav det mange parallelle chromium-faner som svelta kvarandre på CPU, med timeouts (også på screenshots) og userEvent-flytar (opplasting, dato-skriving, fleirsteg) som ikkje fullførte.

- Køyr browser-testane med turbo --concurrency=1 slik at berre éin app køyrer av gangen og får heile runneren.
- Auk testTimeout til 30s for browser-prosjektet for litt headroom.