### PR TITLE
fix: rett SonarCloud-warnings (unntatt TODO)

### DIFF
--- a/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
+++ b/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
@@ -23,6 +23,20 @@ type MellomlagreSøknadOptions = {
 
 export type MellomlagreSøknadFn = (options?: MellomlagreSøknadOptions) => Promise<void>;
 
+const tilMellomlagringsFeil = (error: unknown): Error => {
+    if (error instanceof HTTPError) {
+        if (error.response.status === 401 || error.response.status === 403) {
+            return error;
+        }
+        const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
+        return new ApiError('', 'Feil ved mellomlagring av engangsstønad', jsonResponse);
+    }
+    if (error instanceof Error) {
+        return error;
+    }
+    return new Error(String(error), { cause: error });
+};
+
 export const useEsMellomlagring = (
     personinfo: EsPersonopplysningerDto_fpoversikt,
     setVelkommen: (erVelkommen: boolean) => void,
@@ -71,18 +85,7 @@ export const useEsMellomlagring = (
                                 : {}),
                         });
                     } catch (error: unknown) {
-                        if (error instanceof HTTPError) {
-                            if (error.response.status === 401 || error.response.status === 403) {
-                                throw error;
-                            }
-
-                            const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                            throw new ApiError('', 'Feil ved mellomlagring av engangsstønad', jsonResponse);
-                        }
-                        if (error instanceof Error) {
-                            throw error;
-                        }
-                        throw new Error(String(error), { cause: error });
+                        throw tilMellomlagringsFeil(error);
                     }
                 } else {
                     // Ved avbryt så set ein Path = undefined og må så rydda opp i data her

--- a/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.test.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.test.tsx
@@ -114,7 +114,7 @@ describe('<EttersendingPage>', () => {
 
         expect(optionsTextContent).toContain('Terminbekreftelse');
         expect(optionsTextContent).toContain('Fødselsattest');
-        expect(optionsTextContent.length).toBe(2);
+        expect(optionsTextContent).toHaveLength(2);
     });
 
     it('skal preselektere dokumenttype dersom kun én manglende dokumenttype i queryparam', () => {

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
@@ -128,56 +128,41 @@ describe('Fordeling - MorAleneomsorgDekning80EttBarnFør1Okt2021', () => {
         expect(screen.getByText('Du kan endre datoer senere, også etter du har sendt søknaden.')).toBeInTheDocument();
     });
 
-    it('skal vise riktig informasjon om mor skal trekkes en dag av fellesperioden', async () => {
-        await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
-            args: {
-                ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        await userEvent.click(await screen.findByText('Jeg vil velge en annen dato'));
-        const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '30.08.2021');
-        fireEvent.blur(oppstart);
-        expect(screen.getByText('3 uker og 1 dag før fødsel.')).toBeInTheDocument();
-        expect(screen.getByText('1 dag tas fra fellesperioden.')).toBeInTheDocument();
-    });
-
-    it('skal vise riktig informasjon om mor skal mister en dag av foreldrepenger før fødsel', async () => {
-        await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
-            args: {
-                ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        await userEvent.click(await screen.findByText('Jeg vil velge en annen dato'));
-        const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '01.09.2021');
-        fireEvent.blur(oppstart);
-        expect(screen.getByText('2 uker og 4 dager før fødsel.')).toBeInTheDocument();
-        expect(screen.getByText('Du mister 1 dag.')).toBeInTheDocument();
-    });
-
-    it('skal vise riktig informasjon om mor mister 2 uker og 4 dager av foreldrepenger før fødsel', async () => {
-        await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
-            args: {
-                ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        await userEvent.click(await screen.findByText('Jeg vil velge en annen dato'));
-        const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '20.09.2021');
-        fireEvent.blur(oppstart);
-        expect(screen.getByText('1 dag før fødsel.')).toBeInTheDocument();
-        expect(screen.getByText('Du mister 2 uker og 4 dager.')).toBeInTheDocument();
-    });
+    it.each([
+        {
+            fom: '30.08.2021',
+            forventetPeriode: '3 uker og 1 dag før fødsel.',
+            forventetKonsekvens: '1 dag tas fra fellesperioden.',
+        },
+        {
+            fom: '01.09.2021',
+            forventetPeriode: '2 uker og 4 dager før fødsel.',
+            forventetKonsekvens: 'Du mister 1 dag.',
+        },
+        {
+            fom: '20.09.2021',
+            forventetPeriode: '1 dag før fødsel.',
+            forventetKonsekvens: 'Du mister 2 uker og 4 dager.',
+        },
+    ])(
+        'skal vise riktig informasjon når mor starter permisjon $fom',
+        async ({ fom, forventetPeriode, forventetKonsekvens }) => {
+            await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
+                args: {
+                    ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
+                    gåTilNesteSide,
+                    mellomlagreSøknadOgNaviger,
+                },
+            });
+            expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
+            await userEvent.click(await screen.findByText('Jeg vil velge en annen dato'));
+            const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
+            await userEvent.type(oppstart, fom);
+            fireEvent.blur(oppstart);
+            expect(screen.getByText(forventetPeriode)).toBeInTheDocument();
+            expect(screen.getByText(forventetKonsekvens)).toBeInTheDocument();
+        },
+    );
 
     it('kan ikke angi feil format for oppstartdato', async () => {
         await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
@@ -201,7 +186,23 @@ describe('Fordeling - MorAleneomsorgDekning80EttBarnFør1Okt2021', () => {
         ).toHaveLength(2);
     });
 
-    it('kan ikke angi for sen oppstartsdato', async () => {
+    it.each([
+        {
+            beskrivelse: 'for sen oppstartsdato',
+            fom: '22.09.2021',
+            forventetFeilmelding: 'Oppstartsdato for foreldrepenger kan være senest 21.09.2021.',
+        },
+        {
+            beskrivelse: 'for tidlig oppstartsdato',
+            fom: '28.06.2021',
+            forventetFeilmelding: 'Oppstartsdato for foreldrepenger kan være tidligst 02.07.2021.',
+        },
+        {
+            beskrivelse: 'for oppstartsdato på en helgedag',
+            fom: '03.07.2021',
+            forventetFeilmelding: 'Oppstartsdato for foreldrepenger må være en ukedag.',
+        },
+    ])('kan ikke angi $beskrivelse', async ({ fom, forventetFeilmelding }) => {
         await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
             args: {
                 ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
@@ -212,50 +213,12 @@ describe('Fordeling - MorAleneomsorgDekning80EttBarnFør1Okt2021', () => {
         expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
         await userEvent.click(screen.getByText('Jeg vil velge en annen dato'));
         const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '22.09.2021');
+        await userEvent.type(oppstart, fom);
         fireEvent.blur(oppstart);
 
         await userEvent.click(screen.getByText('Neste steg'));
         expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
-        expect(screen.getAllByText('Oppstartsdato for foreldrepenger kan være senest 21.09.2021.')).toHaveLength(2);
-    });
-
-    it('kan ikke angi for tidlig oppstartsdato', async () => {
-        await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
-            args: {
-                ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        await userEvent.click(screen.getByText('Jeg vil velge en annen dato'));
-        const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '28.06.2021');
-        fireEvent.blur(oppstart);
-
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
-        expect(screen.getAllByText('Oppstartsdato for foreldrepenger kan være tidligst 02.07.2021.')).toHaveLength(2);
-    });
-
-    it('kan ikke angi for oppstartsdato på en helgedag', async () => {
-        await MorAleneomsorgDekning80EttBarnFør1Okt2021.run({
-            args: {
-                ...MorAleneomsorgDekning80EttBarnFør1Okt2021.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        await userEvent.click(screen.getByText('Jeg vil velge en annen dato'));
-        const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '03.07.2021');
-        fireEvent.blur(oppstart);
-
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
-        expect(screen.getAllByText('Oppstartsdato for foreldrepenger må være en ukedag.')).toHaveLength(2);
+        expect(screen.getAllByText(forventetFeilmelding)).toHaveLength(2);
     });
 });
 
@@ -700,46 +663,6 @@ describe('Fordeling - MorDeltUttakEttBarnPrematurFødsel', () => {
         expect(screen.getAllByText('Du må oppgi en lengde på fellesperioden din.')).toHaveLength(2);
     });
 
-    it('skal ikke kunne skrive inn tekst for antall uker hun ønsker av fellesperioden', async () => {
-        await MorDeltUttakEttBarnPrematurFødsel.run({
-            args: {
-                ...MorDeltUttakEttBarnPrematurFødsel.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        expect(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
-        const ukerInput = screen.getByLabelText('Uker');
-        await userEvent.type(ukerInput, 'test');
-        fireEvent.blur(ukerInput);
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(
-            screen.getAllByText('Antall uker du ønsker å ha av fellesperioden må være et heltall større enn 0.'),
-        ).toHaveLength(2);
-    });
-
-    it('skal ikke kunne skrive inn desimaltall for antall uker hun ønsker av fellesperioden', async () => {
-        await MorDeltUttakEttBarnPrematurFødsel.run({
-            args: {
-                ...MorDeltUttakEttBarnPrematurFødsel.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        expect(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
-        const ukerInput = screen.getByLabelText('Uker');
-        await userEvent.type(ukerInput, '1,5');
-        fireEvent.blur(ukerInput);
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(
-            screen.getAllByText('Antall uker du ønsker å ha av fellesperioden må være et heltall større enn 0.'),
-        ).toHaveLength(2);
-    });
-
     it('skal ikke kunne skrive inn for mange uker for antall uker hun ønsker av fellesperioden', async () => {
         await MorDeltUttakEttBarnPrematurFødsel.run({
             args: {
@@ -758,7 +681,11 @@ describe('Fordeling - MorDeltUttakEttBarnPrematurFødsel', () => {
         expect(screen.getAllByText('Fellesperioden kan være maksimalt 20 uker lang.')).toHaveLength(2);
     });
 
-    it('skal ikke kunne skrive inn et negativt tall for antall uker hun ønsker av fellesperioden', async () => {
+    it.each([
+        { beskrivelse: 'skrive inn tekst', ukerVerdi: 'test' },
+        { beskrivelse: 'skrive inn desimaltall', ukerVerdi: '1,5' },
+        { beskrivelse: 'skrive inn et negativt tall', ukerVerdi: '-1' },
+    ])('skal ikke kunne $beskrivelse for antall uker hun ønsker av fellesperioden', async ({ ukerVerdi }) => {
         await MorDeltUttakEttBarnPrematurFødsel.run({
             args: {
                 ...MorDeltUttakEttBarnPrematurFødsel.args,
@@ -770,7 +697,7 @@ describe('Fordeling - MorDeltUttakEttBarnPrematurFødsel', () => {
         expect(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha')).toBeInTheDocument();
         await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
         const ukerInput = screen.getByLabelText('Uker');
-        await userEvent.type(ukerInput, '-1');
+        await userEvent.type(ukerInput, ukerVerdi);
         fireEvent.blur(ukerInput);
         await userEvent.click(screen.getByText('Neste steg'));
         expect(
@@ -888,7 +815,11 @@ describe('Fordeling - MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning', () 
         await userEvent.click(screen.getByText('Neste steg'));
         expect(screen.queryByText('Du må oppgi en lengde på fellesperioden din.')).not.toBeInTheDocument();
     });
-    it('skal ikke kunne oppgi desimaltall som antall dager', async () => {
+    it.each([
+        { beskrivelse: 'desimaltall', dagerVerdi: '1,4' },
+        { beskrivelse: 'tekst', dagerVerdi: 'to' },
+        { beskrivelse: 'negativt tall', dagerVerdi: '-2' },
+    ])('skal ikke kunne oppgi $beskrivelse som antall dager', async ({ dagerVerdi }) => {
         await MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.run({
             args: {
                 ...MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.args,
@@ -901,47 +832,7 @@ describe('Fordeling - MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning', () 
         await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
         expect(screen.getByText('Hvor mye av fellesperioden skal du ha?')).toBeInTheDocument();
         const dagerInput = screen.getByLabelText('Dager');
-        await userEvent.type(dagerInput, '1,4');
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
-        expect(
-            screen.getAllByText('Antall dager du ønsker å ha av fellesperioden må være et heltall større enn 0.'),
-        ).toHaveLength(2);
-    });
-    it('skal ikke kunne oppgi tekst som antall dager', async () => {
-        await MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.run({
-            args: {
-                ...MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        expect(screen.getByText(/Hvordan vil dere fordele fellesperioden på/)).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
-        expect(screen.getByText('Hvor mye av fellesperioden skal du ha?')).toBeInTheDocument();
-        const dagerInput = screen.getByLabelText('Dager');
-        await userEvent.type(dagerInput, 'to');
-        await userEvent.click(screen.getByText('Neste steg'));
-        expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
-        expect(
-            screen.getAllByText('Antall dager du ønsker å ha av fellesperioden må være et heltall større enn 0.'),
-        ).toHaveLength(2);
-    });
-    it('skal ikke kunne oppgi negativt tall som antall dager', async () => {
-        await MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.run({
-            args: {
-                ...MorDeltUttakEttBarnetter1Juli2024Med80ProsentDekning.args,
-                gåTilNesteSide,
-                mellomlagreSøknadOgNaviger,
-            },
-        });
-        expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
-        expect(screen.getByText(/Hvordan vil dere fordele fellesperioden på/)).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Jeg vil velge hvor mye av fellesperioden jeg skal ha'));
-        expect(screen.getByText('Hvor mye av fellesperioden skal du ha?')).toBeInTheDocument();
-        const dagerInput = screen.getByLabelText('Dager');
-        await userEvent.type(dagerInput, '-2');
+        await userEvent.type(dagerInput, dagerVerdi);
         await userEvent.click(screen.getByText('Neste steg'));
         expect(screen.getByText('Du må rette opp i følgende feil:')).toBeInTheDocument();
         expect(

--- a/apps/foreldrepengesoknad/src/utils/validationUtil.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/validationUtil.test.ts
@@ -31,31 +31,28 @@ describe('validationUtil', () => {
         expect(resultat).toBeNull();
     });
 
-    it('skal gi feilmelding når søker oppgir sitt eget fnr som andre parts fnr', () => {
+    it.each([
+        {
+            beskrivelse: 'søker oppgir sitt eget fnr som andre parts fnr',
+            andrePartFnr: '05510552883',
+            forventetFeilmelding: 'Du kan ikke oppgi ditt eget fødselsnummer',
+        },
+        {
+            beskrivelse: 'andre parts fnr er tom string',
+            andrePartFnr: '',
+            forventetFeilmelding: 'Du må skrive et gyldig fødselsnummer',
+        },
+        {
+            beskrivelse: 'annen part er under seksten',
+            andrePartFnr: '21091981146',
+            forventetFeilmelding: 'Feil i fødselsnummer. Den andre forelderen må være over seksten år gammel',
+        },
+    ])('skal gi feilmelding når $beskrivelse', ({ andrePartFnr, forventetFeilmelding }) => {
         const søkerFnr = '05510552883';
-        const andrePartFnr = '05510552883';
 
         const resultat = validateFødselsnummer(intl, søkerFnr, 'fødselsnummer')(andrePartFnr);
 
-        expect(resultat).toBe('Du kan ikke oppgi ditt eget fødselsnummer');
-    });
-
-    it('skal gi feilmelding når andre parts fnr er tom string', () => {
-        const søkerFnr = '05510552883';
-        const andrePartFnr = '';
-
-        const resultat = validateFødselsnummer(intl, søkerFnr, 'fødselsnummer')(andrePartFnr);
-
-        expect(resultat).toBe('Du må skrive et gyldig fødselsnummer');
-    });
-
-    it('skal gi feilmelding når annen part er under seksten', () => {
-        const søkerFnr = '05510552883';
-        const andrePartFnr = '21091981146';
-
-        const resultat = validateFødselsnummer(intl, søkerFnr, 'fødselsnummer')(andrePartFnr);
-
-        expect(resultat).toBe('Feil i fødselsnummer. Den andre forelderen må være over seksten år gammel');
+        expect(resultat).toBe(forventetFeilmelding);
     });
 
     it('skal gi feilmelding når frn er utenlandsk og fnr er tom string', () => {

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -85,7 +85,7 @@ export const PlanleggerDataFetcher = () => {
                 return data;
             }
             // Lag en dyp kopi for å unngå å modifisere original data
-            const modifiserteData = JSON.parse(JSON.stringify(data)) as KontoBeregningResultatDto;
+            const modifiserteData = structuredClone(data);
             // Liste over dekningsgrader vi skal prosessere
             const dekningsgrader = ['80', '100'] as const;
             // Bearbeide hver dekningsgrad

--- a/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -26,6 +26,20 @@ type MellomlagreSøknadOptions = {
 
 export type MellomlagreSøknadFn = (options?: MellomlagreSøknadOptions) => Promise<void>;
 
+const tilMellomlagringsFeil = (error: unknown): Error => {
+    if (error instanceof HTTPError) {
+        if (error.response.status === 401 || error.response.status === 403) {
+            return error;
+        }
+        const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
+        return new ApiError('', 'Feil ved mellomlagring av svangerskapspengesøknad', jsonResponse);
+    }
+    if (error instanceof Error) {
+        return error;
+    }
+    return new Error(String(error), { cause: error });
+};
+
 export const useMellomlagreSøknad = (
     søkerInfo: SvpPersonopplysningerDto_fpoversikt,
     setHarGodkjentVilkår: (harGodkjentVilkår: boolean) => void,
@@ -74,18 +88,7 @@ export const useMellomlagreSøknad = (
                                 : {}),
                         });
                     } catch (error: unknown) {
-                        if (error instanceof HTTPError) {
-                            if (error.response.status === 401 || error.response.status === 403) {
-                                throw error;
-                            }
-
-                            const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                            throw new ApiError('', 'Feil ved mellomlagring av svangerskapspengesøknad', jsonResponse);
-                        }
-                        if (error instanceof Error) {
-                            throw error;
-                        }
-                        throw new Error(String(error), { cause: error });
+                        throw tilMellomlagringsFeil(error);
                     }
                 } else {
                     setHarGodkjentVilkår(false);

--- a/apps/svangerskapspengesoknad/src/steps/perioder/perioderValidation.ts
+++ b/apps/svangerskapspengesoknad/src/steps/perioder/perioderValidation.ts
@@ -212,8 +212,8 @@ const validateSammenhengendePerioderFom = (
                 ? dayjs(sisteDagForSvangerskapspenger)
                 : dayjs(periode.tom);
         });
-    const tomSomErDagenFørFom = alleTom.find((tom) => dayjs(fom).subtract(1, 'd').isSame(dayjs(tom), 'day'));
-    if (!tomSomErDagenFørFom) {
+    const finnesTomSomErDagenFørFom = alleTom.some((tom) => dayjs(fom).subtract(1, 'd').isSame(dayjs(tom), 'day'));
+    if (!finnesTomSomErDagenFørFom) {
         return intl.formatMessage({ id: 'valideringsfeil.periode.ikkeSammenhengende' });
     }
     return null;

--- a/packages/observability/src/initFaro.test.ts
+++ b/packages/observability/src/initFaro.test.ts
@@ -97,46 +97,17 @@ describe('initFaro', () => {
             expect(resultat).toBe(exceptionItem);
         });
 
-        it('filtrerer bort exception med "401" i value', () => {
+        it.each([
+            { beskrivelse: '"401" i value', type: 'HTTPError', value: 'HTTP 401 Unauthorized' },
+            { beskrivelse: '"401" i type', type: 'Error 401', value: 'Noe gikk galt' },
+            { beskrivelse: '"Unauthorized" i value', type: 'Error', value: 'Unauthorized' },
+        ])('filtrerer bort exception med $beskrivelse', ({ type, value }) => {
             vi.stubGlobal('location', { hostname: 'www.nav.no' });
             initFaro({ app: APP });
 
             const beforeSend = hentBeforeSend();
 
-            const exceptionItem = lagExceptionItem({
-                type: 'HTTPError',
-                value: 'HTTP 401 Unauthorized',
-            });
-
-            const resultat = beforeSend(exceptionItem);
-            expect(resultat).toBeNull();
-        });
-
-        it('filtrerer bort exception med "401" i type', () => {
-            vi.stubGlobal('location', { hostname: 'www.nav.no' });
-            initFaro({ app: APP });
-
-            const beforeSend = hentBeforeSend();
-
-            const exceptionItem = lagExceptionItem({
-                type: 'Error 401',
-                value: 'Noe gikk galt',
-            });
-
-            const resultat = beforeSend(exceptionItem);
-            expect(resultat).toBeNull();
-        });
-
-        it('filtrerer bort exception med "Unauthorized" i value', () => {
-            vi.stubGlobal('location', { hostname: 'www.nav.no' });
-            initFaro({ app: APP });
-
-            const beforeSend = hentBeforeSend();
-
-            const exceptionItem = lagExceptionItem({
-                type: 'Error',
-                value: 'Unauthorized',
-            });
+            const exceptionItem = lagExceptionItem({ type, value });
 
             const resultat = beforeSend(exceptionItem);
             expect(resultat).toBeNull();

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
@@ -206,43 +206,15 @@ describe('useGyldigeKvotetyper - mors kvoter', () => {
         expect(result.current.gyldigeStønadskontoerForMor).toEqual(['FORELDREPENGER_FØR_FØDSEL']);
     });
 
-    it('skal ikke ha foreldrepenger før fødsel når familiehendelsesdato er valgt', () => {
+    it.each([
+        { beskrivelse: 'foreldrepenger før fødsel når familiehendelsesdato er valgt', fom: '2024-05-27' },
+        { beskrivelse: 'foreldrepenger når en har valgt dag før tre uker før fødsel', fom: '2024-05-24' },
+        { beskrivelse: 'noen gyldige kontotyper for mor når en har valgt dag mer enn 60 dager før fødsel', fom: '2024-03-24' },
+    ])('skal ikke ha $beskrivelse', ({ fom }) => {
         const { result } = renderHook(
             () =>
                 useGyldigeKvotetyper({
-                    valgtePerioder: [{ fom: '2024-05-27', tom: FAMILIEHENDELSESDATO }],
-                    harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
-                    ønskerFlerbarnsdager: false,
-                }),
-            {
-                wrapper: getWrapper(),
-            },
-        );
-
-        expect(result.current.gyldigeStønadskontoerForMor).toEqual([]);
-    });
-
-    it('skal ikke ha foreldrepenger når en har valgt dag før tre uker før fødsel', () => {
-        const { result } = renderHook(
-            () =>
-                useGyldigeKvotetyper({
-                    valgtePerioder: [{ fom: '2024-05-24', tom: FAMILIEHENDELSESDATO }],
-                    harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
-                    ønskerFlerbarnsdager: false,
-                }),
-            {
-                wrapper: getWrapper(),
-            },
-        );
-
-        expect(result.current.gyldigeStønadskontoerForMor).toEqual([]);
-    });
-
-    it('skal ikke ha noen gyldige kontotyper for mor når en har valgt dag mer enn 60 dager før fødsel', () => {
-        const { result } = renderHook(
-            () =>
-                useGyldigeKvotetyper({
-                    valgtePerioder: [{ fom: '2024-03-24', tom: FAMILIEHENDELSESDATO }],
+                    valgtePerioder: [{ fom, tom: FAMILIEHENDELSESDATO }],
                     harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
                     ønskerFlerbarnsdager: false,
                 }),


### PR DESCRIPTION
- Reduser cognitive complexity i useEsMellomlagring og useMellomlagreSøknad ved å skille ut feilnormalisering i egen funksjon (S3776)
- Slå sammen grupper på 3 nesten identiske tester til parameteriserte it.each-tester i FordelingSteg.test.tsx, initFaro.test.ts, kvoteRegler.test.tsx og validationUtil.test.ts (S5976)
- Bruk structuredClone i stedet for JSON.parse(JSON.stringify(...)) i Planlegger.tsx (S7784)
- Bruk .some() i stedet for .find() for boolsk sjekk i perioderValidation.ts (S7754)
- Bruk mer spesifikk assertion (toHaveLength) i EttersendingPage.test.tsx (S5906)

To S7785-warnings (foretrekk top-level await) i server/src/server.ts og server-uinnlogget/src/server.ts er bevisst latt urørt, siden esbuild bundler disse til CommonJS for produksjonsbygget som kjøres direkte med node i Docker-imaget, og CommonJS støtter ikke top-level await.