### PR TITLE
TFP-7066: krev ikke mors aktivitet ved samtidig uttak under 100%

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -55,7 +55,11 @@ export const useFinnFørsteSubmitFeilmelding = ({
     const harOvertrukketDager = () => erAntallDagerOvertrukket;
 
     const manglerMorsAktivitetDerPåkrevd = (perioder: UttaksplanPerioder) =>
-        harPeriodeDerMorsAktivitetIkkeErValgt(utledRettighet(erAleneOmOmsorg, erDeltUttak), perioder);
+        harPeriodeDerMorsAktivitetIkkeErValgt(
+            utledRettighet(erAleneOmOmsorg, erDeltUttak),
+            erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR',
+            perioder,
+        );
 
     const manglerGraderingsaktivitet = (perioder: UttaksplanPerioder) => {
         const søkersForelder = erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR';

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/submitValidering.ts
@@ -58,6 +58,7 @@ export const useFinnFørsteSubmitFeilmelding = ({
         harPeriodeDerMorsAktivitetIkkeErValgt(
             utledRettighet(erAleneOmOmsorg, erDeltUttak),
             erSøkerFarEllerMedmor ? 'FAR_MEDMOR' : 'MOR',
+            false,
             perioder,
         );
 

--- a/packages/uttaksplan/src/kalender/Uttaksplankalender.stories.tsx
+++ b/packages/uttaksplan/src/kalender/Uttaksplankalender.stories.tsx
@@ -1184,7 +1184,7 @@ export const MarkerPeriodeNårFarHarFellesperiodeOgMorsAktivitetMåFyllesUt: Sto
         },
         foreldreInfo: {
             rettighetType: 'BEGGE_RETT',
-            søker: 'MOR',
+            søker: 'FAR_MEDMOR',
             navnPåForeldre: { mor: 'Hanne', farMedmor: 'Hans' },
             erMedmorDelAvSøknaden: false,
         },

--- a/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
+++ b/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
@@ -41,7 +41,7 @@ export const usePerioderForKalendervisning = (
 
     const {
         barn,
-        foreldreInfo: { søker, navnPåForeldre, rettighetType },
+        foreldreInfo: { søker, navnPåForeldre, rettighetType, erIkkeSøkerSpesifisert },
         familiehendelsedato,
         uttakPerioder,
         kanVelgeArbeidsgiver,
@@ -81,6 +81,7 @@ export const usePerioderForKalendervisning = (
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
                     søker,
+                    erIkkeSøkerSpesifisert ?? false,
                 ),
             ];
         }
@@ -103,6 +104,7 @@ export const usePerioderForKalendervisning = (
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
                     søker,
+                    erIkkeSøkerSpesifisert ?? false,
                 ),
             ];
         }
@@ -122,6 +124,7 @@ export const usePerioderForKalendervisning = (
                     uttakPerioder,
                     kanVelgeArbeidsgiver,
                     søker,
+                    erIkkeSøkerSpesifisert ?? false,
                 ),
             } satisfies CalendarPeriod,
         ];
@@ -361,6 +364,7 @@ const splittPeriodeITo = (
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     kanVelgeArbeidsgiver: boolean,
     søker: BrukerRolleSak_fpoversikt,
+    erIkkeSøkerSpesifisert: boolean,
 ): CalendarPeriod[] => {
     const forrige = Uttaksdagen.forrige(dato).getDato();
     const neste = Uttaksdagen.neste(dato).getDato();
@@ -370,6 +374,7 @@ const splittPeriodeITo = (
         allePerioder,
         kanVelgeArbeidsgiver,
         søker,
+        erIkkeSøkerSpesifisert,
     );
 
     const lagPeriode = (fom: string, tom: string): CalendarPeriod => ({
@@ -398,12 +403,16 @@ const leggTilVarselikonVedManglendeObligatoriskeValg = (
     allePerioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>,
     kanVelgeArbeidsgiver: boolean,
     søker: BrukerRolleSak_fpoversikt,
+    erIkkeSøkerSpesifisert: boolean,
 ) => {
     const morsPerioder = allePerioder.filter(
         (p): p is UttakPeriode_fpoversikt => erVanligUttakPeriode(p) && p.forelder === 'MOR',
     );
     if (
-        harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [periode, ...morsPerioder]) ||
+        harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, erIkkeSøkerSpesifisert, [
+            periode,
+            ...morsPerioder,
+        ]) ||
         (kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode], søker))
     ) {
         return {

--- a/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
+++ b/packages/uttaksplan/src/kalender/utils/usePerioderForKalendervisning.tsx
@@ -403,7 +403,7 @@ const leggTilVarselikonVedManglendeObligatoriskeValg = (
         (p): p is UttakPeriode_fpoversikt => erVanligUttakPeriode(p) && p.forelder === 'MOR',
     );
     if (
-        harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [periode, ...morsPerioder]) ||
+        harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [periode, ...morsPerioder]) ||
         (kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet([periode], søker))
     ) {
         return {

--- a/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
+++ b/packages/uttaksplan/src/liste/UttaksplanListe.stories.tsx
@@ -603,7 +603,7 @@ export const MarkeringNårFarHarFellesperiodeOgMorsAktivitetMåFyllesUt: Story =
         },
         foreldreInfo: {
             rettighetType: 'BEGGE_RETT',
-            søker: 'MOR',
+            søker: 'FAR_MEDMOR',
             navnPåForeldre: { mor: 'Hanne', farMedmor: 'Hans' },
             erMedmorDelAvSøknaden: false,
         },

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/EndrePeriodePanel.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/EndrePeriodePanel.tsx
@@ -26,7 +26,7 @@ export const EndrePeriodePanel = ({ closePanel, uttaksplanperioder }: Props) => 
     const erKunEnPeriodeEllerSamtidigUttak = uttaksplanperioder.length === 1 || erSamtidigUttak;
 
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
         uttakPerioder,
     } = useUttaksplanData();
 
@@ -60,7 +60,7 @@ export const EndrePeriodePanel = ({ closePanel, uttaksplanperioder }: Props) => 
                             !erSamtidigUttak && uttaksplanperioder.length !== 1 ? setValgtPeriodeIndex : undefined
                         }
                         erNyPeriodeModus={false}
-                        harPeriodeDerMorsAktivitetIkkeErValgt={harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [
+                        harPeriodeDerMorsAktivitetIkkeErValgt={harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, erIkkeSøkerSpesifisert ?? false, [
                             finnUttakplanperiode(erSamtidigUttak, uttaksplanperioder, valgtPeriodeIndex),
                             ...uttakPerioder.filter(
                                 (mp): mp is UttakPeriode_fpoversikt => !erEøsUttakPeriode(mp) && mp.forelder === 'MOR',

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/EndrePeriodePanel.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/EndrePeriodePanel.tsx
@@ -26,7 +26,7 @@ export const EndrePeriodePanel = ({ closePanel, uttaksplanperioder }: Props) => 
     const erKunEnPeriodeEllerSamtidigUttak = uttaksplanperioder.length === 1 || erSamtidigUttak;
 
     const {
-        foreldreInfo: { rettighetType },
+        foreldreInfo: { rettighetType, søker },
         uttakPerioder,
     } = useUttaksplanData();
 
@@ -60,7 +60,7 @@ export const EndrePeriodePanel = ({ closePanel, uttaksplanperioder }: Props) => 
                             !erSamtidigUttak && uttaksplanperioder.length !== 1 ? setValgtPeriodeIndex : undefined
                         }
                         erNyPeriodeModus={false}
-                        harPeriodeDerMorsAktivitetIkkeErValgt={harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [
+                        harPeriodeDerMorsAktivitetIkkeErValgt={harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [
                             finnUttakplanperiode(erSamtidigUttak, uttaksplanperioder, valgtPeriodeIndex),
                             ...uttakPerioder.filter(
                                 (mp): mp is UttakPeriode_fpoversikt => !erEøsUttakPeriode(mp) && mp.forelder === 'MOR',

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -31,7 +31,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
     const intl = useIntl();
 
     const {
-        foreldreInfo: { søker, navnPåForeldre, rettighetType },
+        foreldreInfo: { søker, navnPåForeldre, rettighetType, erIkkeSøkerSpesifisert },
         uttakPerioder,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -68,7 +68,10 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                         return (
                             <Radio key={genererPeriodeKey(p)} value={index} autoFocus={index === 0}>
                                 <HStack gap="space-4">
-                                    {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [p, ...morsPerioder]) && (
+                                    {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, erIkkeSøkerSpesifisert ?? false, [
+                                        p,
+                                        ...morsPerioder,
+                                    ]) && (
                                         <ExclamationmarkTriangleFillIcon
                                             title={intl.formatMessage({
                                                 id: 'PeriodeListeHeader.MorsAktivitetIkkeValgt',

--- a/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/endre-periode-panel/VelgPeriodePanelStep.tsx
@@ -68,7 +68,7 @@ export const VelgPeriodePanelStep = ({ perioder, setValgtPeriodeIndex, closePane
                         return (
                             <Radio key={genererPeriodeKey(p)} value={index} autoFocus={index === 0}>
                                 <HStack gap="space-4">
-                                    {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [p, ...morsPerioder]) && (
+                                    {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [p, ...morsPerioder]) && (
                                         <ExclamationmarkTriangleFillIcon
                                             title={intl.formatMessage({
                                                 id: 'PeriodeListeHeader.MorsAktivitetIkkeValgt',

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
@@ -29,7 +29,7 @@ interface Props {
 export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåForeldre, erFarEllerMedmor }: Props) => {
     const intl = useIntl();
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
         uttakPerioder,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -52,7 +52,10 @@ export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåF
 
     return (
         <HStack gap="space-8">
-            {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [periode, ...morsPerioder]) && (
+            {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, erIkkeSøkerSpesifisert ?? false, [
+                periode,
+                ...morsPerioder,
+            ]) && (
                 <ExclamationmarkTriangleFillIcon
                     title={intl.formatMessage({ id: 'PeriodeListeHeader.MorsAktivitetIkkeValgt' })}
                     fontSize="1.5rem"

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-content/components/UttaksperiodeContent.tsx
@@ -52,7 +52,7 @@ export const UttaksperiodeContent = ({ periode, inneholderKunEnPeriode, navnPåF
 
     return (
         <HStack gap="space-8">
-            {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, [periode, ...morsPerioder]) && (
+            {harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, [periode, ...morsPerioder]) && (
                 <ExclamationmarkTriangleFillIcon
                     title={intl.formatMessage({ id: 'PeriodeListeHeader.MorsAktivitetIkkeValgt' })}
                     fontSize="1.5rem"

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
@@ -31,7 +31,7 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
 
     const {
         familiehendelsedato,
-        foreldreInfo: { rettighetType, søker, navnPåForeldre },
+        foreldreInfo: { rettighetType, søker, navnPåForeldre, erIkkeSøkerSpesifisert },
         familiesituasjon,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -56,7 +56,12 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
         rettighetType === 'BEGGE_RETT',
     );
 
-    const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, uttaksplanperioder);
+    const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(
+        rettighetType,
+        søker,
+        erIkkeSøkerSpesifisert ?? false,
+        uttaksplanperioder,
+    );
     const harUkjentGraderingsaktivitet =
         kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder, søker);
     const harValideringsfeil = harMorsAktivitetIkkeErValgt || harUkjentGraderingsaktivitet;

--- a/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
+++ b/packages/uttaksplan/src/liste/periode-liste-item/periode-liste-header/PeriodeListeHeader.tsx
@@ -56,7 +56,7 @@ export const PeriodeListeHeader = ({ uttaksplanperioder, isOpen }: Props) => {
         rettighetType === 'BEGGE_RETT',
     );
 
-    const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, uttaksplanperioder);
+    const harMorsAktivitetIkkeErValgt = harPeriodeDerMorsAktivitetIkkeErValgt(rettighetType, søker, uttaksplanperioder);
     const harUkjentGraderingsaktivitet =
         kanVelgeArbeidsgiver && harPeriodeMedUkjentGraderingsaktivitet(uttaksplanperioder, søker);
     const harValideringsfeil = harMorsAktivitetIkkeErValgt || harUkjentGraderingsaktivitet;

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -76,7 +76,7 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
     periode: Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager,
 ) => { morsAktivitetIkkeValgt?: AktivAlertMetadata; graderingsaktivitetIkkeValgt?: AktivAlertMetadata }) => {
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
         uttakPerioder,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -89,6 +89,7 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
         morsAktivitetIkkeValgt: tilAktiv(MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE, {
             rettighetType,
             søker,
+            erIkkeSøkerSpesifisert: erIkkeSøkerSpesifisert ?? false,
             periode,
             morsUttakPerioder,
         }),
@@ -104,11 +105,16 @@ export const useUttaksplanListeAlerts = (
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>,
 ): UttaksplanListeAlerts => {
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
-        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_LISTE, { rettighetType, søker, perioder }),
+        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_LISTE, {
+            rettighetType,
+            søker,
+            erIkkeSøkerSpesifisert: erIkkeSøkerSpesifisert ?? false,
+            perioder,
+        }),
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_LISTE, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
@@ -123,11 +129,16 @@ export const useUttaksplanKalenderAlerts = (
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>,
 ): UttaksplanKalenderAlerts => {
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
-        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_KALENDER, { rettighetType, søker, perioder }),
+        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_KALENDER, {
+            rettighetType,
+            søker,
+            erIkkeSøkerSpesifisert: erIkkeSøkerSpesifisert ?? false,
+            perioder,
+        }),
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_KALENDER, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
@@ -142,12 +153,13 @@ export const useLeggTilEndreSkjemaInfoAlerts = (
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>,
 ): LeggTilEndreSkjemaInfoAlerts => {
     const {
-        foreldreInfo: { rettighetType, søker },
+        foreldreInfo: { rettighetType, søker, erIkkeSøkerSpesifisert },
     } = useUttaksplanData();
     return {
         morsAktivitetIkkeOppgittAlert: tilAktiv(MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING, {
             rettighetType,
             søker,
+            erIkkeSøkerSpesifisert: erIkkeSøkerSpesifisert ?? false,
             perioder,
         }),
     };

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -88,6 +88,7 @@ export const useEksisterendeValgtePeriodeAlerts = (): ((
     return (periode) => ({
         morsAktivitetIkkeValgt: tilAktiv(MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE, {
             rettighetType,
+            søker,
             periode,
             morsUttakPerioder,
         }),
@@ -107,7 +108,7 @@ export const useUttaksplanListeAlerts = (
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
-        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_LISTE, { rettighetType, perioder }),
+        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_LISTE, { rettighetType, søker, perioder }),
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_LISTE, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
@@ -126,7 +127,7 @@ export const useUttaksplanKalenderAlerts = (
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
     return {
-        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_KALENDER, { rettighetType, perioder }),
+        manglerMorsAktivitetAlert: tilAktiv(MANGLER_MORS_AKTIVITET_KALENDER, { rettighetType, søker, perioder }),
         manglerGraderingsaktivitetAlert: kanVelgeArbeidsgiver
             ? tilAktiv(MANGLER_GRADERINGSAKTIVITET_KALENDER, {
                   perioder: filtrerSøkersIkkeEøsPerioder(perioder, søker),
@@ -141,10 +142,14 @@ export const useLeggTilEndreSkjemaInfoAlerts = (
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>,
 ): LeggTilEndreSkjemaInfoAlerts => {
     const {
-        foreldreInfo: { rettighetType },
+        foreldreInfo: { rettighetType, søker },
     } = useUttaksplanData();
     return {
-        morsAktivitetIkkeOppgittAlert: tilAktiv(MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING, { rettighetType, perioder }),
+        morsAktivitetIkkeOppgittAlert: tilAktiv(MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING, {
+            rettighetType,
+            søker,
+            perioder,
+        }),
     };
 };
 

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
@@ -24,12 +24,14 @@ dayjs.extend(isSameOrAfter);
 type MorsAktivitetListeKontekst = {
     rettighetType: RettighetType_fpoversikt;
     søker: BrukerRolleSak_fpoversikt;
+    erIkkeSøkerSpesifisert: boolean;
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>;
 };
 
 type EksisterendeValgtePeriodeKontekst = {
     rettighetType: RettighetType_fpoversikt;
     søker: BrukerRolleSak_fpoversikt;
+    erIkkeSøkerSpesifisert: boolean;
     periode: Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager;
     morsUttakPerioder: readonly UttakPeriode_fpoversikt[];
 };
@@ -78,7 +80,7 @@ export const MANGLER_MORS_AKTIVITET_LISTE = lagAlertregel<MorsAktivitetListeKont
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, ctx.erIkkeSøkerSpesifisert, [...ctx.perioder]),
 });
 
 export const MANGLER_MORS_AKTIVITET_KALENDER = lagAlertregel<MorsAktivitetListeKontekst>({
@@ -93,7 +95,7 @@ export const MANGLER_MORS_AKTIVITET_KALENDER = lagAlertregel<MorsAktivitetListeK
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, ctx.erIkkeSøkerSpesifisert, [...ctx.perioder]),
 });
 
 export const MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING = lagAlertregel<MorsAktivitetListeKontekst>({
@@ -111,7 +113,7 @@ export const MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING = lagAlertregel<MorsAktivite
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, ctx.erIkkeSøkerSpesifisert, [...ctx.perioder]),
 });
 
 export const MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<EksisterendeValgtePeriodeKontekst>({
@@ -127,7 +129,7 @@ export const MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<Eksisterende
     variant: 'warning',
     type: 'kontekstuell',
     skalVises: (ctx) =>
-        harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [ctx.periode, ...ctx.morsUttakPerioder]),
+        harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, ctx.erIkkeSøkerSpesifisert, [ctx.periode, ...ctx.morsUttakPerioder]),
 });
 
 export const KAN_MISTE_DAGER = lagAlertregel<PeriodeDetaljerKontekst>({

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
@@ -23,11 +23,13 @@ dayjs.extend(isSameOrAfter);
 
 type MorsAktivitetListeKontekst = {
     rettighetType: RettighetType_fpoversikt;
+    søker: BrukerRolleSak_fpoversikt;
     perioder: ReadonlyArray<Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager>;
 };
 
 type EksisterendeValgtePeriodeKontekst = {
     rettighetType: RettighetType_fpoversikt;
+    søker: BrukerRolleSak_fpoversikt;
     periode: Uttaksplanperiode | UttaksplanperiodeMedKunTapteDager;
     morsUttakPerioder: readonly UttakPeriode_fpoversikt[];
 };
@@ -76,7 +78,7 @@ export const MANGLER_MORS_AKTIVITET_LISTE = lagAlertregel<MorsAktivitetListeKont
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
 });
 
 export const MANGLER_MORS_AKTIVITET_KALENDER = lagAlertregel<MorsAktivitetListeKontekst>({
@@ -91,7 +93,7 @@ export const MANGLER_MORS_AKTIVITET_KALENDER = lagAlertregel<MorsAktivitetListeK
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
 });
 
 export const MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING = lagAlertregel<MorsAktivitetListeKontekst>({
@@ -109,7 +111,7 @@ export const MORS_AKTIVITET_IKKE_OPPGITT_REDIGERING = lagAlertregel<MorsAktivite
     ],
     variant: 'warning',
     type: 'kontekstuell',
-    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, [...ctx.perioder]),
+    skalVises: (ctx) => harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [...ctx.perioder]),
 });
 
 export const MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<EksisterendeValgtePeriodeKontekst>({
@@ -125,7 +127,7 @@ export const MORS_AKTIVITET_IKKE_VALGT_EKSISTERENDE = lagAlertregel<Eksisterende
     variant: 'warning',
     type: 'kontekstuell',
     skalVises: (ctx) =>
-        harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, [ctx.periode, ...ctx.morsUttakPerioder]),
+        harPeriodeDerMorsAktivitetIkkeErValgt(ctx.rettighetType, ctx.søker, [ctx.periode, ...ctx.morsUttakPerioder]),
 });
 
 export const KAN_MISTE_DAGER = lagAlertregel<PeriodeDetaljerKontekst>({

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -65,17 +65,22 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     });
 
     it('skal returnere false når mor tar samtidig uttak selv om det ikke summerer til 100% (samlet uttak 80%)', () => {
-        const perioder = [
-            lagFarPeriode({ samtidigUttak: 40 }),
-            lagMorPeriode({
-                samtidigUttak: 40,
-                gradering: { arbeidstidprosent: 40, aktivitet: { type: 'ANNET' } },
-            }),
-        ];
+        const perioder = [lagFarPeriode({ samtidigUttak: 40 }), lagMorPeriode({ samtidigUttak: 40 })];
 
         const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
 
         expect(result).toBe(false);
+    });
+
+    it('skal returnere true når overlappende mor-periode kun har gradering uten samtidig uttak', () => {
+        const perioder = [
+            lagFarPeriode(),
+            lagMorPeriode({ gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ANNET' } } }),
+        ];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+
+        expect(result).toBe(true);
     });
 
     it('skal returnere true når mor-perioden ikke overlapper med far-perioden', () => {

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -72,18 +72,13 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
         expect(result).toBe(false);
     });
 
-    it('skal returnere false når mor tar samtidig uttak selv om det ikke summerer til 100% (samlet uttak 80%)', () => {
-        const perioder = [lagFarPeriode({ samtidigUttak: 40 }), lagMorPeriode({ samtidigUttak: 40 })];
-
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
-
-        expect(result).toBe(false);
-    });
-
-    it('skal returnere true når overlappende mor-periode kun har gradering uten samtidig uttak', () => {
+    it('skal returnere true når overlappende mor-periode ikke summerer til 100% (samtidigUttak + gradering < 100)', () => {
         const perioder = [
-            lagFarPeriode(),
-            lagMorPeriode({ gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ANNET' } } }),
+            lagFarPeriode({ samtidigUttak: 40 }),
+            lagMorPeriode({
+                samtidigUttak: 40,
+                gradering: { arbeidstidprosent: 40, aktivitet: { type: 'ANNET' } },
+            }),
         ];
 
         const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -64,7 +64,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
         expect(result).toBe(false);
     });
 
-    it('skal returnere true når overlappende mor-periode ikke summerer til 100% (samtidigUttak + gradering < 100)', () => {
+    it('skal returnere false når mor tar samtidig uttak selv om det ikke summerer til 100% (samlet uttak 80%)', () => {
         const perioder = [
             lagFarPeriode({ samtidigUttak: 40 }),
             lagMorPeriode({
@@ -75,7 +75,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
 
         const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
     });
 
     it('skal returnere true når mor-perioden ikke overlapper med far-perioden', () => {

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -29,15 +29,23 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere true når far har periode uten morsAktivitet og ingen overlappende mor-periode', () => {
         const perioder = [lagFarPeriode()];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(true);
+    });
+
+    it('skal returnere false når søker er MOR uavhengig av far-perioder uten morsAktivitet', () => {
+        const perioder = [lagFarPeriode()];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'MOR', perioder);
+
+        expect(result).toBe(false);
     });
 
     it('skal returnere false ved ALENEOMSORG uavhengig av perioder', () => {
         const perioder = [lagFarPeriode()];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('ALENEOMSORG', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('ALENEOMSORG', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(false);
     });
@@ -51,7 +59,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(false);
     });
@@ -59,7 +67,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når mor tar 100% samtidigUttak uten gradering', () => {
         const perioder = [lagFarPeriode({ samtidigUttak: 100 }), lagMorPeriode({ samtidigUttak: 100 })];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(false);
     });
@@ -67,7 +75,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når mor tar samtidig uttak selv om det ikke summerer til 100% (samlet uttak 80%)', () => {
         const perioder = [lagFarPeriode({ samtidigUttak: 40 }), lagMorPeriode({ samtidigUttak: 40 })];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(false);
     });
@@ -78,7 +86,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             lagMorPeriode({ gradering: { arbeidstidprosent: 50, aktivitet: { type: 'ANNET' } } }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(true);
     });
@@ -94,7 +102,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(true);
     });
@@ -102,7 +110,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når far-periode med morsAktivitet satt ikke trigges', () => {
         const perioder = [lagFarPeriode({ morsAktivitet: 'ARBEID' })];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
 
         expect(result).toBe(false);
     });

--- a/packages/uttaksplan/src/utils/periodeUtils.test.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.test.ts
@@ -29,7 +29,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere true når far har periode uten morsAktivitet og ingen overlappende mor-periode', () => {
         const perioder = [lagFarPeriode()];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(true);
     });
@@ -37,15 +37,23 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når søker er MOR uavhengig av far-perioder uten morsAktivitet', () => {
         const perioder = [lagFarPeriode()];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'MOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'MOR', false, perioder);
 
         expect(result).toBe(false);
+    });
+
+    it('skal returnere true når søker er MOR men søker ikke er spesifisert (planlegger felles plan)', () => {
+        const perioder = [lagFarPeriode()];
+
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'MOR', true, perioder);
+
+        expect(result).toBe(true);
     });
 
     it('skal returnere false ved ALENEOMSORG uavhengig av perioder', () => {
         const perioder = [lagFarPeriode()];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('ALENEOMSORG', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('ALENEOMSORG', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(false);
     });
@@ -59,7 +67,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(false);
     });
@@ -67,7 +75,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når mor tar 100% samtidigUttak uten gradering', () => {
         const perioder = [lagFarPeriode({ samtidigUttak: 100 }), lagMorPeriode({ samtidigUttak: 100 })];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(false);
     });
@@ -81,7 +89,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(true);
     });
@@ -97,7 +105,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
             }),
         ];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(true);
     });
@@ -105,7 +113,7 @@ describe('harPeriodeDerMorsAktivitetIkkeErValgt', () => {
     it('skal returnere false når far-periode med morsAktivitet satt ikke trigges', () => {
         const perioder = [lagFarPeriode({ morsAktivitet: 'ARBEID' })];
 
-        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', perioder);
+        const result = harPeriodeDerMorsAktivitetIkkeErValgt('BEGGE_RETT', 'FAR_MEDMOR', false, perioder);
 
         expect(result).toBe(false);
     });

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -221,9 +221,9 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
                 tom: morPeriode.tom,
             });
 
-            const morsTotalprosent = (morPeriode.samtidigUttak ?? 0) + (morPeriode.gradering?.arbeidstidprosent ?? 0);
+            const morTarSamtidigUttakProsent = morPeriode.samtidigUttak ?? 0;
 
-            return overlapper && morsTotalprosent > 0;
+            return overlapper && morTarSamtidigUttakProsent > 0;
         });
 
     return perioder.some((periode) => {

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -211,7 +211,7 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
         return false;
     }
 
-    const morTarSamtidigUttak = (farPeriode: UttakPeriode_fpoversikt) =>
+    const morHar100ProsentUttakOgGradering = (farPeriode: UttakPeriode_fpoversikt) =>
         perioder.some((morPeriode) => {
             if (!erVanligUttakPeriode(morPeriode) || morPeriode.forelder !== 'MOR') {
                 return false;
@@ -222,9 +222,9 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
                 tom: morPeriode.tom,
             });
 
-            const morTarSamtidigUttakProsent = morPeriode.samtidigUttak ?? 0;
+            const morsTotalprosent = (morPeriode.samtidigUttak ?? 0) + (morPeriode.gradering?.arbeidstidprosent ?? 0);
 
-            return overlapper && morTarSamtidigUttakProsent > 0;
+            return overlapper && morsTotalprosent === 100;
         });
 
     return perioder.some((periode) => {
@@ -241,7 +241,7 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
             periode.morsAktivitet === undefined &&
             periode.flerbarnsdager === false;
 
-        return erFarMedmorsKvote && erInnvilgetUtenMorsAktivitet && !morTarSamtidigUttak(periode);
+        return erFarMedmorsKvote && erInnvilgetUtenMorsAktivitet && !morHar100ProsentUttakOgGradering(periode);
     });
 };
 

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -205,9 +205,10 @@ export const sorterUttakPerioder = (
 export const harPeriodeDerMorsAktivitetIkkeErValgt = (
     rettighetType: RettighetType_fpoversikt,
     søker: BrukerRolleSak_fpoversikt,
+    erIkkeSøkerSpesifisert: boolean,
     perioder?: UttaksplanperiodeMedKunTapteDager[] | Uttaksplanperiode[],
 ) => {
-    if (rettighetType === 'ALENEOMSORG' || søker === 'MOR' || !perioder) {
+    if (rettighetType === 'ALENEOMSORG' || (søker === 'MOR' && !erIkkeSøkerSpesifisert) || !perioder) {
         return false;
     }
 

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -210,7 +210,7 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
         return false;
     }
 
-    const morHar100ProsentUttakOgGradering = (farPeriode: UttakPeriode_fpoversikt) =>
+    const morTarSamtidigUttak = (farPeriode: UttakPeriode_fpoversikt) =>
         perioder.some((morPeriode) => {
             if (!erVanligUttakPeriode(morPeriode) || morPeriode.forelder !== 'MOR') {
                 return false;
@@ -223,7 +223,7 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
 
             const morsTotalprosent = (morPeriode.samtidigUttak ?? 0) + (morPeriode.gradering?.arbeidstidprosent ?? 0);
 
-            return overlapper && morsTotalprosent === 100;
+            return overlapper && morsTotalprosent > 0;
         });
 
     return perioder.some((periode) => {
@@ -240,7 +240,7 @@ export const harPeriodeDerMorsAktivitetIkkeErValgt = (
             periode.morsAktivitet === undefined &&
             periode.flerbarnsdager === false;
 
-        return erFarMedmorsKvote && erInnvilgetUtenMorsAktivitet && !morHar100ProsentUttakOgGradering(periode);
+        return erFarMedmorsKvote && erInnvilgetUtenMorsAktivitet && !morTarSamtidigUttak(periode);
     });
 };
 

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -204,9 +204,10 @@ export const sorterUttakPerioder = (
 
 export const harPeriodeDerMorsAktivitetIkkeErValgt = (
     rettighetType: RettighetType_fpoversikt,
+    søker: BrukerRolleSak_fpoversikt,
     perioder?: UttaksplanperiodeMedKunTapteDager[] | Uttaksplanperiode[],
 ) => {
-    if (rettighetType === 'ALENEOMSORG' || !perioder) {
+    if (rettighetType === 'ALENEOMSORG' || søker === 'MOR' || !perioder) {
         return false;
     }
 


### PR DESCRIPTION
Mors aktivitetskrav ble feilaktig vist i mors plan når far hadde fellesperiode med samtidig uttak under 100%. Aktivitetskravet anses nå oppfylt når mor faktisk tar samtidig uttak, uavhengig av samlet prosent.

https://jira.adeo.no/browse/TFP-7066