### PR TITLE
TFP-7069: rett feilaktig visning av tapte dager innen 6 uker for BFHR

### DIFF
--- a/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
+++ b/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
@@ -13,7 +13,7 @@ export const VERSJON_MELLOMLAGRING = 6;
 
 export type EsMellomlagretData = { version: number; personinfo: EsPersonopplysningerDto_fpoversikt } & ContextDataMap;
 
-export type MellomlagreSøknadOptions = {
+type MellomlagreSøknadOptions = {
     // Naviger (react-router) til gjeldande steg før lagring. Default true.
     // Settast false når kallaren skal forlate appen (t.d. fortsett-seinare).
     naviger?: boolean;

--- a/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -25,7 +25,7 @@ export type FpMellomlagretData = {
     annenPartVedtak?: AnnenPartSak_fpoversikt;
 } & ContextDataMap;
 
-export type MellomlagreSøknadOptions = {
+type MellomlagreSøknadOptions = {
     // Naviger (react-router) til gjeldande steg før lagring. Default true.
     // Settast false når kallaren skal forlate appen (t.d. fortsett-seinare).
     naviger?: boolean;

--- a/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -16,7 +16,7 @@ export type SvpMellomlagretData = {
     søkerInfo: SvpPersonopplysningerDto_fpoversikt;
 } & ContextDataMap;
 
-export type MellomlagreSøknadOptions = {
+type MellomlagreSøknadOptions = {
     // Naviger (react-router) til gjeldande steg før lagring. Default true.
     // Settast false når kallaren skal forlate appen (t.d. fortsett-seinare).
     naviger?: boolean;

--- a/packages/uttaksplan/src/utils/lagHullPerioder.test.ts
+++ b/packages/uttaksplan/src/utils/lagHullPerioder.test.ts
@@ -143,6 +143,28 @@ describe('lagHullPerioder', () => {
         ]);
     });
 
+    it('skal ikke vise tapte dager i seksukersperioden for kun far har rett når eneste periode ligger helt innenfor seksukersperioden', () => {
+        const familiehendelsedato = '2025-03-26';
+
+        const perioder = [
+            {
+                fom: '2025-03-26',
+                tom: '2025-04-08',
+                flerbarnsdager: false,
+                forelder: 'FAR_MEDMOR',
+            },
+        ] satisfies UttakPeriode_fpoversikt[];
+        const foreldreInfo = {
+            ...DEFAULT_FORELDRE_INFO,
+            søker: 'FAR_MEDMOR',
+            rettighetType: 'BARE_SØKER_RETT',
+        } satisfies ForeldreInfo;
+
+        const perioderMedHull = lagTapteDagerPerioder(perioder, familiehendelsedato, 'fødsel', foreldreInfo);
+
+        expect(perioderMedHull).toEqual([]);
+    });
+
     it('skal legge til hull fra omsorgsovertakelse og til første periode for kun far har rett ved adopsjon', () => {
         const familiehendelsedato = '2025-03-26';
 

--- a/packages/uttaksplan/src/utils/lagHullPerioder.ts
+++ b/packages/uttaksplan/src/utils/lagHullPerioder.ts
@@ -57,23 +57,25 @@ export const lagTapteDagerPerioder = (
     foreldreInfo: ForeldreInfo,
 ): TapteDagerHull[] => {
     if (foreldreInfo.søker === 'FAR_MEDMOR' && foreldreInfo.rettighetType === 'BARE_SØKER_RETT') {
-        const fom =
+        // Første dagen far/medmor kan ta ut dager: 6 uker etter fødsel (mors reserverte
+        // periode) ved fødsel, eller omsorgsovertakelsesdatoen ved adopsjon.
+        const førsteMuligeUttaksdag =
             familiesituasjon === 'adopsjon'
                 ? Uttaksdagen.denneEllerNeste(familiehendelsedato).getDato()
                 : Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(30);
 
-        // Perioder som ligger i sin helhet før seksukersperioden er ferdig (f.eks. mors
-        // periode rett etter fødsel) skal ikke regnes med her, siden far/medmor uansett
-        // ikke kan ta ut dager i denne perioden. Uten dette blir intervallet som sjekkes
-        // for hull snudd (tom før fom), og det vises feilaktig tapte dager i seksukersperioden.
-        const sistePeriodeSomStarterEtterSeksukersperioden = sortertePerioder.findLast((p) =>
-            dayjs(p.fom).isSameOrAfter(fom),
+        // Perioder som starter før denne datoen skal ikke være med når vi finner slutten
+        // på intervallet vi sjekker for hull, siden far/medmor uansett ikke kan ta ut dager
+        // før den. Ellers kan sluttdatoen (tom) havne før startdatoen (fom), slik at
+        // intervallet blir snudd og det vises feilaktig tapte dager.
+        const sistePeriodeSomStarterEtterFørsteMuligeUttaksdag = sortertePerioder.findLast((p) =>
+            dayjs(p.fom).isSameOrAfter(førsteMuligeUttaksdag),
         );
 
-        if (sistePeriodeSomStarterEtterSeksukersperioden?.fom) {
+        if (sistePeriodeSomStarterEtterFørsteMuligeUttaksdag?.fom) {
             const periodeSomSkalSjekkesForHull = {
-                fom,
-                tom: sistePeriodeSomStarterEtterSeksukersperioden.fom,
+                fom: førsteMuligeUttaksdag,
+                tom: sistePeriodeSomStarterEtterFørsteMuligeUttaksdag.fom,
             };
 
             return lagTapteDagerHull(sortertePerioder, foreldreInfo.søker, periodeSomSkalSjekkesForHull);

--- a/packages/uttaksplan/src/utils/lagHullPerioder.ts
+++ b/packages/uttaksplan/src/utils/lagHullPerioder.ts
@@ -57,17 +57,23 @@ export const lagTapteDagerPerioder = (
     foreldreInfo: ForeldreInfo,
 ): TapteDagerHull[] => {
     if (foreldreInfo.søker === 'FAR_MEDMOR' && foreldreInfo.rettighetType === 'BARE_SØKER_RETT') {
-        const sistePeriodeSomStarterEtterFamiliehendelsedato = sortertePerioder.findLast((p) =>
-            dayjs(p.fom).isSameOrAfter(familiehendelsedato),
+        const fom =
+            familiesituasjon === 'adopsjon'
+                ? Uttaksdagen.denneEllerNeste(familiehendelsedato).getDato()
+                : Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(30);
+
+        // Perioder som ligger i sin helhet før seksukersperioden er ferdig (f.eks. mors
+        // periode rett etter fødsel) skal ikke regnes med her, siden far/medmor uansett
+        // ikke kan ta ut dager i denne perioden. Uten dette blir intervallet som sjekkes
+        // for hull snudd (tom før fom), og det vises feilaktig tapte dager i seksukersperioden.
+        const sistePeriodeSomStarterEtterSeksukersperioden = sortertePerioder.findLast((p) =>
+            dayjs(p.fom).isSameOrAfter(fom),
         );
 
-        if (sistePeriodeSomStarterEtterFamiliehendelsedato?.fom) {
+        if (sistePeriodeSomStarterEtterSeksukersperioden?.fom) {
             const periodeSomSkalSjekkesForHull = {
-                fom:
-                    familiesituasjon === 'adopsjon'
-                        ? Uttaksdagen.denneEllerNeste(familiehendelsedato).getDato()
-                        : Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(30),
-                tom: sistePeriodeSomStarterEtterFamiliehendelsedato.fom,
+                fom,
+                tom: sistePeriodeSomStarterEtterSeksukersperioden.fom,
             };
 
             return lagTapteDagerHull(sortertePerioder, foreldreInfo.søker, periodeSomSkalSjekkesForHull);


### PR DESCRIPTION
Når bare far/medmor har rett (BFHR) og planen kun inneholder en periode som ligger helt innenfor de første 6 ukene etter fødsel, ble det feilaktig vist "tapte dager" innenfor seksukersperioden.

Rotårsak: I lagTapteDagerPerioder ble intervallet som sjekkes for hull bygget slik at tom var fom-datoen til "siste periode som starter på/etter familiehendelsedato". Siden søket brukte >= familiehendelsedato (ikke 6-ukersgrensen), kunne tom havne innenfor de første 6 ukene mens fom var 6-ukersgrensen. Da ble intervallet snudd (tom før fom), og hull-algoritmen produserte et feilaktig tapte-dager-hull som dekket nesten hele seksukersperioden.

Dette forklarer også hvorfor feilen "rettet seg opp" når man la til uttak senere i planen: da fikk intervallet igjen en tom etter 6-ukersgrensen og ble ikke snudd.

Fiks: Regn ut 6-ukersgrensen (fom) først, og velg "siste periode" kun blant perioder som starter på/etter denne grensen. Perioder som ligger helt innenfor de første 6 ukene ignoreres, siden far/medmor uansett ikke kan ta ut dager der.

Verifisert ved å rekonstruere gammel kode: scenarioet ga et snudd intervall { fom: 2025-05-07, tom: 2025-04-09 } og et feilaktig hull { 2025-04-10 .. 2025-05-05 }. Etter fiks gir samme scenario tom liste. La til regresjonstest og kjørte full uttaksplan-testsuite (274 tester), tsc og eslint uten nye feil.

https://jira.adeo.no/browse/TFP-7069