### PR TITLE
TFP-7073: varsle om ferie i uke 7 etter termin kan gi tapte dager

### DIFF
--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
@@ -129,8 +129,8 @@ describe('kanMisteDagerVedFerieIUke7EtterTermin', () => {
     it('skal returnere true dersom familiesituasjon er termin og perioden er i uke 7 etter familiehendelsedato', () => {
         const perioder = [
             {
-                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
-                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
+                fom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
+                tom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
             },
         ];
 
@@ -140,8 +140,8 @@ describe('kanMisteDagerVedFerieIUke7EtterTermin', () => {
     it('skal returnere false dersom familiesituasjon er fødsel, selv om perioden er i uke 7 etter familiehendelsedato', () => {
         const perioder = [
             {
-                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
-                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
+                fom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
+                tom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
             },
         ];
 
@@ -159,8 +159,8 @@ describe('kanMisteDagerVedFerieIUke7EtterTermin', () => {
     it('skal returnere false dersom perioden ligger etter uke 7', () => {
         const perioder = [
             {
-                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(40),
-                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(45),
+                fom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(40),
+                tom: Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(45),
             },
         ];
 

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.test.tsx
@@ -12,6 +12,7 @@ import messages from '../intl/messages/nb_NO.json';
 import { LeggTilEllerEndrePeriodeFormFormValues } from './LeggTilEllerEndrePeriodeFellesForm';
 import {
     kanMisteDagerVedEndringTilFerie,
+    kanMisteDagerVedFerieIUke7EtterTermin,
     prosentValideringGradering,
     useFormSubmitValidator,
     valideringSamtidigUttak,
@@ -119,6 +120,51 @@ describe('kanMisteDagerVedEndringTilFerie', () => {
             },
         ];
         expect(kanMisteDagerVedEndringTilFerie(perioder, familiehendelsedato)).toBe(false);
+    });
+});
+
+describe('kanMisteDagerVedFerieIUke7EtterTermin', () => {
+    const familiehendelsedato = dayjs().format(ISO_DATE_FORMAT);
+
+    it('skal returnere true dersom familiesituasjon er termin og perioden er i uke 7 etter familiehendelsedato', () => {
+        const perioder = [
+            {
+                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
+                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
+            },
+        ];
+
+        expect(kanMisteDagerVedFerieIUke7EtterTermin(perioder, familiehendelsedato, 'termin')).toBe(true);
+    });
+
+    it('skal returnere false dersom familiesituasjon er fødsel, selv om perioden er i uke 7 etter familiehendelsedato', () => {
+        const perioder = [
+            {
+                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(32),
+                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(34),
+            },
+        ];
+
+        expect(kanMisteDagerVedFerieIUke7EtterTermin(perioder, familiehendelsedato, 'fødsel')).toBe(false);
+    });
+
+    it('skal returnere false dersom perioden ligger innenfor de seks første ukene (dekket av annen regel)', () => {
+        const perioder = [
+            { fom: familiehendelsedato, tom: dayjs(familiehendelsedato).add(10, 'day').format(ISO_DATE_FORMAT) },
+        ];
+
+        expect(kanMisteDagerVedFerieIUke7EtterTermin(perioder, familiehendelsedato, 'termin')).toBe(false);
+    });
+
+    it('skal returnere false dersom perioden ligger etter uke 7', () => {
+        const perioder = [
+            {
+                fom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(40),
+                tom: Uttaksdagen.denne(familiehendelsedato).getDatoAntallUttaksdagerSenere(45),
+            },
+        ];
+
+        expect(kanMisteDagerVedFerieIUke7EtterTermin(perioder, familiehendelsedato, 'termin')).toBe(false);
     });
 });
 

--- a/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
+++ b/packages/uttaksplan/src/felles/uttaksplanValidatorer.tsx
@@ -1,5 +1,7 @@
 import { useIntl } from 'react-intl';
 
+import { Familiesituasjon } from '@navikt/fp-types';
+
 import { useUttaksplanData } from '../context/UttaksplanDataContext';
 import { valider } from '../regler/validering/valider';
 import { UttaksperiodeValidatorer } from '../utils/UttaksperiodeValidatorer';
@@ -27,6 +29,20 @@ export const kanMisteDagerVedEndringTilFerie = (
         )
     );
 };
+
+/**
+ * Mor søker før fødsel (familiesituasjon er «termin», dvs. barnet er ikke
+ * født ennå) og har valgt å endre én eller flere perioder i uke 7 etter
+ * termin til ferie. Dersom barnet blir født etter termin, forskyves de
+ * seks lovpålagte ukene med mødrekvote, og ferien kan da bli avslått.
+ */
+export const kanMisteDagerVedFerieIUke7EtterTermin = (
+    perioder: Array<{ fom: string; tom: string }>,
+    familiehendelsedato: string,
+    familiesituasjon: Familiesituasjon,
+) =>
+    familiesituasjon === 'termin' &&
+    UttaksperiodeValidatorer.erNoenPerioderIUke7EtterFamiliehendelsesdato(perioder, familiehendelsedato);
 
 export const useFormSubmitValidator = <T extends LeggTilEllerEndrePeriodeFormFormValues>() => {
     const intl = useIntl();

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -259,6 +259,7 @@
     "RedigeringPanel.UtenAktivitetskrav": "Parental benefits without activity requirements",
     "RedigeringPanel.Pleiepenger": "This period is rejected due to care benefits",
     "RedigeringPanel.KanMisteDager": "You lose days if you do not have parental benefits before the due date or in the first six weeks after birth.",
+    "RedigeringPanel.FerieUke7EtterTermin": "In the first six weeks after birth, you must use the mother's quota. If the baby is born after the due date, you may lose days if you have scheduled vacation instead of the mother's quota.",
     "RedigeringPanel.NyeDagerForklaring": "You have marked days that are not yet included in the plan. Select 'New period' to create a new period.",
     "RedigeringPanel.Maksimer": "Expand panel",
     "RedigeringPanel.Minimer": "Minimize panel",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -259,6 +259,7 @@
     "RedigeringPanel.Begge": "Begge",
     "RedigeringPanel.Pleiepenger": "Denne perioden er avslått grunnet pleiepenger",
     "RedigeringPanel.KanMisteDager": "Du mister dager hvis du ikke har foreldrepenger før termin eller i de seks første ukene etter fødsel.",
+    "RedigeringPanel.FerieUke7EtterTermin": "I de første seks ukene etter fødsel må du ha mødrekvote. Hvis barnet blir født etter termin, kan du miste dager om du har ferie i stedet for mødrekvote.",
     "RedigeringPanel.NyeDagerForklaring": "Du har markert dager som ikke er lagt til i planen ennå. Velg 'Ny periode' for å opprette en ny periode.",
     "RedigeringPanel.Maksimer": "Utvid panel",
     "RedigeringPanel.Minimer": "Minimer panel",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -257,6 +257,7 @@
     "RedigeringPanel.Begge": "Begge",
     "RedigeringPanel.Pleiepenger": "Denne perioden er avslått grunna pleiepenger",
     "RedigeringPanel.KanMisteDager": "Du mistar dagar hvis du ikkje har foreldrepengar før termin eller i dei seks første vekene etter fødsel.",
+    "RedigeringPanel.FerieUke7EtterTermin": "I dei første seks vekene etter fødsel må du ha mødrekvote. Viss barnet blir fødd etter termin, kan du mista dagar om du har ferie i staden for mødrekvote.",
     "RedigeringPanel.NyeDagerForklaring": "Du har markert dagar som ikkje er lagt til i planen enno. Velg 'Ny periode' for å opprette ein ny periode.",
     "RedigeringPanel.Maksimer": "Utvid panel",
     "RedigeringPanel.Minimer": "Minimer panel",

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/PeriodeDetaljerOgInfoMeldinger.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/eksisterende-perioder/PeriodeDetaljerOgInfoMeldinger.tsx
@@ -20,7 +20,7 @@ export const PeriodeDetaljerOgInfoMeldinger = () => {
         uttakPerioderInkludertTapteDager,
     );
 
-    const { adopsjonFørFamhend, eøs, pleiepenger, kanMisteDager } = usePeriodeDetaljerAlerts({
+    const { adopsjonFørFamhend, eøs, pleiepenger, kanMisteDager, ferieUke7EtterTermin } = usePeriodeDetaljerAlerts({
         sammenslåtteValgtePerioder,
         eksisterendePerioderSomErValgt,
     });
@@ -73,6 +73,12 @@ export const PeriodeDetaljerOgInfoMeldinger = () => {
             {kanMisteDager && (
                 <Alert variant={kanMisteDager.variant} size="small">
                     {kanMisteDager.melding}
+                </Alert>
+            )}
+
+            {ferieUke7EtterTermin && (
+                <Alert variant={ferieUke7EtterTermin.variant} size="small">
+                    {ferieUke7EtterTermin.melding}
                 </Alert>
             )}
         </VStack>

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlertHooks.tsx
@@ -21,6 +21,7 @@ import {
     IKKE_REDIGERBAR_EØS,
     IKKE_REDIGERBAR_PLEIEPENGER,
     KAN_MISTE_DAGER,
+    FERIE_UKE_7_ETTER_TERMIN,
     MANGLER_GRADERINGSAKTIVITET_KALENDER,
     MANGLER_GRADERINGSAKTIVITET_LISTE,
     MANGLER_MORS_AKTIVITET_KALENDER,
@@ -201,6 +202,7 @@ export const usePeriodeDetaljerAlerts = (input: {
         eøs: tilAktiv(IKKE_REDIGERBAR_EØS, ctx),
         pleiepenger: tilAktiv(IKKE_REDIGERBAR_PLEIEPENGER, ctx),
         kanMisteDager: tilAktiv(KAN_MISTE_DAGER, ctx),
+        ferieUke7EtterTermin: tilAktiv(FERIE_UKE_7_ETTER_TERMIN, ctx),
     };
 };
 
@@ -313,6 +315,7 @@ type PeriodeDetaljerAlerts = {
     eøs?: AktivAlertMetadata;
     pleiepenger?: AktivAlertMetadata;
     kanMisteDager?: AktivAlertMetadata;
+    ferieUke7EtterTermin?: AktivAlertMetadata;
 };
 type ForskyvEllerErstattAlerts = {
     senerePerioderReadonly?: AktivAlertMetadata;

--- a/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/informasjonsAlerts.tsx
@@ -10,7 +10,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 
-import { kanMisteDagerVedEndringTilFerie } from '../../felles/uttaksplanValidatorer';
+import { kanMisteDagerVedEndringTilFerie, kanMisteDagerVedFerieIUke7EtterTermin } from '../../felles/uttaksplanValidatorer';
 import { Uttaksplanperiode, UttaksplanperiodeMedKunTapteDager, erEøsUttakPeriode } from '../../types/UttaksplanPeriode';
 import { harPeriodeDerMorsAktivitetIkkeErValgt, harPeriodeMedUkjentGraderingsaktivitet } from '../../utils/periodeUtils';
 import { Periode } from '../types';
@@ -147,6 +147,26 @@ export const KAN_MISTE_DAGER = lagAlertregel<PeriodeDetaljerKontekst>({
         erIkkeAdopsjon(ctx.familiesituasjon) &&
         !ctx.harPeriodeMedPleiepenger &&
         kanMisteDagerVedEndringTilFerie([...ctx.sammenslåtteValgtePerioder], ctx.familiehendelsedato),
+});
+
+export const FERIE_UKE_7_ETTER_TERMIN = lagAlertregel<PeriodeDetaljerKontekst>({
+    id: 'informasjonsAlerts.ferieUke7EtterTermin',
+    beskrivelse:
+        'Mor søker før fødsel (familiesituasjon er «termin») og har valgt å endre én ' +
+        'eller flere perioder i uke 7 etter termin til ferie. Dersom barnet blir født ' +
+        'etter termin, forskyves de seks lovpålagte ukene med mødrekvote, og ferien kan ' +
+        'da bli avslått med tapte dager som resultat.',
+    visningssteder: ['periode-detaljer-redigering'],
+    meldinger: [<FormattedMessage key="RedigeringPanel.FerieUke7EtterTermin" id="RedigeringPanel.FerieUke7EtterTermin" />],
+    variant: 'info',
+    type: 'kontekstuell',
+    skalVises: (ctx) =>
+        ctx.søker === 'MOR' &&
+        kanMisteDagerVedFerieIUke7EtterTermin(
+            [...ctx.sammenslåtteValgtePerioder],
+            ctx.familiehendelsedato,
+            ctx.familiesituasjon,
+        ),
 });
 
 export const ADOPSJON_PERIODE_FØR_FAMHEND = lagAlertregel<PeriodeDetaljerKontekst>({
@@ -326,6 +346,7 @@ export const INFORMASJONS_ALERTS: readonly AlertregelDoc[] = [
     MANGLER_GRADERINGSAKTIVITET_KALENDER,
     GRADERINGSAKTIVITET_IKKE_VALGT_EKSISTERENDE,
     KAN_MISTE_DAGER,
+    FERIE_UKE_7_ETTER_TERMIN,
     ADOPSJON_PERIODE_FØR_FAMHEND,
     IKKE_REDIGERBAR_EØS,
     IKKE_REDIGERBAR_PLEIEPENGER,

--- a/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
+++ b/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
@@ -11,6 +11,7 @@ dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 
 const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
+const ANTALL_UTTAKSDAGER_SYV_UKER = 35;
 
 type Periode = { fom: string; tom: string };
 
@@ -33,6 +34,27 @@ export const UttaksperiodeValidatorer = {
             Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(
                 ANTALL_UTTAKSDAGER_SEKS_UKER,
             );
+
+        return perioder.some((periode) => {
+            const fom = dayjs(periode.fom);
+            const tom = dayjs(periode.tom);
+            return tom.isSameOrAfter(førsteDag, 'day') && fom.isBefore(sisteDag, 'day');
+        });
+    },
+
+    /**
+     * Uke 7 etter familiehendelsedato — uken rett etter den lovpålagte
+     * seksukersperioden. Brukt til å varsle om at ferie/opphold lagt inn
+     * her kan bli avslått dersom fødselen skjer etter termin, siden de
+     * seks lovpålagte ukene da forskyves og kan overlappe med perioden.
+     */
+    erNoenPerioderIUke7EtterFamiliehendelsesdato(perioder: Periode[], familiehendelsedato: string) {
+        const førsteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(
+            ANTALL_UTTAKSDAGER_SEKS_UKER,
+        );
+        const sisteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerSenere(
+            ANTALL_UTTAKSDAGER_SYV_UKER,
+        );
 
         return perioder.some((periode) => {
             const fom = dayjs(periode.fom);


### PR DESCRIPTION
Mor søker før fødsel og legger inn ferie i uke 7 etter termin. Dersom barnet blir født etter termin, forskyves de seks lovpålagte ukene med mødrekvote, og ferien kan bli avslått med tapte dager som resultat.

Legger til en ny informasjons-alert som varsler om dette i redigeringspanelet når mor endrer en periode i uke 7 etter termin til ferie, og familiesituasjonen er termin (barnet ikke født ennå).

https://jira.adeo.no/browse/TFP-7073