### PR TITLE
TFP-7038: normaliser familiehendelsedato til kalenderdato

### DIFF
--- a/packages/utils/src/barnUtils.test.ts
+++ b/packages/utils/src/barnUtils.test.ts
@@ -16,6 +16,18 @@ describe('barnUtils', () => {
         expect(new Date(dato)).toEqual(new Date('2021-10-05'));
     });
 
+    it('skal kutte bort UTC-tidskomponent fra fødselsdato slik at datosammenligninger ikke bommer med én dag', () => {
+        const barn = {
+            type: BarnType.FØDT,
+            fødselsdatoer: ['2026-06-18T00:00:00.000Z'],
+            termindato: '2026-06-30',
+        } as Barn;
+
+        const dato = getFamiliehendelsedato(barn);
+
+        expect(dato).toEqual('2026-06-18');
+    });
+
     it('skal returnere termindato når barn ikke er født', () => {
         const barn = {
             type: BarnType.UFØDT,

--- a/packages/utils/src/barnUtils.test.ts
+++ b/packages/utils/src/barnUtils.test.ts
@@ -19,9 +19,10 @@ describe('barnUtils', () => {
     it('skal kutte bort UTC-tidskomponent fra fødselsdato slik at datosammenligninger ikke bommer med én dag', () => {
         const barn = {
             type: BarnType.FØDT,
+            antallBarn: 1,
             fødselsdatoer: ['2026-06-18T00:00:00.000Z'],
             termindato: '2026-06-30',
-        } as Barn;
+        } satisfies Barn;
 
         const dato = getFamiliehendelsedato(barn);
 

--- a/packages/utils/src/barnUtils.ts
+++ b/packages/utils/src/barnUtils.ts
@@ -9,15 +9,26 @@ import {
     isUfødtBarn,
 } from '@navikt/fp-types';
 
+/**
+ * Familiehendelsedatoen er en kalenderdato. Enkelte kilder (f.eks.
+ * `barn.fødselsdatoer`) serialiserer den som UTC-midnatt, altså
+ * `"2026-06-18T00:00:00.000Z"`. Uten normalisering vil dayjs tolke rene
+ * datoperioder som `"2026-06-18"` som *lokal* midnatt, som i norsk tid ligger
+ * før UTC-midnatt. Datosammenligninger mot familiehendelsedatoen (f.eks. om en
+ * uttaksperiode er før/etter fødsel) blir da feil med én dag. Vi kutter derfor
+ * bort en eventuell tidskomponent og beholder bare `YYYY-MM-DD`.
+ */
+const tilKalenderdato = (dato: string): string => dato?.slice(0, 10);
+
 export const getFamiliehendelsedato = (barn: Barn): string => {
     if (isFødtBarn(barn) || isIkkeUtfyltTypeBarn(barn)) {
-        return barn.fødselsdatoer[0]!;
+        return tilKalenderdato(barn.fødselsdatoer[0]!);
     }
     if (isUfødtBarn(barn)) {
-        return barn.termindato;
+        return tilKalenderdato(barn.termindato);
     }
 
-    return barn.adopsjonsdato;
+    return tilKalenderdato(barn.adopsjonsdato);
 };
 
 type PersonMedFødselsdato = { fødselsdato: string; navn?: { fornavn?: string } };

--- a/packages/utils/src/barnUtils.ts
+++ b/packages/utils/src/barnUtils.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 
+import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import {
     Barn,
     Familiesituasjon,
@@ -9,16 +11,21 @@ import {
     isUfødtBarn,
 } from '@navikt/fp-types';
 
+dayjs.extend(utc);
+
 /**
  * Familiehendelsedatoen er en kalenderdato. Enkelte kilder (f.eks.
  * `barn.fødselsdatoer`) serialiserer den som UTC-midnatt, altså
- * `"2026-06-18T00:00:00.000Z"`. Uten normalisering vil dayjs tolke rene
- * datoperioder som `"2026-06-18"` som *lokal* midnatt, som i norsk tid ligger
- * før UTC-midnatt. Datosammenligninger mot familiehendelsedatoen (f.eks. om en
- * uttaksperiode er før/etter fødsel) blir da feil med én dag. Vi kutter derfor
- * bort en eventuell tidskomponent og beholder bare `YYYY-MM-DD`.
+ * `"2026-06-18T00:00:00.000Z"`. Uten normalisering vil datosammenligninger mot
+ * familiehendelsedatoen bomme med én dag: rene datoperioder som `"2026-06-18"`
+ * tolkes som *lokal* midnatt, som i norsk tid ligger før UTC-midnatt, slik at en
+ * periode som starter på selve fødselsdatoen feilaktig regnes som før fødsel.
+ *
+ * Vi tolker derfor datoen eksplisitt i UTC og formaterer den til `YYYY-MM-DD`.
+ * Dette er tidssone-uavhengig (i motsetning til lokal `dayjs(dato).format(...)`,
+ * som ville gjeninnført samme feil).
  */
-const tilKalenderdato = (dato: string): string => dato?.slice(0, 10);
+const tilKalenderdato = (dato: string): string => (dato ? dayjs.utc(dato).format(ISO_DATE_FORMAT) : dato);
 
 export const getFamiliehendelsedato = (barn: Barn): string => {
     if (isFødtBarn(barn) || isIkkeUtfyltTypeBarn(barn)) {


### PR DESCRIPTION
barn.fødselsdatoer kan komme som UTC-midnatt ("2026-06-18T00:00:00.000Z"). Sammenligninger mot valgte perioder (rene datoer tolket som lokal midnatt) ble da feil med én dag i norsk tidssone, slik at en periode som starter på selve fødselsdatoen ble regnet som før fødsel. Det ga blokkerende meldinger for mor både ved å markere kun fødselsdatoen ("kun annen part kan endre") og fødselsdato + dagen etter ("både før og etter fødselsdato").

getFamiliehendelsedato kutter nå bort en eventuell tidskomponent og returnerer YYYY-MM-DD. Dette treffer både crossing-regelen og kvoteRegler, og forklarer hvorfor feilen kun oppsto for fødte barn (termindato lagres uten UTC-tid).

https://jira.adeo.no/browse/TFP-7038