### PR TITLE
feat: aktiver CDN-serving av assets for alle apper

### DIFF
--- a/.github/workflows/build-engangsstonad.yml
+++ b/.github/workflows/build-engangsstonad.yml
@@ -27,6 +27,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: engangsstonad
       image_suffix: '/engangsstonad'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at engangsstonad laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /engangsstonad/soknad).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/engangsstonad/soknad/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -49,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-foreldrepengeoversikt.yml
+++ b/.github/workflows/build-foreldrepengeoversikt.yml
@@ -27,6 +27,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: foreldrepengeoversikt
       image_suffix: '/foreldrepengeoversikt'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at foreldrepengeoversikt laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /foreldrepenger/oversikt).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/foreldrepenger/oversikt/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -49,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-foreldrepengesoknad.yml
+++ b/.github/workflows/build-foreldrepengesoknad.yml
@@ -29,6 +29,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: foreldrepengesoknad
       image_suffix: '/foreldrepengesoknad'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at foreldrepengesoknad laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /foreldrepenger/soknad).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/foreldrepenger/soknad/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -51,7 +54,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-svangerskapspengesoknad.yml
+++ b/.github/workflows/build-svangerskapspengesoknad.yml
@@ -27,6 +27,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: svangerskapspengesoknad
       image_suffix: '/svangerskapspengesoknad'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at svangerskapspengesoknad laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /svangerskapspenger/soknad).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/svangerskapspenger/soknad/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -49,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-veiviser-fp-eller-es.yml
+++ b/.github/workflows/build-veiviser-fp-eller-es.yml
@@ -27,6 +27,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: veiviser-fp-eller-es
       image_suffix: '/veiviser-fp-eller-es'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at veiviser-fp-eller-es laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /foreldrepenger/foreldrepenger-eller-engangsstonad).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/foreldrepenger/foreldrepenger-eller-engangsstonad/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -49,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-veiviser-hvor-mye.yml
+++ b/.github/workflows/build-veiviser-hvor-mye.yml
@@ -27,6 +27,9 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: veiviser-hvor-mye
       image_suffix: '/veiviser-hvor-mye'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at veiviser-hvor-mye laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /foreldrepenger/hvor-mye).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/foreldrepenger/hvor-mye/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -49,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ on:
       vite-cdn-url:
         required: false
         type: string
-        description: 'CDN-URL som bakes inn i appens asset-referanser ved bygg (kun planlegger i dag)'
+        description: 'CDN-URL som bakes inn i appens asset-referanser ved bygg'
         default: ''
     outputs:
       build-version:

--- a/apps/engangsstonad/vite.config.ts
+++ b/apps/engangsstonad/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedConfigWithCrossorgin } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-engangsstonad.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedConfigWithCrossorgin(setupFileDirName), {
     base: '/engangsstonad/soknad',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 9113,
     },

--- a/apps/foreldrepengeoversikt/vite.config.ts
+++ b/apps/foreldrepengeoversikt/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedConfigWithCrossorgin } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-foreldrepengeoversikt.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedConfigWithCrossorgin(setupFileDirName), {
     base: '/foreldrepenger/oversikt',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 9110,
     },

--- a/apps/foreldrepengesoknad/vite.config.ts
+++ b/apps/foreldrepengesoknad/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedConfigWithCrossorgin } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-foreldrepengesoknad.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedConfigWithCrossorgin(setupFileDirName), {
     base: '/foreldrepenger/soknad',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 9114,
     },

--- a/apps/svangerskapspengesoknad/vite.config.ts
+++ b/apps/svangerskapspengesoknad/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedConfigWithCrossorgin } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-svangerskapspengesoknad.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedConfigWithCrossorgin(setupFileDirName), {
     base: '/svangerskapspenger/soknad',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 9112,
     },

--- a/apps/veiviser-fp-eller-es/vite.config.ts
+++ b/apps/veiviser-fp-eller-es/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedAppConfig } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-veiviser-fp-eller-es.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedAppConfig(setupFileDirName), {
     base: '/foreldrepenger/foreldrepenger-eller-engangsstonad',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 8091,
     },

--- a/apps/veiviser-hvor-mye/vite.config.ts
+++ b/apps/veiviser-hvor-mye/vite.config.ts
@@ -7,9 +7,20 @@ import { createSharedAppConfig } from '@navikt/fp-config-vite';
 
 const setupFileDirName = path.resolve(__dirname, './vitest/setupTests.ts');
 
+// Settes i build-workflowen (build-veiviser-hvor-mye.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens `base` fortsatt styrer routing (BrowserRouter) og API-prefiks.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedAppConfig(setupFileDirName), {
     base: '/foreldrepenger/hvor-mye',
+    ...(cdnUrl
+        ? {
+              experimental: {
+                  renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+              },
+          }
+        : {}),
     server: {
         port: 8092,
     },


### PR DESCRIPTION
Alle apper følger nå samme mønster som planlegger:
- vite.config.ts leser VITE_CDN_URL og bruker renderBuiltUrl
- build-workflow sender vite-cdn-url til build-jobben
- deploy-dev venter på upload-to-CDN før deploy

CDN-URLer:
- engangsstonad:           cdn.nav.no/teamforeldrepenger/engangsstonad/soknad/
- foreldrepengeoversikt:   cdn.nav.no/teamforeldrepenger/foreldrepenger/oversikt/
- foreldrepengesoknad:     cdn.nav.no/teamforeldrepenger/foreldrepenger/soknad/
- svangerskapspengesoknad: cdn.nav.no/teamforeldrepenger/svangerskapspenger/soknad/
- veiviser-fp-eller-es:    cdn.nav.no/teamforeldrepenger/foreldrepenger/foreldrepenger-eller-engangsstonad/
- veiviser-hvor-mye:       cdn.nav.no/teamforeldrepenger/foreldrepenger/hvor-mye/