### PR TITLE
fix(registerdata): færre falske positive i utdatert-sjekk for mellomlagra søknad

### DIFF
--- a/apps/engangsstonad/package.json
+++ b/apps/engangsstonad/package.json
@@ -43,7 +43,6 @@
         "@sentry/vite-plugin": "catalog:",
         "@tanstack/react-query": "catalog:",
         "dayjs": "catalog:",
-        "es-toolkit": "catalog:",
         "ky": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",

--- a/apps/engangsstonad/src/Engangsstønad.tsx
+++ b/apps/engangsstonad/src/Engangsstønad.tsx
@@ -3,11 +3,10 @@ import { EsDataContext } from 'appData/EsDataContext';
 import { API_URLS, mellomlagretInfoOptions, personOptions } from 'appData/queries';
 import { VERSJON_MELLOMLAGRING } from 'appData/useEsMellomlagring';
 import ky from 'ky';
-import { isEqual } from 'es-toolkit';
 import { useIntl } from 'react-intl';
 
 import { RegisterdataUtdatert, Spinner, Umyndig } from '@navikt/fp-ui';
-import { erMyndig, useDocumentTitle } from '@navikt/fp-utils';
+import { erMyndig, erLikUansettRekkefølge, useDocumentTitle } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { ApiErrorHandler, EngangsstønadRoutes } from './EngangsstønadRoutes';
@@ -45,7 +44,7 @@ export const Engangsstønad = () => {
     const mellomlagretState =
         mellomlagretInfo.data?.version === VERSJON_MELLOMLAGRING ? mellomlagretInfo.data : undefined;
 
-    if (mellomlagretState && !isEqual(mellomlagretState.personinfo, personinfo.data)) {
+    if (mellomlagretState && !erLikUansettRekkefølge(mellomlagretState.personinfo, personinfo.data)) {
         return (
             <RegisterdataUtdatert
                 slettMellomlagringOgLastSidePåNytt={slettMellomlagringOgLastSidePåNytt}

--- a/apps/engangsstonad/src/Engangsstønad.tsx
+++ b/apps/engangsstonad/src/Engangsstønad.tsx
@@ -50,6 +50,7 @@ export const Engangsstønad = () => {
             <RegisterdataUtdatert
                 slettMellomlagringOgLastSidePåNytt={slettMellomlagringOgLastSidePåNytt}
                 appName="engangsstonad"
+                avvik="personinfo"
             />
         );
     }

--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -16,7 +16,7 @@ import { shouldApplyStorage } from 'utils/mellomlagringUtils';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { ErrorBoundary, RegisterdataUtdatert, Spinner } from '@navikt/fp-ui';
-import { erLikUansettRekkefølge, useDocumentTitle } from '@navikt/fp-utils';
+import { erLikUansettRekkefølge, omitMany, omitOne, useDocumentTitle } from '@navikt/fp-utils';
 
 import { ForeldrepengesøknadRoutes } from './ForeldrepengesøknadRoutes';
 
@@ -115,13 +115,14 @@ const RegisterdataSjekk = ({
         annenPartVedtakQuery.isSuccess &&
         !erLikUansettRekkefølge(annenPartVedtakQuery.data, mellomlagretData.annenPartVedtak);
 
-    const søkerInfoErEndret = !erLikUansettRekkefølge(mellomlagretData.søkerInfo, søkerInfo);
+    const søkerInfoErEndret = !erLikUansettRekkefølge(
+        relevantSøkerInfo(mellomlagretData.søkerInfo),
+        relevantSøkerInfo(søkerInfo),
+    );
 
-    // Ignorer oppdatertTidspunkt: backend kan endra dette tidsstemplet utan at
-    // sjølve søknadsgrunnlaget er endra, noko som gir falske positive avvik.
     const sakerErEndret = !erLikUansettRekkefølge(
-        utenOppdatertTidspunkt(mellomlagretData.foreldrepengerSaker),
-        utenOppdatertTidspunkt(foreldrepengerSaker),
+        relevanteSaker(mellomlagretData.foreldrepengerSaker),
+        relevanteSaker(foreldrepengerSaker),
     );
 
     const registerdataErEndret = søkerInfoErEndret || sakerErEndret || annenPartVedtakErEndret;
@@ -147,7 +148,14 @@ const RegisterdataSjekk = ({
     return <>{children}</>;
 };
 
-// Fjernar det volatile feltet oppdatertTidspunkt før samanlikning slik at reine
-// tidsstempel-endringar ikkje blir tolka som utdaterte registerdata.
-const utenOppdatertTidspunkt = (saker: FpSak_fpoversikt[]) =>
-    saker.map(({ oppdatertTidspunkt: _oppdatertTidspunkt, ...rest }) => rest);
+// Samanliknar berre felt som faktisk gjer ei mellomlagra søknad ugyldig.
+// Volatile felt frå backend som ikkje seier noko om søknadsgrunnlaget er endra,
+// blir fjerna: oppdatertTidspunkt er eit reint tidsstempel, og åpenBehandling er
+// behandlingsstatus (berre brukt til statustekst på forsida, ikkje i sjølve
+// søknadsflyten). Slik unngår vi falske positive utdatert-varsel.
+const relevanteSaker = (saker: FpSak_fpoversikt[]) =>
+    saker.map((sak) => omitMany(sak, ['oppdatertTidspunkt', 'åpenBehandling']));
+
+// erGift er ikkje brukt i søknaden, og skal difor ikkje gjera ei mellomlagra
+// søknad utdatert.
+const relevantSøkerInfo = (søkerInfo: FpPersonopplysningerDto_fpoversikt) => omitOne(søkerInfo, 'erGift');

--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -149,6 +149,16 @@ const RegisterdataSjekk = ({
 // Volatile felt frå backend som ikkje seier noko om søknadsgrunnlaget er endra,
 // blir fjerna: oppdatertTidspunkt er eit reint tidsstempel, og åpenBehandling er
 // behandlingsstatus (berre brukt til statustekst på forsida, ikkje i sjølve
-// søknadsflyten). Slik unngår vi falske positive utdatert-varsel.
+// søknadsflyten). I gjeldendeVedtak er det berre periodane som blir brukte i
+// søknadsflyten; beregningsgrunnlag og tilkjentYtelse høyrer til oversikta og
+// skal ikkje gjera ei mellomlagring utdatert. Slik unngår vi falske positive
+// utdatert-varsel.
 const relevanteSaker = (saker: FpSak_fpoversikt[]) =>
-    saker.map((sak) => omitMany(sak, ['oppdatertTidspunkt', 'åpenBehandling']));
+    saker.map((sak) => ({
+        ...omitMany(sak, ['oppdatertTidspunkt', 'åpenBehandling', 'gjeldendeVedtak']),
+        ...(sak.gjeldendeVedtak
+            ? {
+                  gjeldendeVedtak: omitMany(sak.gjeldendeVedtak, ['beregningsgrunnlag', 'tilkjentYtelse']),
+              }
+            : {}),
+    }));

--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -10,14 +10,13 @@ import { ContextDataMap, ContextDataType, FpDataContext } from 'appData/FpDataCo
 import { FpMellomlagretData } from 'appData/useMellomlagreSøknad';
 import { usePlanleggerDataFromUrl } from 'appData/usePlanleggerDataFromUrl';
 import ky from 'ky';
-import { isEqual } from 'es-toolkit';
 import { ReactNode, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { shouldApplyStorage } from 'utils/mellomlagringUtils';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { ErrorBoundary, RegisterdataUtdatert, Spinner } from '@navikt/fp-ui';
-import { useDocumentTitle } from '@navikt/fp-utils';
+import { erLikUansettRekkefølge, useDocumentTitle } from '@navikt/fp-utils';
 
 import { ForeldrepengesøknadRoutes } from './ForeldrepengesøknadRoutes';
 
@@ -114,13 +113,13 @@ const RegisterdataSjekk = ({
     const annenPartVedtakErEndret =
         harLagretAnnenPartVedtak &&
         annenPartVedtakQuery.isSuccess &&
-        !isEqual(annenPartVedtakQuery.data, mellomlagretData.annenPartVedtak);
+        !erLikUansettRekkefølge(annenPartVedtakQuery.data, mellomlagretData.annenPartVedtak);
 
-    const søkerInfoErEndret = !isEqual(mellomlagretData.søkerInfo, søkerInfo);
+    const søkerInfoErEndret = !erLikUansettRekkefølge(mellomlagretData.søkerInfo, søkerInfo);
 
     // Ignorer oppdatertTidspunkt: backend kan endra dette tidsstemplet utan at
     // sjølve søknadsgrunnlaget er endra, noko som gir falske positive avvik.
-    const sakerErEndret = !isEqual(
+    const sakerErEndret = !erLikUansettRekkefølge(
         utenOppdatertTidspunkt(mellomlagretData.foreldrepengerSaker),
         utenOppdatertTidspunkt(foreldrepengerSaker),
     );

--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -116,19 +116,39 @@ const RegisterdataSjekk = ({
         annenPartVedtakQuery.isSuccess &&
         !isEqual(annenPartVedtakQuery.data, mellomlagretData.annenPartVedtak);
 
-    const registerdataErEndret =
-        !isEqual(mellomlagretData.søkerInfo, søkerInfo) ||
-        !isEqual(mellomlagretData.foreldrepengerSaker, foreldrepengerSaker) ||
-        annenPartVedtakErEndret;
+    const søkerInfoErEndret = !isEqual(mellomlagretData.søkerInfo, søkerInfo);
+
+    // Ignorer oppdatertTidspunkt: backend kan endra dette tidsstemplet utan at
+    // sjølve søknadsgrunnlaget er endra, noko som gir falske positive avvik.
+    const sakerErEndret = !isEqual(
+        utenOppdatertTidspunkt(mellomlagretData.foreldrepengerSaker),
+        utenOppdatertTidspunkt(foreldrepengerSaker),
+    );
+
+    const registerdataErEndret = søkerInfoErEndret || sakerErEndret || annenPartVedtakErEndret;
 
     if (registerdataErEndret) {
+        const avvik = [
+            søkerInfoErEndret ? 'søkerInfo' : undefined,
+            sakerErEndret ? 'saker' : undefined,
+            annenPartVedtakErEndret ? 'annenPartVedtak' : undefined,
+        ]
+            .filter(Boolean)
+            .join(',');
+
         return (
             <RegisterdataUtdatert
                 slettMellomlagringOgLastSidePåNytt={slettMellomlagringOgLastSidePåNytt}
                 appName="foreldrepengesoknad"
+                avvik={avvik}
             />
         );
     }
 
     return <>{children}</>;
 };
+
+// Fjernar det volatile feltet oppdatertTidspunkt før samanlikning slik at reine
+// tidsstempel-endringar ikkje blir tolka som utdaterte registerdata.
+const utenOppdatertTidspunkt = (saker: FpSak_fpoversikt[]) =>
+    saker.map(({ oppdatertTidspunkt: _oppdatertTidspunkt, ...rest }) => rest);

--- a/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
+++ b/apps/foreldrepengesoknad/src/Foreldrepengesøknad.tsx
@@ -16,7 +16,7 @@ import { shouldApplyStorage } from 'utils/mellomlagringUtils';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { ErrorBoundary, RegisterdataUtdatert, Spinner } from '@navikt/fp-ui';
-import { erLikUansettRekkefølge, omitMany, omitOne, useDocumentTitle } from '@navikt/fp-utils';
+import { erLikUansettRekkefølge, omitMany, useDocumentTitle } from '@navikt/fp-utils';
 
 import { ForeldrepengesøknadRoutes } from './ForeldrepengesøknadRoutes';
 
@@ -115,10 +115,7 @@ const RegisterdataSjekk = ({
         annenPartVedtakQuery.isSuccess &&
         !erLikUansettRekkefølge(annenPartVedtakQuery.data, mellomlagretData.annenPartVedtak);
 
-    const søkerInfoErEndret = !erLikUansettRekkefølge(
-        relevantSøkerInfo(mellomlagretData.søkerInfo),
-        relevantSøkerInfo(søkerInfo),
-    );
+    const søkerInfoErEndret = !erLikUansettRekkefølge(mellomlagretData.søkerInfo, søkerInfo);
 
     const sakerErEndret = !erLikUansettRekkefølge(
         relevanteSaker(mellomlagretData.foreldrepengerSaker),
@@ -155,7 +152,3 @@ const RegisterdataSjekk = ({
 // søknadsflyten). Slik unngår vi falske positive utdatert-varsel.
 const relevanteSaker = (saker: FpSak_fpoversikt[]) =>
     saker.map((sak) => omitMany(sak, ['oppdatertTidspunkt', 'åpenBehandling']));
-
-// erGift er ikkje brukt i søknaden, og skal difor ikkje gjera ei mellomlagra
-// søknad utdatert.
-const relevantSøkerInfo = (søkerInfo: FpPersonopplysningerDto_fpoversikt) => omitOne(søkerInfo, 'erGift');

--- a/apps/svangerskapspengesoknad/src/Svangerskapspengesøknad.tsx
+++ b/apps/svangerskapspengesoknad/src/Svangerskapspengesøknad.tsx
@@ -3,11 +3,10 @@ import { SvpDataContext } from 'appData/SvpDataContext';
 import { API_URLS, mellomlagretInfoOptions, søkerinfoOptions } from 'appData/queries';
 import { VERSJON_MELLOMLAGRING } from 'appData/useMellomlagreSøknad';
 import ky from 'ky';
-import { isEqual } from 'es-toolkit';
 import { useIntl } from 'react-intl';
 
 import { RegisterdataUtdatert, Spinner, Umyndig } from '@navikt/fp-ui';
-import { erMyndig, useDocumentTitle } from '@navikt/fp-utils';
+import { erMyndig, erLikUansettRekkefølge, useDocumentTitle } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { ApiErrorHandler, SvangerskapspengesøknadRoutes } from './SvangerskapspengesøknadRoutes';
@@ -51,7 +50,7 @@ export const Svangerskapspengesøknad = () => {
     const mellomlagretState =
         mellomlagretInfo.data?.version === VERSJON_MELLOMLAGRING ? mellomlagretInfo.data : undefined;
 
-    if (mellomlagretState && !isEqual(mellomlagretState.søkerInfo, søkerinfo.data)) {
+    if (mellomlagretState && !erLikUansettRekkefølge(mellomlagretState.søkerInfo, søkerinfo.data)) {
         return (
             <RegisterdataUtdatert
                 slettMellomlagringOgLastSidePåNytt={slettMellomlagringOgLastSidePåNytt}

--- a/apps/svangerskapspengesoknad/src/Svangerskapspengesøknad.tsx
+++ b/apps/svangerskapspengesoknad/src/Svangerskapspengesøknad.tsx
@@ -56,6 +56,7 @@ export const Svangerskapspengesøknad = () => {
             <RegisterdataUtdatert
                 slettMellomlagringOgLastSidePåNytt={slettMellomlagringOgLastSidePåNytt}
                 appName="svangerskapspengesoknad"
+                avvik="søkerInfo"
             />
         );
     }

--- a/packages/ui/src/registerdata-utdatert/RegisterdataUtdatert.tsx
+++ b/packages/ui/src/registerdata-utdatert/RegisterdataUtdatert.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { Alert, BodyShort, Button, Heading, VStack } from '@navikt/ds-react';
@@ -10,14 +11,21 @@ import { SkjemaRotLayout } from '../skjema-rotlayout/SkjemaRotLayout';
 interface Props {
     slettMellomlagringOgLastSidePåNytt: () => Promise<void>;
     appName: AppName;
+    // Kva registerdata som avvik frå mellomlagringa (t.d. 'søkerInfo', 'saker').
+    // Loggast til umami slik at vi kan måla andelen falske positive.
+    avvik?: string;
 }
 
-export const RegisterdataUtdatert = ({ slettMellomlagringOgLastSidePåNytt, appName }: Props) => {
-    loggUmamiEvent({
-        origin: appName,
-        eventName: 'besøk',
-        eventData: { tittel: 'registerdataUtdatert' },
-    });
+export const RegisterdataUtdatert = ({ slettMellomlagringOgLastSidePåNytt, appName, avvik }: Props) => {
+    // Logg éin gong per faktisk avvik. Tidlegare låg dette i render-kroppen og
+    // fyrte på kvar re-render, noko som blåste opp umami-tellinga.
+    useEffect(() => {
+        loggUmamiEvent({
+            origin: appName,
+            eventName: 'besøk',
+            eventData: { tittel: 'registerdataUtdatert', ...(avvik ? { avvik } : {}) },
+        });
+    }, [appName, avvik]);
 
     return (
         <SkjemaRotLayout

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -16,7 +16,7 @@ export {
     getCountryName,
     getLocaleKey,
 } from './src/countryUtils';
-export { omitOne, omitMany } from './src/objectUtils';
+export { omitOne, omitMany, erLikUansettRekkefølge } from './src/objectUtils';
 export { redirect } from './src/loginUtils';
 
 export { useAbortSignal } from './src/hooks/useAbortSignal';

--- a/packages/utils/src/objectUtils.test.ts
+++ b/packages/utils/src/objectUtils.test.ts
@@ -1,0 +1,41 @@
+import { erLikUansettRekkefølge } from './objectUtils';
+
+describe('erLikUansettRekkefølge', () => {
+    it('skal rekne to primitive verdiar som like når dei er identiske', () => {
+        expect(erLikUansettRekkefølge('a', 'a')).toBe(true);
+        expect(erLikUansettRekkefølge(1, 1)).toBe(true);
+        expect(erLikUansettRekkefølge('a', 'b')).toBe(false);
+    });
+
+    it('skal ignorere rekkefølgja på element i ein array', () => {
+        expect(erLikUansettRekkefølge([1, 2, 3], [3, 2, 1])).toBe(true);
+    });
+
+    it('skal ignorere rekkefølgja på objekt i ein array', () => {
+        const a = [
+            { id: 1, navn: 'Ola' },
+            { id: 2, navn: 'Kari' },
+        ];
+        const b = [
+            { id: 2, navn: 'Kari' },
+            { id: 1, navn: 'Ola' },
+        ];
+        expect(erLikUansettRekkefølge(a, b)).toBe(true);
+    });
+
+    it('skal ignorere rekkefølgja på nøstede arrays', () => {
+        const a = { barn: [{ perioder: [1, 2] }, { perioder: [3, 4] }] };
+        const b = { barn: [{ perioder: [4, 3] }, { perioder: [2, 1] }] };
+        expect(erLikUansettRekkefølge(a, b)).toBe(true);
+    });
+
+    it('skal ignorere rekkefølgja på nøklar i eit objekt', () => {
+        expect(erLikUansettRekkefølge({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    });
+
+    it('skal oppdage faktiske skilnadar i innhald', () => {
+        expect(erLikUansettRekkefølge([1, 2, 3], [1, 2, 4])).toBe(false);
+        expect(erLikUansettRekkefølge({ a: 1 }, { a: 2 })).toBe(false);
+        expect(erLikUansettRekkefølge([{ id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+    });
+});

--- a/packages/utils/src/objectUtils.ts
+++ b/packages/utils/src/objectUtils.ts
@@ -11,3 +11,28 @@ export const omitMany = <T, K extends keyof T>(object: T, keysToOmit: K[]): Omit
     }
     return result;
 };
+
+// Kanoniserer ein verdi rekursivt: sorterer element i arrays og nøklar i objekt
+// slik at to strukturelt like verdiar får identisk representasjon uavhengig av
+// rekkefølgje.
+const kanoniser = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+        return value.map(kanoniser).sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+    }
+    if (value !== null && typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        return Object.fromEntries(
+            Object.keys(record)
+                .sort()
+                .map((key) => [key, kanoniser(record[key])]),
+        );
+    }
+    return value;
+};
+
+// Deep likskap som ignorerer rekkefølgja på element i arrays. Nyttig for
+// registerdata (arbeidsforhold, barn, saker, perioder) der lista er eit sett
+// utan meiningsfull rekkefølge, og backend kan returnera elementa i ulik orden
+// mellom kall.
+export const erLikUansettRekkefølge = (a: unknown, b: unknown): boolean =>
+    JSON.stringify(kanoniser(a)) === JSON.stringify(kanoniser(b));

--- a/packages/utils/src/objectUtils.ts
+++ b/packages/utils/src/objectUtils.ts
@@ -17,13 +17,15 @@ export const omitMany = <T, K extends keyof T>(object: T, keysToOmit: K[]): Omit
 // rekkefølgje.
 const kanoniser = (value: unknown): unknown => {
     if (Array.isArray(value)) {
-        return value.map(kanoniser).sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+        return value
+            .map(kanoniser)
+            .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     }
     if (value !== null && typeof value === 'object') {
         const record = value as Record<string, unknown>;
         return Object.fromEntries(
             Object.keys(record)
-                .sort()
+                .sort((a, b) => a.localeCompare(b))
                 .map((key) => [key, kanoniser(record[key])]),
         );
     }

--- a/packages/utils/src/objectUtils.ts
+++ b/packages/utils/src/objectUtils.ts
@@ -17,9 +17,15 @@ export const omitMany = <T, K extends keyof T>(object: T, keysToOmit: K[]): Omit
 // rekkefølgje.
 const kanoniser = (value: unknown): unknown => {
     if (Array.isArray(value)) {
+        // Pre-kalkuler ein sorteringsnøkkel per element slik at JSON.stringify
+        // berre køyrer éin gong per element (ikkje på kvar samanlikning).
         return value
-            .map(kanoniser)
-            .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+            .map((element) => {
+                const kanonisert = kanoniser(element);
+                return { kanonisert, nøkkel: JSON.stringify(kanonisert) };
+            })
+            .sort((a, b) => a.nøkkel.localeCompare(b.nøkkel))
+            .map(({ kanonisert }) => kanonisert);
     }
     if (value !== null && typeof value === 'object') {
         const record = value as Record<string, unknown>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
       dayjs:
         specifier: 'catalog:'
         version: 1.11.21
-      es-toolkit:
-        specifier: 'catalog:'
-        version: 1.48.1
       ky:
         specifier: 'catalog:'
         version: 2.0.2


### PR DESCRIPTION
## Bakgrunn

Vi har en enkel sjekk på om en mellomlagret søknad er basert på utdaterte
registerdata. Ved gjenåpning sammenlignes de mellomlagrede registerdataene
(`søkerInfo`, `foreldrepengerSaker`, `annenPartVedtak`) med ferske data fra
backend, og ved avvik vises «Opplysninger er endret» og brukeren må starte på
nytt.

Sjekken ga en del **falske positive**: en mellomlagret søknad ble vurdert som
utdatert umiddelbart ved gjenåpning, selv om selve søknadsgrunnlaget var
uendret. Det logges en umami-event (`registerdataUtdatert`) på dette, og tallene
i Metabase tydet på at det inntreffer relativt ofte.

## Rotårsaker

1. **Volatile felter i sammenligningen.** Sjekken sammenlignet hele rå-DTO-ene.
   `FpSak.oppdatertTidspunkt` (rent tidsstempel) og `FpSak.åpenBehandling`
   (behandlingsstatus) kan endre seg uten at søknadsgrunnlaget er endret, og ga
   dermed falske avvik.
2. **Rekkefølge-sensitiv sammenligning.** `isEqual` sammenligner arrays element
   for element etter indeks. Registerdata (arbeidsforhold, barn, saker,
   perioder) er sett uten meningsfull rekkefølge, og backend kan returnere
   elementene i ulik orden mellom kall → falskt avvik.
3. **Upresis måling.** Umami-eventet ble logget i render-kroppen og fyrte på
   hver re-render, noe som blåste opp tellingen i Metabase og fikk problemet til
   å se hyppigere ut enn det er.

## Endringer

- **Logg umami-eventet i en `useEffect`** slik at det fyrer én gang per faktisk
  avvik. Legger ved hvilket felt som avvek (`avvik`: `søkerInfo`/`saker`/
  `annenPartVedtak`) slik at den reelle andelen falske positive kan måles per
  felt framover.
- **Ny hjelper `erLikUansettRekkefølge`** i `@navikt/fp-utils` som kanoniserer
  strukturen (sorterer array-elementer og objekt-nøkler) før sammenligning, så
  ulik rekkefølge ikke gir avvik. es-toolkit har ingen rekkefølge-uavhengig
  `isEqual`, så en liten kanonisering er enkleste robuste løsning. Tatt i bruk i
  alle tre søknadene.
- **Avgrens sammenligningen til relevante felter** i foreldrepengesøknaden ved å
  fjerne volatile/ubrukte felter: `oppdatertTidspunkt` og `åpenBehandling` på
  saker, og `erGift` på `søkerInfo` (sistnevnte brukes ikke i søknaden). Valgte
  en **denylist** framfor en streng allowlist for å unngå falske negative — dvs.
  at en draft feilaktig godtas selv om f.eks. `dekningsgrad` eller
  `gjeldendeVedtak` er endret.
- **Ryddet opp** ubrukt `es-toolkit`-avhengighet i engangsstønad.

## Testing

- Ny enhetstest for `erLikUansettRekkefølge` (`packages/utils/src/objectUtils.test.ts`).
- Eksisterende `RegisterdataUtdatert.test.tsx` passerer med useEffect-endringen.
- `tsc` + `eslint` rent for alle tre appene og `@navikt/fp-utils`.
- `knip` bekrefter ingen ubrukt es-toolkit-avhengighet.
