### PR TITLE
chore: oppgrader pnpm@11.9.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 @navikt:registry=https://npm.pkg.github.com
-min-release-age=3

--- a/apps/engangsstonad/package.json
+++ b/apps/engangsstonad/package.json
@@ -76,6 +76,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/apps/foreldrepengeoversikt/package.json
+++ b/apps/foreldrepengeoversikt/package.json
@@ -80,7 +80,6 @@
         "vite": "catalog:",
         "vitest": "catalog:"
     },
-    "packageManager": "pnpm@10.33.1",
     "msw": {
         "workerDirectory": [
             "mock-service-worker"

--- a/apps/foreldrepengesoknad/package.json
+++ b/apps/foreldrepengesoknad/package.json
@@ -84,6 +84,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/apps/planlegger/package.json
+++ b/apps/planlegger/package.json
@@ -76,6 +76,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/apps/svangerskapspengesoknad/package.json
+++ b/apps/svangerskapspengesoknad/package.json
@@ -80,6 +80,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "build": "turbo build",
-        "build:storybook": "turbo run build:storybook --force && pnpm run storybook-create-deploy-folder",
+        "build:storybook": "turbo run build:storybook && pnpm run storybook-create-deploy-folder",
         "test": "turbo test",
         "test:browser": "turbo run test:browser",
         "ci": "turbo run build test",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "build": "turbo build",
-        "build:storybook": "turbo run build:storybook && pnpm run storybook-create-deploy-folder",
+        "build:storybook": "turbo run build:storybook --force && pnpm run storybook-create-deploy-folder",
         "test": "turbo test",
         "test:browser": "turbo run test:browser",
         "ci": "turbo run build test",
@@ -35,7 +35,7 @@
         "apps/**/*.{ts,tsx,js,jsx, css}": "prettier --write",
         "packages/**/*.{ts,tsx,js,jsx, css}": "prettier --write"
     },
-    "packageManager": "pnpm@10.33.1",
+    "packageManager": "pnpm@11.9.0",
     "msw": {
         "workerDirectory": [
             "./scripts/mock-service-worker"

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -37,6 +37,5 @@
         "eslint": "catalog:",
         "typescript": "catalog:",
         "vite": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -6,7 +6,6 @@
     "peerDependencies": {
         "typescript": "catalog:"
     },
-    "packageManager": "pnpm@10.33.1",
     "scripts": {
         "tsc:watch": "tsc --noEmit --watch",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"

--- a/packages/config-vite/package.json
+++ b/packages/config-vite/package.json
@@ -13,7 +13,6 @@
         "vite-plugin-compression2": "2.5.3",
         "vitest": "catalog:"
     },
-    "packageManager": "pnpm@10.33.1",
     "scripts": {
         "tsc:watch": "tsc --noEmit --watch",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -19,6 +19,5 @@
         "@navikt/fp-config-typescript": "workspace:*",
         "eslint": "catalog:",
         "typescript": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/filopplaster/package.json
+++ b/packages/filopplaster/package.json
@@ -43,6 +43,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/form-hooks/package.json
+++ b/packages/form-hooks/package.json
@@ -53,6 +53,5 @@
     },
     "peerDependencies": {
         "react": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -31,6 +31,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -27,6 +27,5 @@
         "@types/node": "catalog:",
         "eslint": "catalog:",
         "typescript": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-arbeidsforhold-og-inntekt/package.json
+++ b/packages/steg-arbeidsforhold-og-inntekt/package.json
@@ -51,6 +51,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-egen-næring/package.json
+++ b/packages/steg-egen-næring/package.json
@@ -52,6 +52,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-frilans/package.json
+++ b/packages/steg-frilans/package.json
@@ -50,6 +50,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-kvittering/package.json
+++ b/packages/steg-kvittering/package.json
@@ -45,6 +45,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-oppsummering/package.json
+++ b/packages/steg-oppsummering/package.json
@@ -49,6 +49,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/steg-utenlandsopphold/package.json
+++ b/packages/steg-utenlandsopphold/package.json
@@ -52,6 +52,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,6 +22,5 @@
         "@navikt/fp-config-eslint": "workspace:*",
         "eslint": "catalog:",
         "typescript": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,6 +51,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -40,6 +40,5 @@
         "storybook": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,6 +35,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -29,6 +29,5 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3398,9 +3398,6 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@navikt/ds-tailwind@8.13.1':
     resolution: {integrity: sha512-19g2WjbyQLwBQtNQ2rXcFhD9heyMOXS5iQWilrzZyHNTnWfJlQVoIHyz+pQvwiPeEEq0rE13ftc+1xfIPxBP+A==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tailwind/8.13.1/b978ae1b8d063bee0783485d485aa57bd3167172}
@@ -8381,12 +8378,11 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@navikt/aksel-icons': 8.13.1
       '@navikt/ds-tokens': 8.13.1
+      '@types/react': 19.2.17
       date-fns: 4.4.0
       react: 19.2.7
       react-day-picker: 9.14.0(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
 
   '@navikt/ds-tailwind@8.13.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,9 @@ minimumReleaseAge: 4320 # minutter
 
 minimumReleaseAgeExclude:
   - '@navikt/*'
+  - '@napi-rs/wasm-runtime@1.1.6'
+  - playwright@1.61.1
+  - playwright-core@1.61.1
 
 allowBuilds:
   msw: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,9 +55,6 @@ minimumReleaseAge: 4320 # minutter
 
 minimumReleaseAgeExclude:
   - '@navikt/*'
-  - '@napi-rs/wasm-runtime@1.1.6'
-  - playwright@1.61.1
-  - playwright-core@1.61.1
 
 allowBuilds:
   msw: true

--- a/server-uinnlogget/package.json
+++ b/server-uinnlogget/package.json
@@ -21,6 +21,5 @@
         "@types/node": "catalog:",
         "esbuild": "catalog:",
         "typescript": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,5 @@
         "supertest": "7.2.2",
         "typescript": "catalog:",
         "vitest": "catalog:"
-    },
-    "packageManager": "pnpm@10.33.1"
+    }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://v2-10-0.turborepo.dev/schema.json",
     "globalPassThroughEnv": [
         "NODE_AUTH_TOKEN",
         "PACKAGES_AUTH_TOKEN",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://v2-10-0.turborepo.dev/schema.json",
+    "$schema": "https://turbo.build/schema.json",
     "globalPassThroughEnv": [
         "NODE_AUTH_TOKEN",
         "PACKAGES_AUTH_TOKEN",


### PR DESCRIPTION
Oppgraderer pnpm og setter minimum release age til 3d slik at vi følger playbooken sin anbefaling + at alle våre frontend-repo har 3 dager.

Grunnen for at jeg ønsker å oppgradere er fordi pnpm 11 har støtte for `pnpm audit --fix=update` som gjør at vi kan fikse sårbare peer dependencies direkte i lockfilen