### PR TITLE
fix: rydd opp SonarCloud-varsler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           esac
 
       - name: Installere dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -70,7 +70,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Installer Playwright (chromium)
-        run: pnpm --ignore-scripts --filter @navikt/fp-config-vite exec playwright install --with-deps chromium
+        run: pnpm --filter @navikt/fp-config-vite exec playwright install --with-deps chromium
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: turbo-${{ runner.os }}-master-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Installere dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
@@ -65,12 +65,12 @@ jobs:
           restore-keys: turbo-browser-${{ runner.os }}-master-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Installere dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Installer Playwright (chromium)
-        run: pnpm --filter @navikt/fp-config-vite exec playwright install --with-deps chromium
+        run: pnpm --ignore-scripts --filter @navikt/fp-config-vite exec playwright install --with-deps chromium
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG SERVER="server"
 
 WORKDIR /app
 
-COPY ${SERVER}/dist/index.js /app/index.js
+COPY ${SERVER}/dist/index.mjs /app/index.mjs
 COPY apps/${APP}/dist /app/public
 
-CMD ["index.js"]
+CMD ["index.mjs"]

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.test.tsx
@@ -201,7 +201,7 @@ describe('<Oppsummering>', () => {
 
         expect(await screen.findAllByText('Arbeidsforhold og inntekt')).toHaveLength(2);
         expect(
-            screen.queryByText('blir kontaktet av Nav for å sende opplysninger om din inntekt', { exact: false }),
+            screen.getByText('blir kontaktet av Nav for å sende opplysninger om din inntekt', { exact: false }),
         ).toBeInTheDocument();
 
         const arbeidsforholdOgInntektDiv = getCardDiv(screen.getAllByText('Arbeidsforhold og inntekt')[1]!);

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
@@ -245,10 +245,10 @@ describe('<HvorLangPeriodePlanleggerSteg>', () => {
 
         await userEvent.click(screen.getByText('100 % utbetaling over 49 uker'));
 
-        expect(screen.queryByText('Siste dag med foreldrepenger kan bli mandag 15. juni 2026')).toBeInTheDocument();
+        expect(screen.getByText('Siste dag med foreldrepenger kan bli mandag 15. juni 2026')).toBeInTheDocument();
 
         expect(
-            screen.queryByText(
+            screen.getByText(
                 'Dette er hvis dere har foreldrepenger sammenhengende fra omsorgsovertagelsen den 08. juli 2025.',
             ),
         ).toBeInTheDocument();

--- a/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.test.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.test.tsx
@@ -471,7 +471,7 @@ describe('<SituasjonSide>', () => {
 
         const alertErSynlig = () =>
             expect(
-                screen.queryByText('For å kunne ha rett til foreldrepenger må man tjene minst', { exact: false }),
+                screen.getByText('For å kunne ha rett til foreldrepenger må man tjene minst', { exact: false }),
             ).toBeInTheDocument();
 
         const alertErIkkeSynlig = () =>

--- a/packages/steg-egen-næring/src/EgenNæringPanel.test.tsx
+++ b/packages/steg-egen-næring/src/EgenNæringPanel.test.tsx
@@ -195,7 +195,7 @@ describe('<Arbeid som selvstendig næringsdrivende>', () => {
         await userEvent.click(screen.getByText('Neste steg'));
 
         expect(
-            screen.queryAllByText('Inntekten din etter endring må være et tall i hele kroner.')[0],
+            screen.getAllByText('Inntekten din etter endring må være et tall i hele kroner.')[0],
         ).toBeInTheDocument();
     });
 

--- a/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
+++ b/packages/uttaksplan/src/kalender/UttaksplanKalender.test.tsx
@@ -1032,7 +1032,7 @@ describe('UttaksplanKalender', () => {
         await userEvent.click(screen.getByText('Fars kvote'));
 
         expect(
-            screen.queryByText(
+            screen.getByText(
                 'De første seks ukene er vanligvis kun for mor.' +
                     ' I noen tilfeller kan du få foreldrepenger i stedet for mor.',
             ),
@@ -1378,17 +1378,17 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getAllByText('Endre')[0]!);
 
-        expect(screen.queryByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
 
         expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).not.toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Far'));
 
-        expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
+        expect(screen.getByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Begge'));
 
-        expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
+        expect(screen.getByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
     });
 
     it('skal ikke spørre om aktivitetskrav for far dersom flerbarnsdager er valgt', async () => {
@@ -1406,17 +1406,17 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getAllByText('Endre')[0]!);
 
-        expect(screen.queryByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
 
         expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).not.toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Far'));
 
-        expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
+        expect(screen.getByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Ja')[0]!);
 
-        expect(screen.queryByText('Far skal ha?')).toBeInTheDocument();
+        expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Fellesperiode')[1]!);
 
@@ -1438,26 +1438,26 @@ describe('UttaksplanKalender', () => {
 
         await userEvent.click(screen.getAllByText('Endre')[0]!);
 
-        expect(screen.queryByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
+        expect(screen.getByText('Hvem skal ha foreldrepenger?')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Begge'));
 
-        expect(screen.queryByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
+        expect(screen.getByText('Ønsker du å bruke flerbarnsdager for denne perioden?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Ja')[0]!);
 
-        expect(screen.queryByText('Mor skal ha?')).toBeInTheDocument();
+        expect(screen.getByText('Mor skal ha?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Fellesperiode')[1]!);
 
-        expect(screen.queryByText('Far skal ha?')).toBeInTheDocument();
+        expect(screen.getByText('Far skal ha?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Fellesperiode')[2]!);
 
         expect(screen.queryByText('Hva skal mor gjøre i denne perioden?')).not.toBeInTheDocument();
 
-        expect(screen.queryByText('Hvor mange prosent til mor?')).toBeInTheDocument();
-        expect(screen.queryByText('Hvor mange prosent til far?')).toBeInTheDocument();
+        expect(screen.getByText('Hvor mange prosent til mor?')).toBeInTheDocument();
+        expect(screen.getByText('Hvor mange prosent til far?')).toBeInTheDocument();
 
         const arbeidsprosentMor = screen.getByText('Hvor mange prosent til mor?');
         await userEvent.type(arbeidsprosentMor, '100');
@@ -1465,8 +1465,8 @@ describe('UttaksplanKalender', () => {
         const arbeidsprosentFar = screen.getByText('Hvor mange prosent til far?');
         await userEvent.type(arbeidsprosentFar, '100');
 
-        expect(screen.queryByText('Skal mor kombinere foreldrepenger med arbeid?')).toBeInTheDocument();
-        expect(screen.queryByText('Skal far kombinere foreldrepenger med arbeid?')).toBeInTheDocument();
+        expect(screen.getByText('Skal mor kombinere foreldrepenger med arbeid?')).toBeInTheDocument();
+        expect(screen.getByText('Skal far kombinere foreldrepenger med arbeid?')).toBeInTheDocument();
 
         await userEvent.click(screen.getAllByText('Nei')[1]!);
         await userEvent.click(screen.getAllByText('Nei')[2]!);

--- a/server-uinnlogget/package.json
+++ b/server-uinnlogget/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs",
+        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs --banner:js=\"import{createRequire as __createRequire}from'node:module';const require=__createRequire(import.meta.url);\"",
         "tsc:watch": "tsc --noEmit --watch",
         "start": "node ./server.js",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"

--- a/server-uinnlogget/package.json
+++ b/server-uinnlogget/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "esbuild ./src/index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js",
+        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs",
         "tsc:watch": "tsc --noEmit --watch",
         "start": "node ./server.js",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"

--- a/server-uinnlogget/package.json
+++ b/server-uinnlogget/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs --banner:js=\"import{createRequire as __createRequire}from'node:module';const require=__createRequire(import.meta.url);\"",
         "tsc:watch": "tsc --noEmit --watch",
-        "start": "node ./server.js",
+        "start": "node ./dist/index.mjs",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"
     },
     "dependencies": {

--- a/server-uinnlogget/src/index.ts
+++ b/server-uinnlogget/src/index.ts
@@ -1,11 +1,9 @@
 import { serverConfig } from '@navikt/fp-server-utils';
 
-import serverPromise from './server.js';
+import server from './server.js';
 
 const port = serverConfig.app.port;
 
-serverPromise.then((server) => {
-    server.listen(port, () => {
-        console.log(`Starting server at ${port}`);
-    });
+server.listen(port, () => {
+    console.log(`Starting server at ${port}`);
 });

--- a/server-uinnlogget/src/server.ts
+++ b/server-uinnlogget/src/server.ts
@@ -12,32 +12,28 @@ import {
 
 import { configureReverseProxyApi } from './reverseProxy';
 
-const createServer = async () => {
-    const server = express();
+const server = express();
 
-    await setupServerDefaults(server);
-    setupActuators(server);
+await setupServerDefaults(server);
+setupActuators(server);
 
-    const router = express.Router();
-    const publicRouter = express.Router();
+const router = express.Router();
+const publicRouter = express.Router();
 
-    // Logging i json format
-    server.use(logger.morganMiddleware);
+// Logging i json format
+server.use(logger.morganMiddleware);
 
-    setupSkjermleserCssTilgang(publicRouter);
+setupSkjermleserCssTilgang(publicRouter);
 
-    publicRouter.use(express.static('./public', { index: false }));
-    server.use(serverConfig.app.publicPath, publicRouter);
+publicRouter.use(express.static('./public', { index: false }));
+server.use(serverConfig.app.publicPath, publicRouter);
 
-    configureReverseProxyApi(router);
-    // Catch all route, må være sist
-    await setupAndServeHtml(router);
+configureReverseProxyApi(router);
+// Catch all route, må være sist
+await setupAndServeHtml(router);
 
-    server.use(serverConfig.app.publicPath, router);
+server.use(serverConfig.app.publicPath, router);
 
-    server.use(errorHandling);
+server.use(errorHandling);
 
-    return server;
-};
-
-export default createServer();
+export default server;

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "esbuild ./src/index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js",
+        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs",
         "test": "vitest run",
         "tsc:watch": "tsc --noEmit --watch",
         "start": "node ./server.js",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
         "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs --banner:js=\"import{createRequire as __createRequire}from'node:module';const require=__createRequire(import.meta.url);\"",
         "test": "vitest run",
         "tsc:watch": "tsc --noEmit --watch",
-        "start": "node ./server.js",
+        "start": "node ./dist/index.mjs",
         "clean": "rm -rf ./dist ./node_modules ./.turbo"
     },
     "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs",
+        "build": "esbuild ./src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs --banner:js=\"import{createRequire as __createRequire}from'node:module';const require=__createRequire(import.meta.url);\"",
         "test": "vitest run",
         "tsc:watch": "tsc --noEmit --watch",
         "start": "node ./server.js",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,9 @@
 import { logger, serverConfig } from '@navikt/fp-server-utils';
 
-import serverPromise from './server.js';
+import server from './server.js';
 
 const port = serverConfig.app.port;
 
-serverPromise.then((server) => {
-    server.listen(port, () => {
-        logger.info(`Starter server på ${port}`);
-    });
+server.listen(port, () => {
+    logger.info(`Starter server på ${port}`);
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,40 +15,36 @@ import { configureReverseProxyApi } from './reverseProxy.js';
 import { rewriteHtmlAmpersandsInQueryString } from './rewriteHtmlAmpersandsInQueryString';
 import { validerInnkommendeIdportenToken } from './tokenValidation.js';
 
-const createServer = async () => {
-    const server = express();
+const server = express();
 
-    await setupServerDefaults(server);
-    setupActuators(server);
+await setupServerDefaults(server);
+setupActuators(server);
 
-    const router = express.Router();
-    const publicRouter = express.Router();
+const router = express.Router();
+const publicRouter = express.Router();
 
-    // Logging i json format
-    server.use(logger.morganMiddleware);
+// Logging i json format
+server.use(logger.morganMiddleware);
 
-    // tidvis får vi &amp; fremfor & som separator i querystrings
-    server.use(rewriteHtmlAmpersandsInQueryString);
+// tidvis får vi &amp; fremfor & som separator i querystrings
+server.use(rewriteHtmlAmpersandsInQueryString);
 
-    // Skjermdeling krever tilgang til CSS uten å være innlogget!
-    setupSkjermleserCssTilgang(publicRouter);
+// Skjermdeling krever tilgang til CSS uten å være innlogget!
+setupSkjermleserCssTilgang(publicRouter);
 
-    // Server ferdig komprimerte gzip/br filer hvis mulig.
-    publicRouter.use(serveKomprimerteFilerHvisMulig);
+// Server ferdig komprimerte gzip/br filer hvis mulig.
+publicRouter.use(serveKomprimerteFilerHvisMulig);
 
-    publicRouter.use(express.static('./public', { index: false }));
-    server.use(serverConfig.app.publicPath, publicRouter);
+publicRouter.use(express.static('./public', { index: false }));
+server.use(serverConfig.app.publicPath, publicRouter);
 
-    server.use(validerInnkommendeIdportenToken);
-    configureReverseProxyApi(router);
-    // Catch all route, må være sist
-    await setupAndServeHtml(router);
+server.use(validerInnkommendeIdportenToken);
+configureReverseProxyApi(router);
+// Catch all route, må være sist
+await setupAndServeHtml(router);
 
-    server.use(serverConfig.app.publicPath, router);
+server.use(serverConfig.app.publicPath, router);
 
-    server.use(errorHandling);
+server.use(errorHandling);
 
-    return server;
-};
-
-export default createServer();
+export default server;


### PR DESCRIPTION
- Legg til --ignore-scripts på pnpm install/exec-kommandoer i GitHub Actions-workflows (githubactions:S6505).
- Bruk top-level await i server/server-uinnlogget sine server.ts i stedet for en async createServer()-wrapper (typescript:S7785). Krever ESM-bundling (esbuild --format=esm, dist/index.mjs) siden top-level await ikke støttes med cjs-format; Dockerfile oppdatert til å kopiere/kjøre index.mjs.
- Bytt queryByText/queryAllByText til getByText/getAllByText i positive toBeInTheDocument()-assertions i 5 testfiler (typescript:S9027). .not.toBeInTheDocument()-tilfeller er uendret.