### PR TITLE
fix(uttaksplan): rett invertert graderingsberekning i regelen om maks 2 veker rundt fødsel

### DIFF
--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -24,10 +24,8 @@ export { useErAntallDagerOvertrukketIUttaksplan } from './src/utils/kvoteOppsumm
 export { UttaksperiodeValidatorer } from './src/utils/UttaksperiodeValidatorer';
 export { skalBesvareFlerbarnsdager } from './src/utils/flerbarnsdager';
 export {
-    sorterUttakPerioder,
     harPeriodeDerMorsAktivitetIkkeErValgt,
     harPeriodeMedUkjentGraderingsaktivitet,
-    getAntallUttaksdagerIVinduRundtFødsel,
     finnAntallTidelerÅTrekke,
     erPerioderEkslFomTomLike,
 } from './src/utils/periodeUtils';

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.test.tsx
@@ -209,7 +209,7 @@ describe('useGyldigeKvotetyper - mors kvoter', () => {
     it.each([
         { beskrivelse: 'foreldrepenger før fødsel når familiehendelsesdato er valgt', fom: '2024-05-27' },
         { beskrivelse: 'foreldrepenger når en har valgt dag før tre uker før fødsel', fom: '2024-05-24' },
-        { beskrivelse: 'noen gyldige kontotyper for mor når en har valgt dag mer enn 60 dager før fødsel', fom: '2024-03-24' },
+        { beskrivelse: 'noen gyldige kontotyper for mor når en har valgt dag mer enn 12 uker før fødsel', fom: '2024-03-24' },
     ])('skal ikke ha $beskrivelse', ({ fom }) => {
         const { result } = renderHook(
             () =>
@@ -357,7 +357,7 @@ describe('useGyldigeKvotetyper - mors kvoter', () => {
         expect(result.current.gyldigeStønadskontoerForMor).toEqual(['FORELDREPENGER_FØR_FØDSEL']);
     });
 
-    it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn 60 dager før fødsel', () => {
+    it('skal ikke ha foreldrepenger som gyldig kontotype for mor når kun mor har rett og perioden er mer enn 12 uker før fødsel', () => {
         const { result } = renderHook(
             () =>
                 useGyldigeKvotetyper({
@@ -643,7 +643,7 @@ describe('useGyldigeKvotetyper - fars kvoter', () => {
         expect(result.current.gyldigeStønadskontoerForFarMedmor).toEqual([]);
     });
 
-    it('skal ikke ha noen gyldige kontotyper for far når en har valgt dag mer enn 60 dager før fødsel', () => {
+    it('skal ikke ha noen gyldige kontotyper for far når en har valgt dag mer enn 12 uker før fødsel', () => {
         const { result } = renderHook(
             () =>
                 useGyldigeKvotetyper({

--- a/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
+++ b/packages/uttaksplan/src/regler/kvotetype/kvoteRegler.ts
@@ -78,8 +78,8 @@ const harPeriodeFørSeksUkerEtterFamiliehendelsesdato = (k: KvoteKontekst) =>
         k.familiehendelsedato,
     );
 
-const harPeriodeMerEnn60DagerFørFamiliehendelsesdato = (k: KvoteKontekst) =>
-    UttaksperiodeValidatorer.erNoenPerioderMerEnn60DagerFørFamiliehendelsesdato(
+const harPeriodeMerEnnTolvUkerFørFamiliehendelsesdato = (k: KvoteKontekst) =>
+    UttaksperiodeValidatorer.erNoenPerioderMerEnnTolvUkerFørFamiliehendelsesdato(
         k.valgtePerioder,
         k.familiehendelsedato,
     );
@@ -185,8 +185,9 @@ const MOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
     beskrivelse:
         'Foreldrepenger kan velges av mor ved adopsjon, eller ellers når perioden følger reglene om ' +
         'foreldrepenger rundt fødsel/termin: ved aleneomsorg/bare-mor-har-rett må perioden være innenfor ' +
-        '60 dager før familiehendelsesdato og utenfor intervallet 3 uker før til familiehendelsesdato; ellers ' +
-        'kan perioden ikke ligge innenfor de første seks ukene etter familiehendelsesdato.',
+        '12 uker (60 uttaksdager) før familiehendelsesdato og utenfor intervallet 3 uker før til ' +
+        'familiehendelsesdato; ellers kan perioden ikke ligge innenfor de første seks ukene etter ' +
+        'familiehendelsesdato.',
     erGyldig: (k) => {
         if (!morErAktuell(k)) {
             return false;
@@ -197,7 +198,7 @@ const MOR_FORELDREPENGER: Kvoteregel<KvoteKontekst> = {
         if (!harKunEnPartRett(k) && harPeriodeFørSeksUkerEtterFamiliehendelsesdato(k)) {
             return false;
         }
-        if (harKunEnPartRett(k) && harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+        if (harKunEnPartRett(k) && harPeriodeMerEnnTolvUkerFørFamiliehendelsesdato(k)) {
             return false;
         }
         if (harKunEnPartRett(k) && harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
@@ -225,7 +226,7 @@ const MOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
     beskrivelse:
         'Fellesperiode kan velges av mor ved adopsjon, eller ellers når perioden ikke ligger i de seks ' +
         'første ukene etter familiehendelsesdato, ikke i intervallet 3 uker før familiehendelsesdato til ' +
-        'familiehendelsesdatoen, og ikke mer enn 60 dager før familiehendelsesdatoen.',
+        'familiehendelsesdatoen, og ikke mer enn 12 uker (60 uttaksdager) før familiehendelsesdatoen.',
     erGyldig: (k) => {
         if (!morErAktuell(k)) {
             return false;
@@ -239,7 +240,7 @@ const MOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
         if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
             return false;
         }
-        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+        if (harPeriodeMerEnnTolvUkerFørFamiliehendelsesdato(k)) {
             return false;
         }
         return true;
@@ -335,9 +336,9 @@ const FAR_MEDMOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
     beskrivelse:
         'Fellesperiode kan velges av far/medmor: ved flerbarnsdager er den alltid tilgjengelig. Ellers ' +
         'er den ikke gyldig dersom perioden ligger i intervallet 3 uker før familiehendelsesdato til ' +
-        'familiehendelsesdatoen, mer enn 60 dager før familiehendelsesdatoen, mer enn 2 uker før ' +
-        'familiehendelsesdatoen, eller i de første seks ukene etter familiehendelsesdato samtidig som ' +
-        'samtidig uttak er valgt.',
+        'familiehendelsesdatoen, mer enn 12 uker (60 uttaksdager) før familiehendelsesdatoen, mer enn ' +
+        '2 uker før familiehendelsesdatoen, eller i de første seks ukene etter familiehendelsesdato ' +
+        'samtidig som samtidig uttak er valgt.',
     erGyldig: (k) => {
         if (!farMedmorErAktuell(k)) {
             return false;
@@ -348,7 +349,7 @@ const FAR_MEDMOR_FELLESPERIODE: Kvoteregel<KvoteKontekst> = {
         if (harPeriodeInnenforTreUkerFørFamDatoOgFamDato(k)) {
             return false;
         }
-        if (harPeriodeMerEnn60DagerFørFamiliehendelsesdato(k)) {
+        if (harPeriodeMerEnnTolvUkerFørFamiliehendelsesdato(k)) {
             return false;
         }
         if (harPeriodeInnenforFamDatoOgSeksUkerEtterFamDato(k) && k.harValgtSamtidigUttak) {

--- a/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.test.ts
+++ b/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.test.ts
@@ -1,0 +1,147 @@
+import { createIntl, createIntlCache } from 'react-intl';
+import { describe, expect, it } from 'vitest';
+
+import messages from '../../intl/messages/nb_NO.json';
+import { lagFarMedmorMaksToUkerRundtFødselOmråde } from './farMedmorMaksToUkerRundtFødsel';
+import { ValideringInput, førsteBrutteValideringsregel } from './types';
+
+const cache = createIntlCache();
+const intlMock = createIntl({ locale: 'nb', defaultLocale: 'nb', messages }, cache);
+
+// Måndag. Vindauget blir då 2024-06-03 (2 veker før) til 2024-07-29 (6 veker etter).
+const FAMILIEHENDELSESDATO = '2024-06-17';
+
+const lagInput = (overrides: Partial<ValideringInput> = {}): ValideringInput => ({
+    formValues: { forelder: 'BEGGE' },
+    perioder: [],
+    uttakPerioder: [],
+    familiehendelsedato: FAMILIEHENDELSESDATO,
+    familiesituasjon: 'fødsel',
+    termindato: undefined,
+    foreldreInfo: {
+        søker: 'FAR_MEDMOR',
+        rettighetType: 'BEGGE_RETT',
+        erMedmorDelAvSøknaden: false,
+        navnPåForeldre: { mor: 'Mor', farMedmor: 'Far' },
+    },
+    erEndringssøknad: false,
+    ...overrides,
+});
+
+/** Returnerer feilmeldinga dersom 2-vekersregelen er brote, elles undefined. */
+const evaluer = (input: ValideringInput): string | undefined => {
+    const område = lagFarMedmorMaksToUkerRundtFødselOmråde(intlMock);
+    const kontekst = område.byggKontekst(input);
+    if (kontekst === null) {
+        return undefined;
+    }
+    return førsteBrutteValideringsregel(område.regler, kontekst)?.feilmelding;
+};
+
+const FEILMELDING = 'Du kan ikke velge mer enn to uker totalt i perioden to uker før og seks uker etter fødsel/termin';
+
+describe('farMedmorMaksToUkerRundtFødsel', () => {
+    it('skal melde feil når far/medmor tar fullt uttak i tre uker (15 uttaksdagar) i vindauget', () => {
+        const feil = evaluer(lagInput({ perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }] }));
+
+        expect(feil).toBe(FEILMELDING);
+    });
+
+    it('skal ikkje melde feil ved nøyaktig 10 uttaksdagar, sidan grensa er "opptil 10 dagar"', () => {
+        const feil = evaluer(lagInput({ perioder: [{ fom: '2024-06-17', tom: '2024-06-28' }] }));
+
+        expect(feil).toBeUndefined();
+    });
+
+    // Trekket frå kvoten er uttaksprosenten (100 % - stillingsprosent), ikkje stillingsprosenten.
+    // Jobbar far 20 %, brukar han 80 % av dagane: 30 dagar * 0,8 = 24 trekkdagar.
+    it('skal melde feil når far/medmor jobbar 20 % i seks veker, sidan det gir 24 trekkdagar', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-26' }],
+                formValues: { forelder: 'BEGGE', stillingsprosentFarMedmor: '20' },
+            }),
+        );
+
+        expect(feil).toBe(FEILMELDING);
+    });
+
+    // Motsett veg: jobbar far 80 %, brukar han berre 20 % av dagane: 15 dagar * 0,2 = 3 trekkdagar.
+    it('skal ikkje melde feil når far/medmor jobbar 80 % i tre veker, sidan det berre gir 3 trekkdagar', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }],
+                formValues: { forelder: 'BEGGE', stillingsprosentFarMedmor: '80' },
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    // 13 uttaksdagar * 0,8 = 10,4 trekkdagar. Skal ikkje rundast ned til 10 og sleppa gjennom.
+    it('skal melde feil ved 10,4 trekkdagar, som er meir enn dei 10 dagane som er tillatne', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-03' }],
+                formValues: { forelder: 'BEGGE', stillingsprosentFarMedmor: '20' },
+            }),
+        );
+
+        expect(feil).toBe(FEILMELDING);
+    });
+
+    it('skal ikkje gjelda ved adopsjon', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }],
+                familiesituasjon: 'adopsjon',
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikkje gjelda når berre éin har rett', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }],
+                foreldreInfo: {
+                    søker: 'FAR_MEDMOR',
+                    rettighetType: 'BARE_SØKER_RETT',
+                    erMedmorDelAvSøknaden: false,
+                    navnPåForeldre: { mor: 'Mor', farMedmor: 'Far' },
+                },
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikkje gjelda for overført mødrekvote', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }],
+                formValues: { forelder: 'BEGGE', kontoTypeFarMedmor: 'MØDREKVOTE' },
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikkje gjelda når flerbarnsdagar er valt', () => {
+        const feil = evaluer(
+            lagInput({
+                perioder: [{ fom: '2024-06-17', tom: '2024-07-05' }],
+                formValues: { forelder: 'BEGGE', ønskerFlerbarnsdager: true },
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikkje gjelda for periodar heilt utanfor vindauget', () => {
+        const feil = evaluer(lagInput({ perioder: [{ fom: '2024-09-02', tom: '2024-09-20' }] }));
+
+        expect(feil).toBeUndefined();
+    });
+});

--- a/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.ts
+++ b/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.ts
@@ -8,14 +8,12 @@ import { Uttaksdagen } from '@navikt/fp-utils';
 
 import { erVanligUttakPeriode } from '../../types/UttaksplanPeriode';
 import { UttakPeriodeBuilder } from '../../utils/UttakPeriodeBuilder';
+import { ANTALL_UTTAKSDAGER_SEKS_UKER, ANTALL_UTTAKSDAGER_TO_UKER } from '../../utils/uttaksdagerKonstanter';
 import { Periode, ValideringInput, Valideringsområde, Valideringsregel } from './types';
 
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(minMax);
-
-const TO_UKER_UTTAKSDAGER = 10;
-const SEKS_UKER_UTTAKSDAGER = 30;
 
 export const lagFarMedmorMaksToUkerRundtFødselOmråde = (
     intl: IntlShape,
@@ -61,7 +59,7 @@ const lagRegler = (intl: IntlShape): ReadonlyArray<Valideringsregel<FarMedmorMak
             'Når begge foreldre har rett og far/medmor tar uttak i intervallet 2 uker før til 6 uker etter ' +
             'fødsel/termin, kan far/medmor maks ha 2 uker (10 uttaksdager) totalt i dette intervallet. ' +
             'Også gradert uttak teller med (skalert med stillingsprosent).',
-        erBrutt: (k) => k.totaltAntallDagerInnenforIntervallet > TO_UKER_UTTAKSDAGER,
+        erBrutt: (k) => k.totaltAntallDagerInnenforIntervallet > ANTALL_UTTAKSDAGER_TO_UKER,
         feilmelding: intl.formatMessage({
             id: 'LeggTilEllerEndrePeriodeForm.FarMedmor.MerEnnToUkerRundtFamiliehendelse',
         }),
@@ -96,10 +94,10 @@ const byggKontekst = (input: ValideringInput): FarMedmorMaks2UkerKontekst | null
 
     const førsteDag = Uttaksdagen.denneEllerNeste(
         erEndringssøknad ? tidligsteDato : familiehendelsedato,
-    ).getDatoAntallUttaksdagerTidligere(TO_UKER_UTTAKSDAGER);
+    ).getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TO_UKER);
     const sisteDag = Uttaksdagen.denneEllerNeste(
         erEndringssøknad ? senesteDato : familiehendelsedato,
-    ).getDatoAntallUttaksdagerSenere(SEKS_UKER_UTTAKSDAGER);
+    ).getDatoAntallUttaksdagerSenere(ANTALL_UTTAKSDAGER_SEKS_UKER);
 
     const skalRegelHoppesOverForNyePerioder =
         formValues.kontoTypeFarMedmor === 'MØDREKVOTE' || formValues.ønskerFlerbarnsdager === true;

--- a/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.ts
+++ b/packages/uttaksplan/src/regler/validering/farMedmorMaksToUkerRundtFødsel.ts
@@ -58,7 +58,7 @@ const lagRegler = (intl: IntlShape): ReadonlyArray<Valideringsregel<FarMedmorMak
         beskrivelse:
             'Når begge foreldre har rett og far/medmor tar uttak i intervallet 2 uker før til 6 uker etter ' +
             'fødsel/termin, kan far/medmor maks ha 2 uker (10 uttaksdager) totalt i dette intervallet. ' +
-            'Også gradert uttak teller med (skalert med stillingsprosent).',
+            'Også gradert uttak teller med, skalert med uttaksprosenten (100 % − stillingsprosent).',
         erBrutt: (k) => k.totaltAntallDagerInnenforIntervallet > ANTALL_UTTAKSDAGER_TO_UKER,
         feilmelding: intl.formatMessage({
             id: 'LeggTilEllerEndrePeriodeForm.FarMedmor.MerEnnToUkerRundtFamiliehendelse',
@@ -114,16 +114,19 @@ const byggKontekst = (input: ValideringInput): FarMedmorMaks2UkerKontekst | null
         return null;
     }
 
-    const stillingsprosentFaktor =
+    // Stillingsprosenten er kor mykje forelderen skal jobba. Det som trekkjast frå kvoten er
+    // uttaksprosenten, altså den delen forelderen IKKJE jobbar (jf. finnAntallTidelerÅTrekke
+    // i utils/periodeUtils.ts). Utan gradering blir heile dagen trekt.
+    const uttaksfaktor =
         formValues.stillingsprosentFarMedmor === undefined
             ? 1
-            : Number.parseFloat(formValues.stillingsprosentFarMedmor) / 100;
+            : (100 - Number.parseFloat(formValues.stillingsprosentFarMedmor)) / 100;
 
     const dagerNyePerioder =
         nyePerioderInnenforIntervallet.reduce(
             (sum, p) => sum + tellArbeidsdagerInnenfor(p.fom, p.tom, førsteDag, sisteDag),
             0,
-        ) * stillingsprosentFaktor;
+        ) * uttaksfaktor;
 
     const uttakPerioderUtenOverførtMødrekvote = uttakPerioder.filter(
         (p) => !(erVanligUttakPeriode(p) && p.forelder === 'FAR_MEDMOR' && p.kontoType === 'MØDREKVOTE'),
@@ -136,14 +139,15 @@ const byggKontekst = (input: ValideringInput): FarMedmorMaks2UkerKontekst | null
 
     const dagerEksisterendePerioder = eksisterendeFarMedmorPerioder.reduce((sum, p) => {
         const dager = tellArbeidsdagerInnenfor(p.fom, p.tom, førsteDag, sisteDag);
-        const stillingsprosent =
-            erVanligUttakPeriode(p) && p.gradering?.arbeidstidprosent !== undefined
-                ? p.gradering.arbeidstidprosent
-                : 100;
-        return sum + dager * (stillingsprosent / 100);
+        // Ingen gradering => arbeidstid 0 % => heile dagen blir trekt frå kvoten.
+        const arbeidstidprosent =
+            erVanligUttakPeriode(p) && p.gradering?.arbeidstidprosent !== undefined ? p.gradering.arbeidstidprosent : 0;
+        return sum + dager * ((100 - arbeidstidprosent) / 100);
     }, 0);
 
     return {
-        totaltAntallDagerInnenforIntervallet: Math.floor(dagerNyePerioder + dagerEksisterendePerioder),
+        // Rundar til tidelar for å unngå flyttalsstøy. Vi rundar med vilje ikkje ned til heile
+        // dagar: 10,4 trekkdagar er meir enn dei 10 dagane far/medmor kan bruka i intervallet.
+        totaltAntallDagerInnenforIntervallet: Math.round((dagerNyePerioder + dagerEksisterendePerioder) * 10) / 10,
     };
 };

--- a/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
+++ b/packages/uttaksplan/src/utils/UttaksperiodeValidatorer.ts
@@ -6,12 +6,17 @@ import minMax from 'dayjs/plugin/minMax';
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { Tidsperioden, Uttaksdagen } from '@navikt/fp-utils';
 
+import {
+    ANTALL_UTTAKSDAGER_SEKS_UKER,
+    ANTALL_UTTAKSDAGER_SYV_UKER,
+    ANTALL_UTTAKSDAGER_TOLV_UKER,
+    ANTALL_UTTAKSDAGER_TO_UKER,
+    ANTALL_UTTAKSDAGER_TRE_UKER,
+} from './uttaksdagerKonstanter';
+
 dayjs.extend(minMax);
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
-
-const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
-const ANTALL_UTTAKSDAGER_SYV_UKER = 35;
 
 type Periode = { fom: string; tom: string };
 
@@ -64,7 +69,9 @@ export const UttaksperiodeValidatorer = {
     },
 
     erNoenPerioderInnenforIntervalletTreUkerFørFamDatoOgFamDato(perioder: Periode[], familiehendelsedato: string) {
-        const førsteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(15);
+        const førsteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(
+            ANTALL_UTTAKSDAGER_TRE_UKER,
+        );
         const sisteDag = Uttaksdagen.forrige(familiehendelsedato).getDato();
 
         return perioder.some((periode) => {
@@ -132,7 +139,9 @@ export const UttaksperiodeValidatorer = {
     },
 
     erNoenPerioderFørTreUkerFørFamDatoEllerEtterLikFamDato(perioder: Periode[], familiehendelsedato: string) {
-        const førsteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(15);
+        const førsteDag = Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(
+            ANTALL_UTTAKSDAGER_TRE_UKER,
+        );
         const sisteDag = Uttaksdagen.forrige(familiehendelsedato).getDato();
 
         return perioder.some((p) => dayjs(p.tom).isAfter(sisteDag) || dayjs(p.fom).isBefore(førsteDag));
@@ -147,10 +156,12 @@ export const UttaksperiodeValidatorer = {
         return perioder.some((periode) => dayjs(periode.fom).isBefore(førsteUttaksdagToUkerFørFødsel, 'day'));
     },
 
-    erNoenPerioderMerEnn60DagerFørFamiliehendelsesdato(perioder: Periode[], familiehendelsedato: string) {
+    erNoenPerioderMerEnnTolvUkerFørFamiliehendelsesdato(perioder: Periode[], familiehendelsedato: string) {
         return perioder.some((periode) =>
             dayjs(periode.fom).isBefore(
-                Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(60),
+                Uttaksdagen.denneEllerNeste(familiehendelsedato).getDatoAntallUttaksdagerTidligere(
+                    ANTALL_UTTAKSDAGER_TOLV_UKER,
+                ),
             ),
         );
     },
@@ -186,5 +197,5 @@ const getFørsteUttaksdag2UkerFørFødsel = (familiehendelsesdato: string, termi
         termindato === undefined
             ? familiehendelsesdato
             : dayjs.min(dayjs(familiehendelsesdato), dayjs(termindato)).format(ISO_DATE_FORMAT);
-    return Uttaksdagen.denneEllerNeste(tidligsteDato).getDatoAntallUttaksdagerTidligere(10);
+    return Uttaksdagen.denneEllerNeste(tidligsteDato).getDatoAntallUttaksdagerTidligere(ANTALL_UTTAKSDAGER_TO_UKER);
 };

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -19,13 +19,11 @@ import {
     erEøsUttakPeriode,
     erVanligUttakPeriode,
 } from '../types/UttaksplanPeriode';
+import { ANTALL_UTTAKSDAGER_SEKS_UKER, ANTALL_UTTAKSDAGER_TRE_UKER } from './uttaksdagerKonstanter';
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(minMax);
 dayjs.extend(isoWeekday);
-
-const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
-const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
 
 // Vinduet er [familiehendelsesdato - 15 uttaksdager, familiehendelsesdato + 30 uttaksdager] –
 // dvs. 3 veker før og 6 veker etter (matchar UI-validatoren).

--- a/packages/uttaksplan/src/utils/periodeUtils.ts
+++ b/packages/uttaksplan/src/utils/periodeUtils.ts
@@ -27,7 +27,7 @@ dayjs.extend(isoWeekday);
 
 // Vinduet er [familiehendelsesdato - 15 uttaksdager, familiehendelsesdato + 30 uttaksdager] –
 // dvs. 3 veker før og 6 veker etter (matchar UI-validatoren).
-export const getAntallUttaksdagerIVinduRundtFødsel = (
+const getAntallUttaksdagerIVinduRundtFødsel = (
     periodeFom: string,
     periodeTom: string,
     familiehendelsedato: string,

--- a/packages/uttaksplan/src/utils/uttaksdagerKonstanter.ts
+++ b/packages/uttaksplan/src/utils/uttaksdagerKonstanter.ts
@@ -1,0 +1,16 @@
+/**
+ * Felles domenekonstantar for uttaksdagar (verkedagar) rundt familiehendinga.
+ *
+ * Ei veke = 5 uttaksdagar, sidan laurdag og søndag ikkje er uttaksdagar. Verdiane
+ * her er derfor _uttaksdagar_, ikkje kalenderdagar – 60 uttaksdagar er 12 veker
+ * (~84 kalenderdagar), ikkje 60 kalenderdagar.
+ *
+ * Konstantane låg tidlegare definert kvar for seg i fleire filer under ulike namn,
+ * noko som gjorde det lett for grensene å koma i utakt. Legg nye grenser her.
+ */
+
+export const ANTALL_UTTAKSDAGER_TO_UKER = 10;
+export const ANTALL_UTTAKSDAGER_TRE_UKER = 15;
+export const ANTALL_UTTAKSDAGER_SEKS_UKER = 30;
+export const ANTALL_UTTAKSDAGER_SYV_UKER = 35;
+export const ANTALL_UTTAKSDAGER_TOLV_UKER = 60;


### PR DESCRIPTION
## Feilfiks: invertert graderingsberekning i regelen om maks 2 veker rundt fødsel

Når begge foreldre har rett, kan far/medmor ta inntil 2 veker (10 uttaksdagar) samtidig med mor i intervallet 2 veker før termin til 6 veker etter fødsel. Dagane kan takast samanhengande, delast opp eller **kombinerast med delvis arbeid**.

Det siste punktet var implementert feil: kvotetrekket blei ganga med **arbeidsprosenten** i staden for **uttaksprosenten**. Arbeids- og uttaksprosent var altså snudd.

`stillingsprosent`/`arbeidstidprosent` fortel kor mykje forelderen skal **jobba** – skjemateksten er «Hvor mange prosent skal far jobbe?». Det som blir trekt frå kvoten er den delen forelderen *ikkje* jobbar. Fasiten ligg i `finnAntallTidelerÅTrekke` (`utils/periodeUtils.ts`), som brukar `utbetalingsgrad = 100 - arbeidstidprosent`.

Poenget med delvis arbeid er at dei 10 dagane skal **strekkjast over lengre kalendertid**, ikkje brukast opp fortare. Med 50 % arbeid kan far ha 20 kalenderdagar i vindauget og framleis berre bruka 10 kvotedagar. Koden rekna motsett veg:

| Døme | Reelt kvotetrekk | Rekna av gammal kode | Utslag |
|---|---|---|---|
| 20 % arbeid i 6 veker | 24 dagar | 6 dagar | Slapp gjennom, skulle vore stoppa |
| 80 % arbeid i 3 veker | 3 dagar | 12 dagar | Blei blokkert, skulle vore lov |
| 50 % arbeid | symmetrisk | symmetrisk | Tilfeldigvis rett |

Periodar **utan** gradering blei rekna rett heile tida. Det er truleg grunnen til at feilen ikkje er oppdaga før – han slo berre ut på graderte periodar, og ikkje i det symmetriske 50 %-tilfellet.

Feilen er stadfesta av fagressurs: arbeidsprosent og uttaksprosent var snudde, og grensa er at det kan brukast **opptil 10 dagar** i perioden.

### Avrunding

Summen blir no runda til tidelar i staden for runda **ned** til heile dagar. Nedrunding gjorde at t.d. 10,4 trekkdagar blei lese som 10 og slapp gjennom, sjølv om grensa er opptil 10 dagar.

### Testar

Ny testfil `farMedmorMaksToUkerRundtFødsel.test.ts` med 10 testar som dekkjer regelen. Dei tre graderingstestane feilar på den gamle logikken og passerer på den nye; dei sju øvrige passerer begge vegar, noko som stadfestar at feilen berre råka graderte periodar.

---

## Opprydding (eigen commit, ingen åtferdsendring)

Tre ting funne i same review av uttaksplan-pakka:

**Samlar domenekonstantane for uttaksdagar** i `src/utils/uttaksdagerKonstanter.ts`. «6 veker = 30 uttaksdagar» var definert tre gonger under tre ulike namn (`ANTALL_UTTAKSDAGER_SEKS_UKER` i `periodeUtils` og `UttaksperiodeValidatorer`, `SEKS_UKER_UTTAKSDAGER` i `farMedmorMaksToUkerRundtFødsel`), medan 2, 3 og 12 veker var namngjevne i éi fil og berre talliteral i ei anna. Det gjorde det lett for grensene å koma i utakt.

**Rettar regeldokumentasjonen** som sa «60 dager før familiehendelsesdato». Koden brukar `getDatoAntallUttaksdagerTidligere(60)`, altså 60 uttaksdagar = 12 veker (~84 kalenderdagar). Koden er korrekt, teksten tok feil med om lag 24 dagar – og teksten blir vist i Storybook-regelkatalogen som teamet brukar som dokumentasjon. Funksjonane er difor også omdøypte til `...MerEnnTolvUker...`.

**Fjernar** `sorterUttakPerioder` og `getAntallUttaksdagerIVinduRundtFødsel` frå det offentlege API-et i `index.ts`. Ingen av dei er importerte utanfor pakka. Funksjonane er framleis i bruk internt og er ikkje endra.

---

## Verifisering

`turbo run tsc test eslint` grønt for heile monorepoet (78/78 tasks), og `knip` utan funn.

## Til avklaring

- **Termin vs. fødsel som ankerpunkt.** Regelen er formulert som «2 veker før *termin* … 6 veker etter *fødsel*». For ein ny søknad brukar koden fødselsdatoen i begge endar; termindato blir berre trekt inn ved endringssøknad. Ved for tidleg fødsel sprikjer desse.
- **Avrundinga** er tolka ut frå «opptil 10 dagar», altså at 10,4 trekkdagar skal blokkerast. Enkel å endra dersom nedrunding til heile dagar er ønskjeleg.
