### PR TITLE
TFP-7054: Erstatt BlåRamme med Chips.Removable i kalenderredigering

### DIFF
--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -224,7 +224,8 @@ const HeaderForDesktop = () => {
                         <FormattedMessage id="RedigeringPanel.EndreTil" />
                     </Heading>
                 </HStack>
-                <div onClickCapture={(e) => e.stopPropagation()}>
+                {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+                <div onClick={(e) => e.stopPropagation()}>
                     <Chips size="small">
                         <Chips.Removable onDelete={() => setValgtePerioder([])}>
                             {intl.formatMessage(
@@ -280,7 +281,8 @@ const HeaderForMobil = ({
                             <FormattedMessage id="RedigeringPanel.EndreTil" />
                         </Heading>
                         {erMinimert && (
-                            <div onClickCapture={(e) => e.stopPropagation()}>
+                            // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+                            <div onClick={(e) => e.stopPropagation()}>
                                 <Chips size="small">
                                     <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                         {intl.formatMessage(
@@ -300,7 +302,8 @@ const HeaderForMobil = ({
                 </HStack>
 
                 {!erMinimert && (
-                    <div onClickCapture={(e) => e.stopPropagation()}>
+                    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+                    <div onClick={(e) => e.stopPropagation()}>
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
@@ -59,16 +59,14 @@ const HeaderDesktop = ({ labels }: { labels: React.ReactNode }) => {
         <Box background="accent-soft" padding="space-16">
             <VStack gap="space-16">
                 <HStack justify="space-between" align="center" wrap={false}>
-                    <div onClickCapture={(e) => e.stopPropagation()}>
+                    {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+                    <div onClick={(e) => e.stopPropagation()}>
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(
                                     { id: 'RedigeringPanel.ValgteDager' },
                                     {
-                                        varighet: getVarighetString(
-                                            finnAntallDager(sammenslåtteValgtePerioder),
-                                            intl,
-                                        ),
+                                        varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
                                     },
                                 )}
                             </Chips.Removable>
@@ -130,16 +128,14 @@ const HeaderMobil = ({
                         />
                     )}
 
-                    <div onClickCapture={(e) => e.stopPropagation()}>
+                    {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+                    <div onClick={(e) => e.stopPropagation()}>
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(
                                     { id: 'RedigeringPanel.ValgteDager' },
                                     {
-                                        varighet: getVarighetString(
-                                            finnAntallDager(sammenslåtteValgtePerioder),
-                                            intl,
-                                        ),
+                                        varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
                                     },
                                 )}
                             </Chips.Removable>


### PR DESCRIPTION
## Hva
Erstatter den egendefinerte `BlåRamme`-komponenten med Aksel sin `Chips.Removable` i kalenderredigeringspanelene (`HvaVilDuEndreTilPanel`, `LeggTilEllerEndrePeriodePanel`).

## Detaljer
- Bruker `Chips.Removable` for å vise valgte perioder/dager med mulighet for å fjerne valget.
- Klikk på selve chippen stopper propagering til det ytre panelet (som ellers ville åpnet/valgt periode), via en `onClick`-wrapper i bubble-fasen.
- La til en begrunnet `eslint-disable-next-line` for `jsx-a11y/no-static-element-interactions` og `jsx-a11y/click-events-have-key-events` på wrapper-diven, siden den kun fungerer som en event-barriere og ikke er et interaktivt element i seg selv.
- Oppdaterte eksisterende tester i `UttaksplanKalender.test.tsx`.

## Testing
- `npx eslint` – ingen feil eller advarsler i endrede filer
- `npx prettier --check` – OK
- `npx vitest run --project=jsdom` i `packages/uttaksplan` – 275 tester passerer (20 test-filer)