### PR TITLE
TFP-7061: skill foreldrepenger med og uten aktivitetskrav i telleverk

### DIFF
--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -255,6 +255,7 @@
     "RedigeringPanel.SamtidigUttakForelder": "{forelder, select, MOR {Mother} other {{erMedmor, select, true {Co-mother} other {Father}}}}",
     "RedigeringPanel.SamtidigUttak": " has {prosent} % {kvote, select, FELLESPERIODE {shared period} MØDREKVOTE {mother's quota} other {{erMedmor, select, true {co-mother's quota} other {father's quota}}}}",
     "RedigeringPanel.Foreldrepenger": "Parental benefits",
+    "RedigeringPanel.MedAktivitetskrav": "Parental benefits with activity requirements",
     "RedigeringPanel.UtenAktivitetskrav": "Parental benefits without activity requirements",
     "RedigeringPanel.Pleiepenger": "This period is rejected due to care benefits",
     "RedigeringPanel.KanMisteDager": "You lose days if you do not have parental benefits before the due date or in the first six weeks after birth.",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -240,6 +240,7 @@
     "RedigeringPanel.EksisterendePerioder": "Valgte datoer inneholder {antall, select, 1 {en eksisterende periode} other {eksisterende perioder}}:",
     "RedigeringPanel.MorHarForeldrepengerFørFødsel": "Foreldrepenger før fødsel",
     "RedigeringPanel.Foreldrepenger": "Foreldrepenger",
+    "RedigeringPanel.MedAktivitetskrav": "Foreldrepenger med aktivitetskrav",
     "RedigeringPanel.UtenAktivitetskrav": "Foreldrepenger uten aktivitetskrav",
     "RedigeringPanel.Fellesperiode": "Fellesperiode",
     "RedigeringPanel.MorKvote": "Mors kvote",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -238,6 +238,7 @@
     "RedigeringPanel.EksisterendePerioder": "Valgte datoar inneheld {antall, select, 1 {ein eksisterande periode} other {eksisterande periodar}}:",
     "RedigeringPanel.MorHarForeldrepengerFørFødsel": "Foreldrepengar før fødsel",
     "RedigeringPanel.UtenAktivitetskrav": "Foreldrepengar uten aktivitetskrav",
+    "RedigeringPanel.MedAktivitetskrav": "Foreldrepengar med aktivitetskrav",
     "RedigeringPanel.Foreldrepenger": "Foreldrepengar",
     "RedigeringPanel.Fellesperiode": "Fellesperiode",
     "RedigeringPanel.MorKvote": "Mors kvote",

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
@@ -423,6 +423,11 @@ const PeriodeKvoteType = ({
         periode.morsAktivitet === 'IKKE_OPPGITT';
 
     const bareFarMedmorHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
+    const erSøkersForeldrepengerMedAktivitetskrav =
+        erIkkeEøsUttakPeriode &&
+        periode.forelder === søker &&
+        periode.kontoType === 'FORELDREPENGER' &&
+        !erAktivitetsfri;
 
     if (periode.kontoType === 'FORELDREPENGER_FØR_FØDSEL') {
         return (
@@ -464,9 +469,7 @@ const PeriodeKvoteType = ({
         );
     }
     if (
-        (periode.kontoType === 'FORELDREPENGER' ||
-            (erIkkeEøsUttakPeriode && periode.oppholdÅrsak === 'FORELDREPENGER_ANNEN_FORELDER')) &&
-        !erAktivitetsfri &&
+        erSøkersForeldrepengerMedAktivitetskrav &&
         bareFarMedmorHarRett
     ) {
         return (

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/EksisterendeValgtePerioder.tsx
@@ -411,12 +411,18 @@ const PeriodeKvoteType = ({
     periode: UttakPeriodeMedAntallDager;
     erMedmorDelAvSøknaden: boolean;
 }) => {
+    const {
+        foreldreInfo: { søker, rettighetType },
+    } = useUttaksplanData();
+
     const erIkkeEøsUttakPeriode = erVanligUttakPeriode(periode);
 
     const erAktivitetsfri =
         erIkkeEøsUttakPeriode &&
         (periode.kontoType === 'FORELDREPENGER' || periode.oppholdÅrsak === 'FORELDREPENGER_ANNEN_FORELDER') &&
         periode.morsAktivitet === 'IKKE_OPPGITT';
+
+    const bareFarMedmorHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
 
     if (periode.kontoType === 'FORELDREPENGER_FØR_FØDSEL') {
         return (
@@ -454,6 +460,18 @@ const PeriodeKvoteType = ({
         return (
             <BodyShort>
                 <FormattedMessage id="RedigeringPanel.MedmorKvote" />
+            </BodyShort>
+        );
+    }
+    if (
+        (periode.kontoType === 'FORELDREPENGER' ||
+            (erIkkeEøsUttakPeriode && periode.oppholdÅrsak === 'FORELDREPENGER_ANNEN_FORELDER')) &&
+        !erAktivitetsfri &&
+        bareFarMedmorHarRett
+    ) {
+        return (
+            <BodyShort>
+                <FormattedMessage id="RedigeringPanel.MedAktivitetskrav" />
             </BodyShort>
         );
     }

--- a/packages/uttaksplan/src/kalender/redigering/utils/kalenderPeriodeUtils.test.ts
+++ b/packages/uttaksplan/src/kalender/redigering/utils/kalenderPeriodeUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { UttakPeriode_fpoversikt } from '@navikt/fp-types';
+import { CalendarPeriod } from '@navikt/fp-ui';
+
+import { erVanligUttakPeriode } from '../../../types/UttaksplanPeriode';
+import { finnValgtePerioder } from './kalenderPeriodeUtils';
+
+describe('finnValgtePerioder', () => {
+    it('skal ikke slå sammen foreldrepenger uten og med aktivitetskrav til én periode (kun far har rett)', () => {
+        const utenAktivitetskrav: UttakPeriode_fpoversikt = {
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FORELDREPENGER',
+            morsAktivitet: 'IKKE_OPPGITT',
+            fom: '2024-01-01',
+            tom: '2024-01-05',
+            flerbarnsdager: false,
+        };
+        const medAktivitetskrav: UttakPeriode_fpoversikt = {
+            forelder: 'FAR_MEDMOR',
+            kontoType: 'FORELDREPENGER',
+            morsAktivitet: undefined,
+            fom: '2024-01-08',
+            tom: '2024-01-12',
+            flerbarnsdager: false,
+        };
+
+        const valgtePerioder: CalendarPeriod[] = [
+            { fom: '2024-01-01', tom: '2024-01-12', color: 'BLUE', srText: '' },
+        ];
+
+        const resultat = finnValgtePerioder(valgtePerioder, [utenAktivitetskrav, medAktivitetskrav]);
+
+        expect(resultat).toHaveLength(2);
+        const aktivitetsfri = resultat.find((p) => erVanligUttakPeriode(p) && p.morsAktivitet === 'IKKE_OPPGITT');
+        const medKrav = resultat.find((p) => erVanligUttakPeriode(p) && p.morsAktivitet === undefined);
+        expect(aktivitetsfri?.valgteDagerIPeriode).toBe(5);
+        expect(medKrav?.valgteDagerIPeriode).toBe(5);
+    });
+});
+

--- a/packages/uttaksplan/src/kalender/redigering/utils/kalenderPeriodeUtils.ts
+++ b/packages/uttaksplan/src/kalender/redigering/utils/kalenderPeriodeUtils.ts
@@ -84,6 +84,7 @@ export const finnValgtePerioder = (
                     erVanligUttakPeriode(p) &&
                     erVanligUttakPeriode(curr) &&
                     p.forelder === curr.forelder &&
+                    p.morsAktivitet === curr.morsAktivitet &&
                     p.samtidigUttak === curr.samtidigUttak &&
                     p.gradering?.arbeidstidprosent === curr.gradering?.arbeidstidprosent &&
                     p.gradering?.aktivitet === curr.gradering?.aktivitet &&


### PR DESCRIPTION
Når kun far/medmor har rett ble foreldrepenger med og uten aktivitetskrav slått sammen i telleverket i legg-til-boksen, slik at alle dagene ble vist som uten aktivitetskrav. Sammenslåingen i finnValgtePerioder skiller nå på morsAktivitet. I tillegg vises teksten Foreldrepenger med aktivitetskrav for perioder med aktivitetskrav når kun far/medmor har rett.

Gjelder også planleggeren, som bruker samme kalender fra fp-uttaksplan.

https://jira.adeo.no/browse/TFP-7061