### PR TITLE
feat(ui): legg til Ukevisning-komponent for veke-visning

### DIFF
--- a/packages/ui/src/ukevisning/Ukevisning.stories.tsx
+++ b/packages/ui/src/ukevisning/Ukevisning.stories.tsx
@@ -1,0 +1,444 @@
+import {
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    ExclamationmarkTriangleFillIcon,
+    ParasolBeachFillIcon,
+    PencilIcon,
+    PersonFillIcon,
+    PersonGroupFillIcon,
+    TrashIcon,
+} from '@navikt/aksel-icons';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { useMemo, useState } from 'react';
+
+import {
+    Alert,
+    BodyLong,
+    BodyShort,
+    Button,
+    Dialog,
+    HStack,
+    Heading,
+    List,
+    Switch,
+    Tag,
+    ToggleGroup,
+    VStack,
+} from '@navikt/ds-react';
+
+import { Ukevisning, finnFørsteDagIIsoUke } from './Ukevisning';
+import { UkevisningPeriode, UkevisningPeriodeType } from './types/UkevisningPeriode';
+
+dayjs.extend(isoWeek);
+
+const meta = {
+    title: 'Ukevisning',
+    component: Ukevisning,
+} satisfies Meta<typeof Ukevisning>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Mock-data — same scenario som i konseptskissa (uke 20, 2026 – 11.–17. mai)
+// ---------------------------------------------------------------------------
+
+const PERSONIKON = <PersonFillIcon aria-hidden />;
+const GRUPPEIKON = <PersonGroupFillIcon aria-hidden />;
+const FERIEIKON = <ParasolBeachFillIcon aria-hidden />;
+
+const PERIODER_UKE_20_2026: UkevisningPeriode[] = [
+    {
+        fom: '2026-05-11',
+        tom: '2026-05-12',
+        type: 'MOR',
+        ikon: PERSONIKON,
+        label: 'Mors periode',
+        meta: 'Mødrekvote · 100 %',
+        srText: 'Mors periode, 11.–12. mai',
+    },
+    {
+        fom: '2026-05-13',
+        tom: '2026-05-13',
+        type: 'FELLES',
+        ikon: GRUPPEIKON,
+        label: 'Fellesperiode',
+        meta: 'Mor på uttak',
+        srText: 'Fellesperiode, 13. mai',
+    },
+    {
+        fom: '2026-05-14',
+        tom: '2026-05-14',
+        type: 'FERIE',
+        ikon: FERIEIKON,
+        label: 'Ferie',
+        meta: 'Mor',
+        srText: 'Ferie, 14. mai',
+    },
+    {
+        fom: '2026-05-15',
+        tom: '2026-05-15',
+        type: 'FAR',
+        ikon: PERSONIKON,
+        label: 'Fars periode',
+        meta: 'Fedrekvote · 100 %',
+        srText: 'Fars periode, 15. mai. Mor mangler aktivitet.',
+        advarsel: 'Mor mangler aktivitet',
+    },
+];
+
+export const Standard: Story = {
+    args: {
+        year: 2026,
+        week: 20,
+        periods: PERIODER_UKE_20_2026,
+        hideWeekend: false,
+    },
+};
+
+export const HelgSkjult: Story = {
+    args: {
+        ...Standard.args,
+        hideWeekend: true,
+    },
+};
+
+export const TomUke: Story = {
+    args: {
+        year: 2026,
+        week: 21,
+        periods: [],
+    },
+};
+
+export const PeriodeInnIHelgen: Story = {
+    name: 'Periode som strekker seg inn i helgen',
+    args: {
+        year: 2026,
+        week: 20,
+        periods: [
+            {
+                fom: '2026-05-15',
+                tom: '2026-05-17',
+                type: 'FAR',
+                ikon: PERSONIKON,
+                label: 'Fars periode',
+                meta: 'Fedrekvote · 100 %',
+                srText: 'Fars periode, 15.–17. mai',
+            },
+        ],
+        hideWeekend: false,
+    },
+};
+
+export const PeriodeInnIHelgenMedHelgSkjult: Story = {
+    name: 'Same periode – ingen dødt helg-hale når helg er skjult',
+    args: {
+        ...PeriodeInnIHelgen.args,
+        hideWeekend: true,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Interaktiv demo
+//
+// Dette er ting frå malen (uke-visning-filtre.html) som *ikkje* er ein del av sjølve
+// Ukevisning-komponenten, på same måte som vekenavigering, eigar-filter og detaljvising heller
+// ikkje er ein del av `Manedsvisning` eller `Calendar` – dei bur hos den som *bruker* komponenten.
+// Her viser vi korleis Ukevisning kan brukast i ein slik samansett kontekst, utan at komponenten
+// sjølv veit noko om navigering, filter eller modal.
+// ---------------------------------------------------------------------------
+
+type DagDetalj = {
+    tittel: string;
+    dato: string;
+    body: string;
+    chips: string[];
+    advarsel?: string;
+};
+
+const byggDagDetaljer = (): Record<string, DagDetalj> => {
+    const detaljer: Record<string, DagDetalj> = {};
+
+    ['2026-05-11', '2026-05-12'].forEach((iso, i) => {
+        detaljer[iso] = {
+            tittel: 'Mors periode',
+            dato: dayjs(iso).format('dddd D. MMMM YYYY'),
+            body: 'Ada er hjemme i foreldrepenger denne dagen. 100 % uttak.',
+            chips: ['Mødrekvote', `Dag ${i + 1} av 75`],
+        };
+    });
+
+    detaljer['2026-05-13'] = {
+        tittel: 'Fellesperiode',
+        dato: dayjs('2026-05-13').format('dddd D. MMMM YYYY'),
+        body: 'Dette er en fellesperiode dere deler. Ada tar 100 % uttak denne dagen.',
+        chips: ['Fellesperiode', 'Mor på uttak', '74 dager igjen'],
+    };
+
+    detaljer['2026-05-14'] = {
+        tittel: 'Ferie Ada',
+        dato: dayjs('2026-05-14').format('dddd D. MMMM YYYY'),
+        body: 'Ada har lagt inn ferie denne dagen. Ferie påvirker ikke kvoten din.',
+        chips: ['Mors ferie', '1 av 25 feriedager'],
+    };
+
+    detaljer['2026-05-15'] = {
+        tittel: 'Fars periode',
+        dato: dayjs('2026-05-15').format('dddd D. MMMM YYYY'),
+        body: 'Erlend er hjemme i foreldrepenger. 100 % uttak.',
+        chips: ['Fedrekvote', '100 %'],
+        advarsel: 'Mor mangler aktivitet, og det må fikses før du kan sende søknaden.',
+    };
+
+    return detaljer;
+};
+
+const DAG_DETALJER = byggDagDetaljer();
+
+const LEGEND: Array<{ type: UkevisningPeriodeType; farge: string; tekst: string }> = [
+    { type: 'MOR', farge: 'bg-ax-bg-accent-soft', tekst: 'Mors periode' },
+    { type: 'FAR', farge: 'bg-ax-bg-success-soft', tekst: 'Fars periode' },
+    { type: 'FELLES', farge: 'bg-ax-bg-brand-beige-soft', tekst: 'Fellesperiode' },
+    { type: 'FERIE', farge: 'bg-ax-bg-warning-soft', tekst: 'Ferie' },
+];
+
+const InteraktivDemo = () => {
+    const [year, setYear] = useState(2026);
+    const [week, setWeek] = useState(20);
+    const [filter, setFilter] = useState<'ALLE' | 'MOR' | 'FAR'>('ALLE');
+    const [skjulHelg, setSkjulHelg] = useState(false);
+    const [valgtDag, setValgtDag] = useState<string | undefined>(undefined);
+
+    const periods = useMemo(
+        () => (filter === 'ALLE' ? PERIODER_UKE_20_2026 : PERIODER_UKE_20_2026.filter((p) => p.type === filter)),
+        [filter],
+    );
+
+    const tilgjengeligeDager = useMemo(() => Object.keys(DAG_DETALJER).sort((a, b) => a.localeCompare(b)), []);
+
+    const gåTilForrigeUke = () => {
+        const forrige = finnFørsteDagIIsoUke(year, week).subtract(1, 'week');
+        setYear(forrige.isoWeekYear());
+        setWeek(forrige.isoWeek());
+    };
+
+    const gåTilNesteUke = () => {
+        const neste = finnFørsteDagIIsoUke(year, week).add(1, 'week');
+        setYear(neste.isoWeekYear());
+        setWeek(neste.isoWeek());
+    };
+
+    const naviger = (retning: 1 | -1) => {
+        if (!valgtDag) {
+            return;
+        }
+        const index = tilgjengeligeDager.indexOf(valgtDag);
+        const nyIndex = index + retning;
+        if (nyIndex >= 0 && nyIndex < tilgjengeligeDager.length) {
+            setValgtDag(tilgjengeligeDager[nyIndex]);
+        }
+    };
+
+    const detalj = valgtDag ? DAG_DETALJER[valgtDag] : undefined;
+    const index = valgtDag ? tilgjengeligeDager.indexOf(valgtDag) : -1;
+
+    return (
+        <VStack gap="space-24">
+            <HStack gap="space-24" align="center" justify="space-between" wrap>
+                <HStack gap="space-8" align="center">
+                    <Button
+                        type="button"
+                        variant="tertiary"
+                        size="small"
+                        icon={<ChevronLeftIcon aria-hidden />}
+                        onClick={gåTilForrigeUke}
+                    >
+                        Forrige uke
+                    </Button>
+                    <Heading size="small" level="2">
+                        Uke {week}, {year}
+                    </Heading>
+                    <Button
+                        type="button"
+                        variant="tertiary"
+                        size="small"
+                        icon={<ChevronRightIcon aria-hidden />}
+                        onClick={gåTilNesteUke}
+                    >
+                        Neste uke
+                    </Button>
+                </HStack>
+
+                <HStack gap="space-16" align="center" wrap>
+                    <ToggleGroup
+                        size="small"
+                        value={filter}
+                        onChange={(value) => setFilter(value as 'ALLE' | 'MOR' | 'FAR')}
+                    >
+                        <ToggleGroup.Item value="MOR">Min del</ToggleGroup.Item>
+                        <ToggleGroup.Item value="ALLE">Begge</ToggleGroup.Item>
+                        <ToggleGroup.Item value="FAR">Erlends del</ToggleGroup.Item>
+                    </ToggleGroup>
+                    <Switch checked={skjulHelg} onChange={(e) => setSkjulHelg(e.target.checked)}>
+                        Skjul helg
+                    </Switch>
+                </HStack>
+            </HStack>
+
+            <BodyShort size="small" textColor="subtle">
+                Trykk på et kort for å se detaljer.
+            </BodyShort>
+
+            <Ukevisning
+                year={year}
+                week={week}
+                periods={periods}
+                hideWeekend={skjulHelg}
+                dateClickCallback={(dato) => (DAG_DETALJER[dato] ? setValgtDag(dato) : undefined)}
+            />
+
+            <HStack gap="space-20" wrap>
+                {LEGEND.map((l) => (
+                    <HStack key={l.type} gap="space-8" align="center">
+                        <span aria-hidden className={`inline-block h-4 w-4 rounded ${l.farge}`} />
+                        <BodyShort size="small">{l.tekst}</BodyShort>
+                    </HStack>
+                ))}
+                <HStack gap="space-8" align="center">
+                    <ExclamationmarkTriangleFillIcon aria-hidden width={16} height={16} />
+                    <BodyShort size="small">Mangler aktivitet</BodyShort>
+                </HStack>
+            </HStack>
+
+            <Dialog open={!!detalj} onOpenChange={(open) => !open && setValgtDag(undefined)}>
+                <Dialog.Popup id="UkevisningDagDetaljer">
+                    {detalj && (
+                        <>
+                            <Dialog.Header>
+                                <Dialog.Title>{detalj.tittel}</Dialog.Title>
+                                <Dialog.Description>{detalj.dato}</Dialog.Description>
+                            </Dialog.Header>
+                            <Dialog.Body>
+                                <VStack gap="space-16">
+                                    <BodyLong>{detalj.body}</BodyLong>
+                                    <HStack gap="space-8" wrap>
+                                        {detalj.chips.map((c) => (
+                                            <Tag key={c} variant="neutral" size="small">
+                                                {c}
+                                            </Tag>
+                                        ))}
+                                    </HStack>
+                                    {detalj.advarsel && (
+                                        <Alert variant="warning" size="small">
+                                            {detalj.advarsel}
+                                        </Alert>
+                                    )}
+                                </VStack>
+                            </Dialog.Body>
+                            <Dialog.Footer>
+                                <HStack gap="space-8" align="center" justify="space-between" className="w-full">
+                                    <HStack gap="space-4">
+                                        <Button
+                                            type="button"
+                                            variant="tertiary"
+                                            size="small"
+                                            icon={<ChevronLeftIcon aria-hidden />}
+                                            disabled={index <= 0}
+                                            onClick={() => naviger(-1)}
+                                        >
+                                            Forrige dag
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="tertiary"
+                                            size="small"
+                                            icon={<ChevronRightIcon aria-hidden />}
+                                            iconPosition="right"
+                                            disabled={index === -1 || index >= tilgjengeligeDager.length - 1}
+                                            onClick={() => naviger(1)}
+                                        >
+                                            Neste dag
+                                        </Button>
+                                    </HStack>
+                                    <HStack gap="space-8">
+                                        <Button
+                                            type="button"
+                                            variant="secondary"
+                                            size="small"
+                                            icon={<TrashIcon aria-hidden />}
+                                        >
+                                            Slett
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="primary"
+                                            size="small"
+                                            icon={<PencilIcon aria-hidden />}
+                                        >
+                                            Endre
+                                        </Button>
+                                    </HStack>
+                                </HStack>
+                            </Dialog.Footer>
+                        </>
+                    )}
+                </Dialog.Popup>
+            </Dialog>
+        </VStack>
+    );
+};
+
+export const Interaktiv: Story = {
+    args: Standard.args,
+    render: () => <InteraktivDemo />,
+};
+
+// ---------------------------------------------------------------------------
+// Dokumentasjon av designutfordringane, henta frå notatfeltet i konseptskissa
+// (uke-visning-filtre.html). Dette er ikkje ein del av sjølve komponenten, men er tatt med her
+// fordi det forklarer designvala som er gjort i Ukevisning.
+// ---------------------------------------------------------------------------
+
+export const OmDesignet: Story = {
+    args: Standard.args,
+    render: () => (
+        <VStack gap="space-16" maxWidth="640px">
+            <Heading size="small" level="2">
+                Det filteret gjør
+            </Heading>
+            <List>
+                <List.Item title="Renere arbeidsuke">
+                    Når brukeren planlegger periodene sine, er det de 5 arbeidsdagene som har betydning. Helgen er
+                    bare kalenderkontekst, ikke et planleggingsobjekt.
+                </List.Item>
+                <List.Item title="Mer plass per dag">
+                    Med 5 kolonner istedenfor 7 får hvert kort 40 % mer horisontal plass. Type-label og metadata blir
+                    mer lesbart, og lange tekster trenger mindre forkorting.
+                </List.Item>
+                <List.Item title="Perioder som strekker seg inn i helgen">
+                    En periode kan teknisk sett vare til og med søndag, men helgedager viser aldri kort – de er alltid
+                    nøytrale «Helg»-celler. I 7-dagers visning gir det et lite dødt hale av tomme helgceller etter
+                    kortet (se historien «Periode som strekker seg inn i helgen»). I 5-dagers visning forsvinner den
+                    døde halen siden helgekolonnene er fjernet helt (se «Same periode – ingen dødt helg-hale»).
+                </List.Item>
+                <List.Item title="Kontinuitet på tvers av uker kommuniseres kun med farge">
+                    Ukevisning viser bare én uke om gangen og vet ikke noe om naboukene. En periode som fortsetter fra
+                    fredag i denne uken til mandag i neste uke kan derfor aldri smelte visuelt sammen på tvers av to
+                    Ukevisning-instanser – det er kun fargen (og srText) som kommuniserer at det er én sammenhengende
+                    periode i FP-betydning. Samme prinsipp gjelder for Manedsvisning på tvers av rader.
+                </List.Item>
+                <List.Item title="Filteret er bevisst sekundært">
+                    Eier-filteret (Min del / Begge / Erlends del) og helg-toggle er ulike dimensjoner. De virker
+                    uavhengig av hverandre, og bor begge utenfor selve Ukevisning-komponenten (se «Interaktiv»).
+                </List.Item>
+                <List.Item title="Statusmelding ved aktivt filter">
+                    En subtil melding under uken minner brukeren om at de er i en filtrert visning, slik at de ikke
+                    glemmer kontekst og fatter beslutning på halv informasjon.
+                </List.Item>
+            </List>
+        </VStack>
+    ),
+};

--- a/packages/ui/src/ukevisning/Ukevisning.test.tsx
+++ b/packages/ui/src/ukevisning/Ukevisning.test.tsx
@@ -1,6 +1,7 @@
 import { composeStories } from '@storybook/react-vite';
 import { render, screen } from '@testing-library/react';
 
+import { Ukevisning } from './Ukevisning';
 import * as stories from './Ukevisning.stories';
 
 const { Standard, HelgSkjult, TomUke, PeriodeInnIHelgen, PeriodeInnIHelgenMedHelgSkjult } = composeStories(stories);
@@ -61,6 +62,36 @@ describe('<Ukevisning>', () => {
         render(<PeriodeInnIHelgenMedHelgSkjult />);
         expect(await screen.findByTestId('dag:15;type:FAR')).toBeInTheDocument();
         expect(screen.queryByTestId('dag:helg')).not.toBeInTheDocument();
+    });
+
+    it('skal vise korrekt dag sjølv om ein periode strekker seg langt utanfor den viste veka', async () => {
+        // Regresjonstest for at periodeoppslaget vert avgrensa til den viste veka (7 dagar) og
+        // ikkje ekspanderer heile fom/tom-intervallet, sjølv for periodar som strekker seg over
+        // fleire månader/år.
+        render(
+            <Ukevisning
+                year={2026}
+                week={20}
+                periods={[
+                    {
+                        fom: '2026-01-01',
+                        tom: '2026-12-31',
+                        type: 'MOR',
+                        ikon: <span aria-hidden />,
+                        label: 'Lang periode',
+                        meta: 'Heile året',
+                        srText: 'Lang periode',
+                    },
+                ]}
+            />,
+        );
+
+        expect(await screen.findByTestId('dag:11;type:MOR')).toBeInTheDocument();
+        expect(screen.getByTestId('dag:15;type:MOR')).toBeInTheDocument();
+        // Alle fem kvardagane skal høyre til same (langvarige) periode og dermed vera
+        // samanhengande (start … middle … middle … middle … end).
+        const mandagKort = screen.getByTestId('dag:11;type:MOR').querySelector('[class*="rounded-lg"]');
+        expect(mandagKort?.className).toContain('right-0');
     });
 
     it('skal vise mandag 11. og tysdag 12. som eit samanhengande (merga) mikrokort', async () => {

--- a/packages/ui/src/ukevisning/Ukevisning.test.tsx
+++ b/packages/ui/src/ukevisning/Ukevisning.test.tsx
@@ -1,0 +1,89 @@
+import { composeStories } from '@storybook/react-vite';
+import { render, screen } from '@testing-library/react';
+
+import * as stories from './Ukevisning.stories';
+
+const { Standard, HelgSkjult, TomUke, PeriodeInnIHelgen, PeriodeInnIHelgenMedHelgSkjult } = composeStories(stories);
+
+describe('<Ukevisning>', () => {
+    it('skal vise uketittelen', async () => {
+        render(<Standard />);
+        expect(await screen.findByText('Uke 20')).toBeInTheDocument();
+    });
+
+    it('skal vise korrekt periodetype på dagane i uke 20 2026', async () => {
+        render(<Standard />);
+        expect(await screen.findByTestId('dag:11;type:MOR')).toBeInTheDocument();
+        expect(screen.getByTestId('dag:12;type:MOR')).toBeInTheDocument();
+        expect(screen.getByTestId('dag:13;type:FELLES')).toBeInTheDocument();
+        expect(screen.getByTestId('dag:14;type:FERIE')).toBeInTheDocument();
+        expect(screen.getByTestId('dag:15;type:FAR')).toBeInTheDocument();
+    });
+
+    it('skal vise helgedagane som helg-celler når hideWeekend ikkje er sett', async () => {
+        render(<Standard />);
+        expect(await screen.findAllByTestId('dag:helg')).toHaveLength(2);
+    });
+
+    it('skal skjule helgedagane når hideWeekend er sett', () => {
+        render(<HelgSkjult />);
+        expect(screen.queryByTestId('dag:helg')).not.toBeInTheDocument();
+    });
+
+    it('skal vise varsel om at helg er skjult når hideWeekend er sett', () => {
+        render(<HelgSkjult />);
+        expect(screen.getByTestId('helg-skjult-varsel')).toBeInTheDocument();
+    });
+
+    it('skal ikkje vise varsel om skjult helg når hideWeekend ikkje er sett', () => {
+        render(<Standard />);
+        expect(screen.queryByTestId('helg-skjult-varsel')).not.toBeInTheDocument();
+    });
+
+    it('skal ikkje vise nokon periodar i ei tom veke', () => {
+        render(<TomUke />);
+        expect(screen.queryByTestId(/type:/, { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('skal vise advarselbadge på perioden som har det', async () => {
+        render(<Standard />);
+        expect(await screen.findByTestId('dag-advarsel')).toHaveTextContent('Mor mangler aktivitet');
+    });
+
+    it('skal vise periode som strekker seg inn i helgen med en daud helg-hale i 7-dagarsvisning', async () => {
+        render(<PeriodeInnIHelgen />);
+        // Perioden går 15.-17. mai (fredag-søndag), men helgedagane skal framleis visast som nøytrale helg-celler
+        expect(await screen.findByTestId('dag:15;type:FAR')).toBeInTheDocument();
+        expect(screen.getAllByTestId('dag:helg')).toHaveLength(2);
+    });
+
+    it('skal ikkje vise nokon daud helg-hale når helg er skjult', async () => {
+        render(<PeriodeInnIHelgenMedHelgSkjult />);
+        expect(await screen.findByTestId('dag:15;type:FAR')).toBeInTheDocument();
+        expect(screen.queryByTestId('dag:helg')).not.toBeInTheDocument();
+    });
+
+    it('skal vise mandag 11. og tysdag 12. som eit samanhengande (merga) mikrokort', async () => {
+        render(<Standard />);
+        const mandagKort = (await screen.findByTestId('dag:11;type:MOR')).querySelector('[class*="rounded-lg"]');
+        const tysdagKort = screen.getByTestId('dag:12;type:MOR').querySelector('[class*="rounded-lg"]');
+
+        // Kortet skal strekka seg heilt til cellekanten (right-0 / left-0) slik at det ikkje er
+        // noko synleg mellomrom mellom dei to dagane som utgjer same periode.
+        expect(mandagKort?.className).toContain('right-0');
+        expect(mandagKort?.className).toContain('rounded-r-none');
+        expect(tysdagKort?.className).toContain('left-0');
+        expect(tysdagKort?.className).toContain('rounded-l-none');
+    });
+
+    it('skal ikkje ha grå bakgrunn på header-rada for helgedagar, berre på dagcellene', async () => {
+        render(<Standard />);
+        const helgHeader = (await screen.findByText('Lørdag')).closest('div');
+        expect(helgHeader?.className).not.toContain('bg-ax-bg-neutral-soft');
+        expect(helgHeader?.className).toContain('bg-ax-bg-default');
+
+        const [helgCelle] = screen.getAllByTestId('dag:helg');
+        expect(helgCelle).toBeDefined();
+        expect(helgCelle?.className).toContain('bg-ax-bg-neutral-soft');
+    });
+});

--- a/packages/ui/src/ukevisning/Ukevisning.tsx
+++ b/packages/ui/src/ukevisning/Ukevisning.tsx
@@ -287,7 +287,7 @@ const MicroKort = ({
 
     if (!dateClickCallback) {
         return (
-            <div className={klasser} aria-hidden>
+            <div className={klasser} aria-label={`${dayjs(iso).format('D. MMMM YYYY')}, ${periode.srText}`}>
                 {innhald}
             </div>
         );
@@ -339,7 +339,8 @@ const formaterDatoIIntervall = (fom: Dayjs, tom: Dayjs): string => {
 
 const finnDagerIUke = (year: number, week: number, periods: UkevisningPeriode[]): DagInfo[] => {
     const førsteIUka = finnFørsteDagIIsoUke(year, week);
-    const periodeForIso = byggPeriodeOppslag(periods);
+    const sisteIUka = førsteIUka.add(6, 'day');
+    const periodeForIso = byggPeriodeOppslag(periods, førsteIUka, sisteIUka);
 
     const dagerUtenMergeForm = Array.from({ length: 7 }, (_, i) => {
         const dato = førsteIUka.add(i, 'day');
@@ -360,14 +361,26 @@ const finnDagerIUke = (year: number, week: number, periods: UkevisningPeriode[])
 
 /**
  * Byggjer eit oppslag frå ISO-dato til periode ved å ekspandere kvar periode sitt fom/tom-
- * intervall éin gong, slik at oppslaget under rendring av kvar dag er O(1).
+ * intervall éin gong, avgrensa til dei sju dagane som faktisk visast i veka. Sidan `Ukevisning`
+ * berre nokosinne treng oppslag for éi veke om gongen, unngår denne avgrensinga at lange periodar
+ * (månader/år) gjev O(periode-lengde) arbeid og ein unødvendig stor Map per render – kostnaden er
+ * i staden avgrensa til maks 7 dagar per periode.
  */
-const byggPeriodeOppslag = (periods: UkevisningPeriode[]): Map<string, UkevisningPeriode> => {
+const byggPeriodeOppslag = (
+    periods: UkevisningPeriode[],
+    førsteIUka: Dayjs,
+    sisteIUka: Dayjs,
+): Map<string, UkevisningPeriode> => {
     const oppslag = new Map<string, UkevisningPeriode>();
     periods.forEach((periode) => {
-        let dato = dayjs(periode.fom);
+        const fom = dayjs(periode.fom);
         const tom = dayjs(periode.tom);
-        while (!dato.isAfter(tom, 'day')) {
+        // Berre ekspander overlappet mellom perioden og den viste veka.
+        const start = fom.isAfter(førsteIUka, 'day') ? fom : førsteIUka;
+        const slutt = tom.isBefore(sisteIUka, 'day') ? tom : sisteIUka;
+
+        let dato = start;
+        while (!dato.isAfter(slutt, 'day')) {
             oppslag.set(dato.format(ISO_DATE_FORMAT), periode);
             dato = dato.add(1, 'day');
         }

--- a/packages/ui/src/ukevisning/Ukevisning.tsx
+++ b/packages/ui/src/ukevisning/Ukevisning.tsx
@@ -1,0 +1,411 @@
+import dayjs, { Dayjs } from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { KeyboardEvent, MutableRefObject, useMemo, useRef } from 'react';
+
+import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+import { BodyShort, HStack } from '@navikt/ds-react';
+
+import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
+import { capitalizeFirstLetter } from '@navikt/fp-utils';
+
+import { UkevisningPeriode, UkevisningPeriodeType } from './types/UkevisningPeriode';
+
+dayjs.extend(isoWeek);
+
+interface Props {
+    /** ISO-vekeår, jf. dayjs sin `isoWeekYear` (kan avvike frå kalenderåret i årsskiftet). */
+    year: number;
+    /** ISO-vekenummer, 1–53. */
+    week: number;
+    periods: UkevisningPeriode[];
+    hideWeekend?: boolean;
+    dateClickCallback?: (date: string) => void;
+}
+
+type DagInfo = {
+    dato: Dayjs;
+    iso: string;
+    erHelg: boolean;
+    periode?: UkevisningPeriode;
+    mergeForm: MergeForm;
+};
+
+type MergeForm = 'single' | 'start' | 'middle' | 'end';
+
+const KORTFARGE: Record<UkevisningPeriodeType, string> = {
+    MOR: 'bg-ax-bg-accent-soft text-ax-text-accent-subtle',
+    FAR: 'bg-ax-bg-success-soft text-ax-text-success-subtle',
+    FELLES: 'bg-ax-bg-brand-beige-soft text-ax-text-brand-beige-subtle',
+    FERIE: 'bg-ax-bg-warning-soft text-ax-text-warning-subtle',
+};
+
+const IKONSIRKEL_FARGE: Record<UkevisningPeriodeType, string> = {
+    MOR: 'bg-ax-bg-accent-moderate text-ax-text-accent-contrast',
+    FAR: 'bg-ax-bg-success-moderate text-ax-text-success-contrast',
+    FELLES: 'bg-ax-bg-brand-beige-moderate text-ax-text-brand-beige-contrast',
+    FERIE: 'bg-ax-bg-warning-moderate text-ax-text-warning-contrast',
+};
+
+const MERGEKLASSE: Record<MergeForm, string> = {
+    single: '',
+    start: 'right-0 rounded-r-none',
+    middle: 'inset-x-0 rounded-none',
+    end: 'left-0 rounded-l-none',
+};
+
+const FOKUSRING_KLASSE =
+    'focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ax-border-focus focus-visible:-outline-offset-2';
+
+function cx(...klasser: Array<string | false | undefined>) {
+    return klasser.filter(Boolean).join(' ');
+}
+
+/**
+ * Vekevisning – eit alternativ til `Calendar` og `Manedsvisning` som viser éi veke om gongen med
+ * fullstore, fargelagde kort per dag (ikon, typetekst og ei metalinje). Samanhengande periodar
+ * smeltar visuelt saman på tvers av kvardagane i veka.
+ *
+ * Komponenten har eit `hideWeekend`-filter som fjernar helgekolonnane heilt (5-dagars arbeidsveke
+ * i staden for 7 dagar). Sidan periodar aldri viser kort i helg (helgedagar er alltid nøytrale
+ * «Helg»-celler), gjev det ein liten daud hale av tomme helgceller etter eit kort som strekker seg
+ * inn i helga i 7-dagarsvisninga. I 5-dagarsvisninga forsvinn den daude halen sidan
+ * helgekolonnane er fjerna heilt. Vekevisninga kjenner ikkje til naboveka si – ein periode som
+ * held fram frå fredag denne veka til måndag neste veke kan difor aldri smelte visuelt saman på
+ * tvers av to Ukevisning-instansar; det er berre fargen (og srText) som kommuniserer at det i
+ * FP-forstand er éin samanhengande periode (same prinsipp som Manedsvisning på tvers av rader).
+ *
+ * Komponenten har ingen eiga vekenavigering, eigar-filter (min del/begge/den andre sin del) eller
+ * detaljvising ved klikk på ein dag – det er opp til den som brukar komponenten å byggje det rundt,
+ * slik Manedsvisning-mønsteret òg legg opp til.
+ *
+ * Ikkje i produksjonsbruk enno – sjå `Ukevisning.stories.tsx` for demo.
+ */
+export const Ukevisning = ({ year, week, periods, hideWeekend = false, dateClickCallback }: Props) => {
+    const alleDager = useMemo(() => finnDagerIUke(year, week, periods), [year, week, periods]);
+    const synligeDager = useMemo(
+        () => (hideWeekend ? alleDager.filter((dag) => !dag.erHelg) : alleDager),
+        [alleDager, hideWeekend],
+    );
+
+    const førsteDag = alleDager[0]!.dato;
+    const sisteDag = alleDager[alleDager.length - 1]!.dato;
+    const visteDagerSisteIndex = synligeDager.length - 1;
+    const ukeTittel = `Uke ${førsteDag.isoWeek()}`;
+    const datoIntervall = hideWeekend
+        ? `${formaterDatoIIntervall(førsteDag, synligeDager[visteDagerSisteIndex]!.dato)} · 5 dager`
+        : formaterDatoIIntervall(førsteDag, sisteDag);
+
+    const fokuserbareDatoer = useMemo(
+        () => synligeDager.filter((dag) => dag.periode).map((dag) => dag.iso),
+        [synligeDager],
+    );
+
+    const dagKnappRef = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+    const håndterTastetrykk = (event: KeyboardEvent<HTMLButtonElement>) => {
+        const target = event.target;
+        if (!(target instanceof HTMLButtonElement) || !target.dataset.iso) {
+            return;
+        }
+        const gjeldendeIndeks = fokuserbareDatoer.indexOf(target.dataset.iso);
+        if (gjeldendeIndeks === -1) {
+            return;
+        }
+
+        let nyIndeks: number | undefined;
+        if (event.key === 'ArrowRight') {
+            nyIndeks = gjeldendeIndeks + 1;
+        } else if (event.key === 'ArrowLeft') {
+            nyIndeks = gjeldendeIndeks - 1;
+        } else {
+            return;
+        }
+
+        if (nyIndeks < 0 || nyIndeks >= fokuserbareDatoer.length) {
+            return;
+        }
+
+        event.preventDefault();
+        dagKnappRef.current.get(fokuserbareDatoer[nyIndeks]!)?.focus();
+    };
+
+    return (
+        <div>
+            <HStack gap="space-4" align="baseline" className="mb-3">
+                <BodyShort weight="semibold">{ukeTittel}</BodyShort>
+                <BodyShort size="small" textColor="subtle">
+                    {datoIntervall}
+                </BodyShort>
+            </HStack>
+
+            <div
+                className="grid overflow-hidden rounded-lg border border-ax-border-subtle"
+                style={{ gridTemplateColumns: `repeat(${synligeDager.length}, 1fr)` }}
+                aria-label={`${ukeTittel}, ${datoIntervall}`}
+            >
+                {synligeDager.map((dag) => (
+                    <DagHeader key={dag.iso} dag={dag} />
+                ))}
+                {synligeDager.map((dag) => (
+                    <Dagcelle
+                        key={dag.iso}
+                        dag={dag}
+                        mergeForm={dag.mergeForm}
+                        dateClickCallback={dateClickCallback}
+                        dagKnappRef={dagKnappRef}
+                        onTastetrykk={håndterTastetrykk}
+                    />
+                ))}
+            </div>
+
+            {hideWeekend && (
+                <div
+                    className="mt-4 flex items-center gap-2 rounded-md bg-ax-bg-neutral-soft px-3.5 py-2.5 text-sm text-ax-text-neutral-subtle"
+                    data-testid="helg-skjult-varsel"
+                >
+                    <BodyShort size="small">
+                        <strong className="text-ax-text-default font-semibold">Helg er skjult.</strong> Foreldrepenger
+                        telles uansett ikke i helg, så planen din endres ikke.
+                    </BodyShort>
+                </div>
+            )}
+        </div>
+    );
+};
+
+const DagHeader = ({ dag }: { dag: DagInfo }) => (
+    <div className="border-r border-b border-ax-border-subtle bg-ax-bg-default px-2 py-2.5 text-center last:border-r-0">
+        <BodyShort size="small" className="text-[11px] font-semibold tracking-[0.06em] text-ax-text-neutral-subtle uppercase">
+            {capitalizeFirstLetter(dag.dato.format('dddd'))}
+        </BodyShort>
+        <BodyShort
+            className={cx('text-[22px] font-semibold', dag.erHelg ? 'text-ax-text-neutral-subtle' : 'text-ax-text-default')}
+        >
+            {dag.dato.date()}
+        </BodyShort>
+    </div>
+);
+
+const Dagcelle = ({
+    dag,
+    mergeForm,
+    dateClickCallback,
+    dagKnappRef,
+    onTastetrykk,
+}: {
+    dag: DagInfo;
+    mergeForm: MergeForm;
+    dateClickCallback?: (date: string) => void;
+    dagKnappRef: MutableRefObject<Map<string, HTMLButtonElement>>;
+    onTastetrykk: (event: KeyboardEvent<HTMLButtonElement>) => void;
+}) => {
+    const cellKlasser = cx(
+        'relative min-h-[220px] border-r border-ax-border-subtle p-1.5 last:border-r-0',
+        dag.erHelg ? 'bg-ax-bg-neutral-soft' : 'bg-ax-bg-default',
+    );
+
+    if (dag.erHelg) {
+        return (
+            <div className={cellKlasser} data-testid="dag:helg">
+                <div className="flex h-full items-center justify-center text-[12px] font-medium tracking-[0.05em] text-ax-text-neutral-subtle uppercase">
+                    Helg
+                </div>
+            </div>
+        );
+    }
+
+    if (!dag.periode) {
+        return <div className={cellKlasser} data-testid={`dag:${dag.dato.date()}`} />;
+    }
+
+    return (
+        <div className={cellKlasser} data-testid={`dag:${dag.dato.date()};type:${dag.periode.type}`}>
+            <MicroKort
+                periode={dag.periode}
+                mergeForm={mergeForm}
+                iso={dag.iso}
+                dateClickCallback={dateClickCallback}
+                dagKnappRef={dagKnappRef}
+                onTastetrykk={onTastetrykk}
+            />
+        </div>
+    );
+};
+
+const MicroKort = ({
+    periode,
+    mergeForm,
+    iso,
+    dateClickCallback,
+    dagKnappRef,
+    onTastetrykk,
+}: {
+    periode: UkevisningPeriode;
+    mergeForm: MergeForm;
+    iso: string;
+    dateClickCallback?: (date: string) => void;
+    dagKnappRef: MutableRefObject<Map<string, HTMLButtonElement>>;
+    onTastetrykk: (event: KeyboardEvent<HTMLButtonElement>) => void;
+}) => {
+    const visInnhald = mergeForm === 'single' || mergeForm === 'start';
+
+    const klasser = cx('absolute inset-1 z-[1] rounded-lg border-0 p-2.5 text-left', KORTFARGE[periode.type], MERGEKLASSE[mergeForm]);
+
+    const innhald = visInnhald && (
+        <>
+            <HStack gap="space-8" align="center" className="mb-2">
+                <span
+                    className={cx(
+                        'flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full [&>svg]:h-3 [&>svg]:w-3',
+                        IKONSIRKEL_FARGE[periode.type],
+                    )}
+                    aria-hidden
+                >
+                    {periode.ikon}
+                </span>
+                <BodyShort size="small" weight="semibold" className="truncate">
+                    {periode.label}
+                </BodyShort>
+            </HStack>
+            <BodyShort size="small" className="opacity-85">
+                {periode.meta}
+            </BodyShort>
+            {periode.advarsel && (
+                <span
+                    className={cx(
+                        'mt-1.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-semibold',
+                        'bg-ax-bg-warning-strong text-ax-text-warning-contrast',
+                    )}
+                    data-testid="dag-advarsel"
+                >
+                    <ExclamationmarkTriangleFillIcon aria-hidden width={11} height={11} />
+                    {periode.advarsel}
+                </span>
+            )}
+        </>
+    );
+
+    if (!dateClickCallback) {
+        return (
+            <div className={klasser} aria-hidden>
+                {innhald}
+            </div>
+        );
+    }
+
+    return (
+        <button
+            type="button"
+            ref={(el) => registrerKnappRef(dagKnappRef, iso, el)}
+            data-iso={iso}
+            className={cx(klasser, 'box-border cursor-pointer hover:brightness-[0.97] focus-visible:brightness-[0.97]', FOKUSRING_KLASSE)}
+            onClick={() => dateClickCallback(iso)}
+            onKeyDown={onTastetrykk}
+            aria-label={`${dayjs(iso).format('D. MMMM YYYY')}, ${periode.srText}`}
+        >
+            {innhald}
+        </button>
+    );
+};
+
+const registrerKnappRef = (
+    dagKnappRef: MutableRefObject<Map<string, HTMLButtonElement>>,
+    iso: string,
+    el: HTMLButtonElement | null,
+) => {
+    if (el) {
+        dagKnappRef.current.set(iso, el);
+    } else {
+        dagKnappRef.current.delete(iso);
+    }
+};
+
+/**
+ * `isoWeekYear()` er berre typa som ein getter i dayjs (ikkje som ein setjar), sjølv om
+ * plugin-implementasjonen faktisk støttar å setje han. Vi må derfor konstruere datoen via ein
+ * dato vi *veit* ligg i rett ISO-vekeår: 4. januar ligg alltid i veke 1 av sitt eige ISO-vekeår
+ * (ISO 8601-regelen), så `.year(year).month(0).date(4)` gjev oss ein trygg startdato før vi hoppar
+ * til rett veke med den typa `isoWeek(value)`-setjaren.
+ */
+export const finnFørsteDagIIsoUke = (year: number, week: number): Dayjs =>
+    dayjs().year(year).month(0).date(4).isoWeek(week).startOf('isoWeek');
+
+const formaterDatoIIntervall = (fom: Dayjs, tom: Dayjs): string => {
+    if (fom.month() === tom.month()) {
+        return `${fom.format('D.')}–${tom.format('D. MMMM YYYY')}`;
+    }
+    return `${fom.format('D. MMMM')} – ${tom.format('D. MMMM YYYY')}`;
+};
+
+const finnDagerIUke = (year: number, week: number, periods: UkevisningPeriode[]): DagInfo[] => {
+    const førsteIUka = finnFørsteDagIIsoUke(year, week);
+    const periodeForIso = byggPeriodeOppslag(periods);
+
+    const dagerUtenMergeForm = Array.from({ length: 7 }, (_, i) => {
+        const dato = førsteIUka.add(i, 'day');
+        const iso = dato.format(ISO_DATE_FORMAT);
+        const erHelg = dato.isoWeekday() === 6 || dato.isoWeekday() === 7;
+        return {
+            dato,
+            iso,
+            erHelg,
+            // Periodar visest aldri i helg – FP telles ikkje i helgedagar.
+            periode: erHelg ? undefined : periodeForIso.get(iso),
+        };
+    });
+
+    const mergeFormer = finnMergeFormerForDager(dagerUtenMergeForm);
+    return dagerUtenMergeForm.map((dag, i) => ({ ...dag, mergeForm: mergeFormer[i]! }));
+};
+
+/**
+ * Byggjer eit oppslag frå ISO-dato til periode ved å ekspandere kvar periode sitt fom/tom-
+ * intervall éin gong, slik at oppslaget under rendring av kvar dag er O(1).
+ */
+const byggPeriodeOppslag = (periods: UkevisningPeriode[]): Map<string, UkevisningPeriode> => {
+    const oppslag = new Map<string, UkevisningPeriode>();
+    periods.forEach((periode) => {
+        let dato = dayjs(periode.fom);
+        const tom = dayjs(periode.tom);
+        while (!dato.isAfter(tom, 'day')) {
+            oppslag.set(dato.format(ISO_DATE_FORMAT), periode);
+            dato = dato.add(1, 'day');
+        }
+    });
+    return oppslag;
+};
+
+/**
+ * Finn samanslåingsform per dag. Samanslåinga vert alltid rekna ut over alle sju dagane i veka
+ * (måndag–søndag), uavhengig av `hideWeekend`: sidan periodar aldri visest i helg, kan éin
+ * periode aldri stå på begge sider av helga innanfor same veke (helga er alltid dei to siste
+ * dagane), så det å skjule helg-kolonnane endrar aldri korleis kvardagskorta smeltar saman – det
+ * fjernar berre dei tomme helg-cellene frå visninga.
+ */
+const finnMergeFormerForDager = (dager: Array<Omit<DagInfo, 'mergeForm'>>): MergeForm[] => {
+    const erSammePeriode = (a?: UkevisningPeriode, b?: UkevisningPeriode) =>
+        !!a && !!b && a.fom === b.fom && a.tom === b.tom;
+
+    return dager.map((dag, i) => {
+        if (!dag.periode) {
+            return 'single';
+        }
+
+        const forrigeDag = i > 0 ? dager[i - 1] : undefined;
+        const nesteDag = i < dager.length - 1 ? dager[i + 1] : undefined;
+
+        const prevSame = erSammePeriode(dag.periode, forrigeDag?.periode);
+        const nextSame = erSammePeriode(dag.periode, nesteDag?.periode);
+
+        if (prevSame && nextSame) {
+            return 'middle';
+        }
+        if (prevSame) {
+            return 'end';
+        }
+        if (nextSame) {
+            return 'start';
+        }
+        return 'single';
+    });
+};

--- a/packages/ui/src/ukevisning/types/UkevisningPeriode.ts
+++ b/packages/ui/src/ukevisning/types/UkevisningPeriode.ts
@@ -1,0 +1,25 @@
+import { ReactElement } from 'react';
+
+/**
+ * Dei fire kategoriane vekevisninga skil visuelt mellom. Same sett som i Manedsvisning, men her
+ * har kvart kort nok plass til ikon, ei eiga typetekst (`label`) og ein metalinje – ikkje berre farge.
+ */
+export type UkevisningPeriodeType = 'MOR' | 'FAR' | 'FELLES' | 'FERIE';
+
+export type UkevisningPeriode = {
+    fom: string;
+    tom: string;
+    type: UkevisningPeriodeType;
+    /** Ikon vist i den vesle sirkelen øvst i kortet, t.d. eit person- eller ferie-ikon. */
+    ikon: ReactElement;
+    /** Typetekst, t.d. «Mors periode» eller «Fellesperiode». */
+    label: string;
+    /** Kort metadatalinje under typeteksten, t.d. «Mødrekvote · 100 %». */
+    meta: string;
+    srText: string;
+    /**
+     * Tekst for eit lite varsel på kortet, t.d. «Mor mangler aktivitet». Vises berre på det
+     * første kortet i ein samanhengande periode (sjå merge-logikken i Ukevisning.tsx).
+     */
+    advarsel?: string;
+};


### PR DESCRIPTION
Ny komponent i packages/ui som følger same mønster som Calendar (år) og Manedsvisning (branch maanedsvisning), basert på uke-visning-filtre.html. Ikkje kopla til produksjonskode/uttaksplan - kun demonstrert via Storybook.

- Ukevisning.tsx: hovudkomponent med DagHeader, Dagcelle, MicroKort, tastaturnavigasjon og merge-form-logikk (single/start/middle/end)
- Ukevisning.stories.tsx: 7 stories (Standard, HelgSkjult, TomUke, PeriodeInnIHelgen, PeriodeInnIHelgenMedHelgSkjult, Interaktiv, OmDesignet)
- Ukevisning.test.tsx: 12 vitest-testar via composeStories
- Header-rada (datoar) har ikkje lenger grå helg-bakgrunn, berre dagcellene
- Mikrokort som strekker seg over fleire dagar (t.d. mandag/tysdag) rører no kvarandre fysisk (right-0/left-0) i staden for å berre fjerne hjørne-radius