### PR TITLE
TFP-7079: la far med aleneomsorg ta ut foreldrepenger to uker før ter…

### DIFF
--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
@@ -808,4 +808,92 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
             expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
         });
     });
+
+    // Regresjonstest for far med aleneomsorg (eller bare søker rett): FORELDREPENGER
+    // må følge samme to-ukers-grense som fedrekvote/mødrekvote/aktivitetsfri kvote,
+    // siden det ikke finnes noen annen forelder som kan dekke dagene før fødsel/termin.
+    describe('far med aleneomsorg — foreldrepenger før termin/fødsel', () => {
+        const TERMINDATO = '2024-06-10'; // Termin mandag 10. juni
+        // familiehendelsedato = 2024-06-17 (1 uke etter termin, barnet født etter termin)
+        // termindato - 2 uker (10 uttaksdager) = mandag 27. mai = tidligst tillatt startdato
+
+        const barnMedTermindato = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: [FAMILIEHENDELSESDATO],
+            termindato: TERMINDATO,
+        } satisfies ComponentProps<typeof UttaksplanDataProvider>['barn'];
+
+        it('skal ha foreldrepenger som gyldig kontotype for far med aleneomsorg når perioden starter nøyaktig 2 uker før termin', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-27', tom: '2024-06-21' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'ALENEOMSORG',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).toContain('FORELDREPENGER');
+        });
+
+        it('skal ikke ha foreldrepenger som gyldig kontotype for far med aleneomsorg når perioden starter før 2 uker før termin', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-24', tom: '2024-06-21' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'ALENEOMSORG',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).not.toContain('FORELDREPENGER');
+        });
+
+        it('skal fortsatt ikke ha foreldrepenger som gyldig kontotype for far med begge rett før familiehendelsesdato', () => {
+            const { result } = renderHook(
+                () =>
+                    useGyldigeKvotetyper({
+                        valgtePerioder: [{ fom: '2024-05-27', tom: '2024-06-21' }],
+                        harValgtSamtidigUttak: !HAR_VALGT_SAMTIDIG_UTTAK,
+                        ønskerFlerbarnsdager: false,
+                    }),
+                {
+                    wrapper: getWrapper({
+                        barn: barnMedTermindato,
+                        foreldreInfo: {
+                            søker: 'FAR_MEDMOR',
+                            rettighetType: 'BEGGE_RETT',
+                            navnPåForeldre: NAVN_PÅ_FORELDRE,
+                            erMedmorDelAvSøknaden: false,
+                        },
+                    }),
+                },
+            );
+
+            expect(result.current.gyldigeStønadskontoerForFarMedmor).not.toContain('FORELDREPENGER');
+        });
+    });
 });

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
@@ -316,9 +316,15 @@ const FAR_MEDMOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
             return false;
         }
         if (kunFarHarRett(k)) {
-            return !harPeriodeFørToUkerFørFamiliehendelsesdato(k);
+            if (harPeriodeFørToUkerFørFamiliehendelsesdato(k)) {
+                return false;
+            }
+            return true;
         }
-        return !harPeriodeFørFamiliehendelsesdato(k);
+        if (harPeriodeFørFamiliehendelsesdato(k)) {
+            return false;
+        }
+        return true;
     },
 };
 

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
@@ -111,17 +111,29 @@ const harPeriodeFørTreUkerFørFamDatoEllerEtterLikFamDato = (k: KvoteKontekst) 
 
 /** Felles forhåndsbetingelser som gjelder før vi sjekker den enkelte kvoten for mor. */
 const morErAktuell = (k: KvoteKontekst): boolean => {
-    if (kunFarHarRett(k)) {return false;}
-    if (erAdopsjon(k) && harPeriodeFørFamiliehendelsesdato(k)) {return false;}
-    if (krysserFamiliehendelse(k)) {return false;}
+    if (kunFarHarRett(k)) {
+        return false;
+    }
+    if (erAdopsjon(k) && harPeriodeFørFamiliehendelsesdato(k)) {
+        return false;
+    }
+    if (krysserFamiliehendelse(k)) {
+        return false;
+    }
     return true;
 };
 
 /** Felles forhåndsbetingelser som gjelder før vi sjekker den enkelte kvoten for far/medmor. */
 const farMedmorErAktuell = (k: KvoteKontekst): boolean => {
-    if (kunMorHarRett(k)) {return false;}
-    if (erAdopsjon(k) && harPeriodeFørFamiliehendelsesdato(k)) {return false;}
-    if (!kunFarHarRett(k) && krysserFamiliehendelse(k)) {return false;}
+    if (kunMorHarRett(k)) {
+        return false;
+    }
+    if (erAdopsjon(k) && harPeriodeFørFamiliehendelsesdato(k)) {
+        return false;
+    }
+    if (!kunFarHarRett(k) && krysserFamiliehendelse(k)) {
+        return false;
+    }
     return true;
 };
 
@@ -153,9 +165,15 @@ const MOR_FEDREKVOTE: Kvoteregel<KvoteKontekst> = {
         'Mor kan velge fedrekvote (overføring fra far) når perioden ikke er samtidig uttak, og — utenom ' +
         'adopsjon — ikke ligger innenfor de første seks ukene etter familiehendelsesdatoen.',
     erGyldig: (k) => {
-        if (!morErAktuell(k)) {return false;}
-        if (k.harValgtSamtidigUttak) {return false;}
-        if (!erAdopsjon(k) && harPeriodeFørSeksUkerEtterFamiliehendelsesdato(k)) {return false;}
+        if (!morErAktuell(k)) {
+            return false;
+        }
+        if (k.harValgtSamtidigUttak) {
+            return false;
+        }
+        if (!erAdopsjon(k) && harPeriodeFørSeksUkerEtterFamiliehendelsesdato(k)) {
+            return false;
+        }
         return true;
     },
 };
@@ -170,11 +188,21 @@ const MOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
         '60 dager før familiehendelsesdato og utenfor intervallet 3 uker før til familiehendelsesdato; ellers ' +
         'kan perioden ikke ligge innenfor de første seks ukene etter familiehendelsesdato.',
     erGyldig: (k) => {
-        if (!morErAktuell(k)) {return false;}
-        if (erAdopsjon(k)) {return true;}
-        if (!harKunEnPartRett(k) && harPeriodeFørSeksUkerEtterFamiliehendelsesdato(k)) {return false;}
-        if (harKunEnPartRett(k) && harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {return false;}
-        if (harKunEnPartRett(k) && harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {return false;}
+        if (!morErAktuell(k)) {
+            return false;
+        }
+        if (erAdopsjon(k)) {
+            return true;
+        }
+        if (!harKunEnPartRett(k) && harPeriodeFørSeksUkerEtterFamiliehendelsesdato(k)) {
+            return false;
+        }
+        if (harKunEnPartRett(k) && harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+            return false;
+        }
+        if (harKunEnPartRett(k) && harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
+            return false;
+        }
         return true;
     },
 };
@@ -199,11 +227,21 @@ const MOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
         'første ukene etter familiehendelsesdato, ikke i intervallet 3 uker før familiehendelsesdato til ' +
         'familiehendelsesdatoen, og ikke mer enn 60 dager før familiehendelsesdatoen.',
     erGyldig: (k) => {
-        if (!morErAktuell(k)) {return false;}
-        if (erAdopsjon(k)) {return true;}
-        if (harPeriodeInnenforFamDatoOgSeksUkerEtterFamDato(k)) {return false;}
-        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {return false;}
-        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {return false;}
+        if (!morErAktuell(k)) {
+            return false;
+        }
+        if (erAdopsjon(k)) {
+            return true;
+        }
+        if (harPeriodeInnenforFamDatoOgSeksUkerEtterFamDato(k)) {
+            return false;
+        }
+        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
+            return false;
+        }
+        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+            return false;
+        }
         return true;
     },
 };
@@ -228,10 +266,18 @@ const FAR_MEDMOR_MØDREKVOTE: Kvoteregel<KvoteKontekst> = {
         'ligger i intervallet 3 uker før familiehendelsesdato til familiehendelsesdatoen, og ikke ligger ' +
         'mer enn 2 uker før familiehendelsesdatoen.',
     erGyldig: (k) => {
-        if (!farMedmorErAktuell(k)) {return false;}
-        if (k.harValgtSamtidigUttak) {return false;}
-        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {return false;}
-        if (harPeriodeFørToUkerFørFamiliehendelsesdato(k)) {return false;}
+        if (!farMedmorErAktuell(k)) {
+            return false;
+        }
+        if (k.harValgtSamtidigUttak) {
+            return false;
+        }
+        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
+            return false;
+        }
+        if (harPeriodeFørToUkerFørFamiliehendelsesdato(k)) {
+            return false;
+        }
         return true;
     },
 };
@@ -266,8 +312,12 @@ const FAR_MEDMOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
         'inntil to uker før familiehendelsesdatoen — samme grense som for de andre kvotetypene til ' +
         'far/medmor — siden det da ikke finnes noen annen forelder som kan dekke dagene før fødsel.',
     erGyldig: (k) => {
-        if (!farMedmorErAktuell(k)) {return false;}
-        if (kunFarHarRett(k)) {return !harPeriodeFørToUkerFørFamiliehendelsesdato(k);}
+        if (!farMedmorErAktuell(k)) {
+            return false;
+        }
+        if (kunFarHarRett(k)) {
+            return !harPeriodeFørToUkerFørFamiliehendelsesdato(k);
+        }
         return !harPeriodeFørFamiliehendelsesdato(k);
     },
 };
@@ -283,12 +333,24 @@ const FAR_MEDMOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
         'familiehendelsesdatoen, eller i de første seks ukene etter familiehendelsesdato samtidig som ' +
         'samtidig uttak er valgt.',
     erGyldig: (k) => {
-        if (!farMedmorErAktuell(k)) {return false;}
-        if (k.ønskerFlerbarnsdager) {return true;}
-        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {return false;}
-        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {return false;}
-        if (harPeriodeInnenforFamDatoOgSeksUkerEtterFamDato(k) && k.harValgtSamtidigUttak) {return false;}
-        if (harPeriodeFørToUkerFørFamiliehendelsesdato(k)) {return false;}
+        if (!farMedmorErAktuell(k)) {
+            return false;
+        }
+        if (k.ønskerFlerbarnsdager) {
+            return true;
+        }
+        if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
+            return false;
+        }
+        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+            return false;
+        }
+        if (harPeriodeInnenforFamDatoOgSeksUkerEtterFamDato(k) && k.harValgtSamtidigUttak) {
+            return false;
+        }
+        if (harPeriodeFørToUkerFørFamiliehendelsesdato(k)) {
+            return false;
+        }
         return true;
     },
 };

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
@@ -261,8 +261,15 @@ const FAR_MEDMOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
     forelder: 'FAR_MEDMOR',
     kontotype: 'FORELDREPENGER',
     beskrivelse:
-        'Foreldrepenger kan velges av far/medmor når perioden ikke ligger før familiehendelsesdatoen.',
-    erGyldig: (k) => farMedmorErAktuell(k) && !harPeriodeFørFamiliehendelsesdato(k),
+        'Foreldrepenger kan velges av far/medmor når perioden ikke ligger før familiehendelsesdatoen. ' +
+        'Når kun far/medmor har rett (aleneomsorg eller bare søker rett), kan perioden i stedet ligge ' +
+        'inntil to uker før familiehendelsesdatoen — samme grense som for de andre kvotetypene til ' +
+        'far/medmor — siden det da ikke finnes noen annen forelder som kan dekke dagene før fødsel.',
+    erGyldig: (k) => {
+        if (!farMedmorErAktuell(k)) {return false;}
+        if (kunFarHarRett(k)) {return !harPeriodeFørToUkerFørFamiliehendelsesdato(k);}
+        return !harPeriodeFørFamiliehendelsesdato(k);
+    },
 };
 
 const FAR_MEDMOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {


### PR DESCRIPTION
…min/fødsel

Far med aleneomsorg (eller bare søker rett) fikk meldingen «Du har valgt en kombinasjon av dager som ikke er gyldig for noen foreldre» ved uttak to uker før termin/fødsel, selv om fedrekvote/mødrekvote/aktivitetsfri kvote allerede tillot dette.

Årsaken var at FAR_MEDMOR_FORELDREPENGER blokkerte alle perioder før familiehendelsesdatoen uten unntak for kun-far-har-rett, i motsetning til søsken-regelen for mor (MOR_FORELDREPENGER) som fikk et slikt unntak i TFP-6933. Regresjonen kan spores til PR #5252 (jan. 2026), som strammet inn FORELDREPENGER for far/medmor generelt — uten å skille ut tilfellet der far er eneste part med rett.

FAR_MEDMOR_FORELDREPENGER bruker nå samme to-ukers-grense (termindato- bevisst, jf. TFP-6989) som de andre kvotetypene til far/medmor når kun far/medmor har rett. For delt uttak (BEGGE_RETT) er oppførselen uendret.

https://jira.adeo.no/browse/TFP-7079