### PR TITLE
TFP-7083: vis riktig forelder-navn for far-og-far i søknadens uttaksplan

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -10,7 +10,7 @@ import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
 import { getAktiveArbeidsforhold } from 'utils/arbeidsforholdUtils';
 import { erPeriodeIOpprinneligPlan } from 'utils/eksisterendeSakUtils';
 import { isFarEllerMedmor } from 'utils/isFarEllerMedmor';
-import { getErSøkerFarEllerMedmor, getKjønnFromFnr, getNavnPåForeldre } from 'utils/personUtils';
+import { getErFarOgFar, getErSøkerFarEllerMedmor, getKjønnFromFnr, getNavnPåForeldre } from 'utils/personUtils';
 
 import { Alert, BodyLong, Tabs } from '@navikt/ds-react';
 
@@ -89,6 +89,7 @@ export const UttaksplanSteg = ({
         : false;
 
     const erSøkerFarEllerMedmor = getErSøkerFarEllerMedmor(søkersituasjon.rolle);
+    const erFarOgFar = getErFarOgFar(søkersituasjon.rolle, annenForelder);
 
     const kvoteOppsummeringRef = useRef<HTMLDivElement>(null);
     const scrollToKvoteOppsummering = () => {
@@ -169,6 +170,7 @@ export const UttaksplanSteg = ({
                             søkersituasjon.rolle === 'medmor' ||
                             (søkersituasjon.rolle === 'mor' && getKjønnFromFnr(annenForelder) === 'K'),
                         erIkkeSøkerSpesifisert: false,
+                        erFarOgFar,
                     }}
                     valgtStønadskvote={valgteStønadskvoter}
                     harAktivitetskravIPeriodeUtenUttak={false}
@@ -177,9 +179,9 @@ export const UttaksplanSteg = ({
                     aktiveArbeidsforhold={aktiveArbeidsforhold}
                     erEndringssøknad={erEndringssøknad}
                 >
-                    <HvaErMulig erFarOgFar={false} loggExpansionCardOpen={loggExpansionCardOpen} />
+                    <HvaErMulig erFarOgFar={erFarOgFar} loggExpansionCardOpen={loggExpansionCardOpen} />
 
-                    <UforutsetteEndringer erFarOgFar={false} loggExpansionCardOpen={loggExpansionCardOpen} />
+                    <UforutsetteEndringer erFarOgFar={erFarOgFar} loggExpansionCardOpen={loggExpansionCardOpen} />
 
                     <div ref={kvoteOppsummeringRef}>
                         <KvoteOppsummering erInnsyn={false} visStatusIkoner />

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForslag.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useUttaksplanForslag.ts
@@ -1,7 +1,7 @@
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
 import { getDatoForAleneomsorg, getErMorUfør } from 'utils/annenForelderUtils';
-import { getErSøkerFarEllerMedmor, getKjønnFromFnr } from 'utils/personUtils';
+import { getErFarOgFar, getErSøkerFarEllerMedmor } from 'utils/personUtils';
 
 import {
     Barn,
@@ -219,7 +219,7 @@ export const useUttaksplanForslag = (
         });
     }
 
-    const erFarOgFar = getKjønnFromFnr(annenForelder) === 'M' && søkersituasjon.rolle === 'far';
+    const erFarOgFar = getErFarOgFar(søkersituasjon.rolle, annenForelder);
 
     const bareFarMedmorHarRett =
         søkersituasjon.rolle !== 'mor' &&

--- a/apps/foreldrepengesoknad/src/utils/personUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/personUtils.test.ts
@@ -7,6 +7,7 @@ import { getNavnGenitivEierform } from '@navikt/fp-utils';
 import messages from '../intl/nb_NO.json';
 import {
     formaterNavn,
+    getErFarOgFar,
     getErSøkerFarEllerMedmor,
     getKjønnFromFnr,
     getMorErAleneOmOmsorg,
@@ -78,6 +79,34 @@ describe('personUtils', () => {
         } as AnnenForelder;
         const kjønn = getKjønnFromFnr(annenForelder);
         expect(kjønn).toBeUndefined();
+    });
+
+    it('skal returnere true for erFarOgFar når søker er far og annen forelder er mann', () => {
+        const annenForelder = {
+            kanIkkeOppgis: false,
+            fnr: '08088611111',
+        } as AnnenForelder;
+
+        expect(getErFarOgFar('far', annenForelder)).toBe(true);
+    });
+
+    it('skal returnere false for erFarOgFar når søker er far og annen forelder er kvinne', () => {
+        const annenForelder = {
+            kanIkkeOppgis: false,
+            fnr: '05510552883',
+        } as AnnenForelder;
+
+        expect(getErFarOgFar('far', annenForelder)).toBe(false);
+    });
+
+    it('skal returnere false for erFarOgFar når søker ikke er far', () => {
+        const annenForelder = {
+            kanIkkeOppgis: false,
+            fnr: '08088611111',
+        } as AnnenForelder;
+
+        expect(getErFarOgFar('mor', annenForelder)).toBe(false);
+        expect(getErFarOgFar('medmor', annenForelder)).toBe(false);
     });
 
     it('skal returnere true når mor har aleneomsorg', () => {

--- a/apps/foreldrepengesoknad/src/utils/personUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/personUtils.ts
@@ -24,6 +24,14 @@ export const getKjønnFromFnr = (annenForelder: AnnenForelder): Kjønn_fpoversik
     return undefined;
 };
 
+/**
+ * Sann når søker er far og den andre forelderen også er mann (f.eks. to fedre ved adopsjon).
+ * Da representerer ikke domenerollene MOR/FAR_MEDMOR en faktisk mor, så generiske
+ * Mor/Far-tekster skal erstattes med foreldrenes faktiske navn.
+ */
+export const getErFarOgFar = (søkersituasjonRolle: Søkerrolle, annenForelder: AnnenForelder): boolean =>
+    søkersituasjonRolle === 'far' && getKjønnFromFnr(annenForelder) === 'M';
+
 export const getKjønnFromFnrString = (fnr: string): Kjønn_fpoversikt | undefined => {
     if (fnr.length !== 11) {
         return undefined;


### PR DESCRIPTION
 Uttaksplansteget i foreldrepengesoknad sende aldri med erFarOgFar til
 UttaksplanDataProvider/HvaErMulig/UforutsetteEndringer (erFarOgFar={false}
 var hardkoda), i motsetning til planlegger som fekk denne fiksen i #5724.
 Dette gjorde at «Hvem skal ha foreldrepenger?» i uttaksplan-kalenderen
 viste generisk «Mor»/«Far» i staden for forelderens faktiske navn når
 begge foreldrene er fedre.

 - Legg til delt getErFarOgFar(rolle, annenForelder) i personUtils.ts og bruk den i UttaksplanSteg.tsx (var heilt fråverande på foreldreInfo) og useUttaksplanForslag.ts (fjernar duplisert logikk).
 - Send faktisk erFarOgFar til HvaErMulig og UforutsetteEndringer i staden for hardkoda false.
 - Legg til enhetstestar for getErFarOgFar.

 https://jira.adeo.no/browse/TFP-7083

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>