### PR TITLE
chore: fjern unødvendig encoding/parsing av body i express

### DIFF
--- a/packages/server-utils/src/serverSetup.ts
+++ b/packages/server-utils/src/serverSetup.ts
@@ -1,5 +1,5 @@
 import { buildCspHeader } from '@navikt/nav-dekoratoren-moduler/ssr/index.js';
-import express, { Express } from 'express';
+import { Express } from 'express';
 
 import config from './config.js';
 
@@ -27,9 +27,6 @@ export const setupServerDefaults = async (server: Express) => {
         res.removeHeader('X-Powered-By');
         next();
     });
-
-    // Restricts the server to only accept UTF-8 encoding of bodies
-    server.use(express.urlencoded({ extended: true }));
 
     server.set('trust proxy', 1);
 };


### PR DESCRIPTION
Foreslås fjernet ettersom jeg ikke finner noe formål, og kommentar i koden ser ut til å være misvisende. Denne treffer ifølge spec kun application/x-www-form-urlencoded. Vi forholder oss ikke til body i express, det meste med innhold blir proxied. Det er vel heller ingen requests som treffer denne pt, da ville vi sikkert støtt på problemer med manglende restreaming av body. Generelt bør bodyparsers settes opp etter proxy i express.

Bakgrunn: kom over denne når jeg så etter mulige problemer med direkte streaming ved opplasting klient > node proxy > fpsoknad > gcs. Ikke relevant for akkurat den problemstillingen.