### PR TITLE
Tekniske forbetringar i foreldrepengesoknad: mellomlagring, ytelse og UU-testing

### DIFF
--- a/apps/foreldrepengesoknad/package.json
+++ b/apps/foreldrepengesoknad/package.json
@@ -8,6 +8,7 @@
         "build:storybook": "storybook build -o .storybook-static-build",
         "test": "vitest --project=jsdom --watch=false",
         "test:browser": "vitest --project=browser",
+        "test:browser:a11y": "vitest --project=browser --watch=false src/tilgjengelighet.test.tsx",
         "eslint": "eslint \"./src/**/*.{js,ts,tsx}\"",
         "eslint:fix": "eslint --quiet --fix \"./src/**/*.{js,ts,tsx}\"",
         "prettier:fix": "prettier --write src",

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -7,34 +7,67 @@ import { useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
 import { useSendSøknad } from 'appData/useSendSøknad';
 import { Forside } from 'pages/forside/Forside';
 import { Søknadsmetadata } from 'pages/forside/utils/useStartSøknad';
-import { KvitteringPage } from 'pages/kvittering/KvitteringPage';
-import { lazy, Suspense, useCallback, useState } from 'react';
+import { Suspense, lazy, useCallback, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import { AndreInntektskilderSteg } from 'steps/andre-inntektskilder/AndreInntektskilderSteg';
-import { AnnenForelderSteg } from 'steps/annen-forelder/AnnenForelderSteg';
-import { ArbeidsforholdOgInntektSteg } from 'steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg';
-import { EgenNæringSteg } from 'steps/egen-næring/EgenNæringSteg';
-import { FordelingSteg } from 'steps/fordeling/FordelingSteg';
-import { FrilansSteg } from 'steps/frilans/FrilansSteg';
-import { ManglendeVedlegg } from 'steps/manglende-vedlegg/ManglendeVedlegg';
-import { OmBarnetSteg } from 'steps/om-barnet/OmBarnetSteg';
-import { OppsummeringSteg } from 'steps/oppsummering/OppsummeringSteg';
-import { PeriodeMedForeldrepengerSteg } from 'steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg';
-import { SøkersituasjonSteg } from 'steps/søkersituasjon/SøkersituasjonSteg';
-import { SenereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg';
-import { TidligereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg';
-import { UtenlandsoppholdSteg } from 'steps/utenlandsopphold/UtenlandsoppholdSteg';
+
+import { Alert, Button, VStack } from '@navikt/ds-react';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 import { ErrorPage, Spinner, Umyndig } from '@navikt/fp-ui';
 import { erMyndig } from '@navikt/fp-utils';
 
-// Uttaksplan-steget (inkl. kalender og regelmotor i @navikt/fp-uttaksplan) er den klart største
-// enkeltavhengigheten i søknaden. Den lastes derfor lazy, med prefetch fra FordelingSteg
-// (steget rett før i den vanlege søknadsflyten, sjå ROUTES_ORDER) slik at chunken ligg i
-// nettlesarcache før brukaren faktisk navigerer dit.
+// Stega er lazy-lasta slik at forsida ikkje må vente på uttaksplan, filopplastar og alle
+// steg-pakkene. Kvart steg blir henta først når brukaren faktisk kjem dit.
+const AndreInntektskilderSteg = lazy(() =>
+    import('steps/andre-inntektskilder/AndreInntektskilderSteg').then((m) => ({ default: m.AndreInntektskilderSteg })),
+);
+const AnnenForelderSteg = lazy(() =>
+    import('steps/annen-forelder/AnnenForelderSteg').then((m) => ({ default: m.AnnenForelderSteg })),
+);
+const ArbeidsforholdOgInntektSteg = lazy(() =>
+    import('steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg').then((m) => ({
+        default: m.ArbeidsforholdOgInntektSteg,
+    })),
+);
+const EgenNæringSteg = lazy(() =>
+    import('steps/egen-næring/EgenNæringSteg').then((m) => ({ default: m.EgenNæringSteg })),
+);
+const FordelingSteg = lazy(() => import('steps/fordeling/FordelingSteg').then((m) => ({ default: m.FordelingSteg })));
+const FrilansSteg = lazy(() => import('steps/frilans/FrilansSteg').then((m) => ({ default: m.FrilansSteg })));
+const KvitteringPage = lazy(() =>
+    import('pages/kvittering/KvitteringPage').then((m) => ({ default: m.KvitteringPage })),
+);
+const ManglendeVedlegg = lazy(() =>
+    import('steps/manglende-vedlegg/ManglendeVedlegg').then((m) => ({ default: m.ManglendeVedlegg })),
+);
+const OmBarnetSteg = lazy(() => import('steps/om-barnet/OmBarnetSteg').then((m) => ({ default: m.OmBarnetSteg })));
+const OppsummeringSteg = lazy(() =>
+    import('steps/oppsummering/OppsummeringSteg').then((m) => ({ default: m.OppsummeringSteg })),
+);
+const PeriodeMedForeldrepengerSteg = lazy(() =>
+    import('steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg').then((m) => ({
+        default: m.PeriodeMedForeldrepengerSteg,
+    })),
+);
+const SenereUtenlandsoppholdSteg = lazy(() =>
+    import('steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg').then((m) => ({
+        default: m.SenereUtenlandsoppholdSteg,
+    })),
+);
+const SøkersituasjonSteg = lazy(() =>
+    import('steps/søkersituasjon/SøkersituasjonSteg').then((m) => ({ default: m.SøkersituasjonSteg })),
+);
+const TidligereUtenlandsoppholdSteg = lazy(() =>
+    import('steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg').then((m) => ({
+        default: m.TidligereUtenlandsoppholdSteg,
+    })),
+);
+const UtenlandsoppholdSteg = lazy(() =>
+    import('steps/utenlandsopphold/UtenlandsoppholdSteg').then((m) => ({ default: m.UtenlandsoppholdSteg })),
+);
 const UttaksplanSteg = lazy(() =>
-    import('steps/uttaksplan/UttaksplanSteg').then((module) => ({ default: module.UttaksplanSteg })),
+    import('steps/uttaksplan/UttaksplanSteg').then((m) => ({ default: m.UttaksplanSteg })),
 );
 
 interface SøknadRoutesOptions {
@@ -304,12 +337,11 @@ export const ForeldrepengesøknadRoutes = ({
 
     const { sendSøknad, errorSendSøknad } = useSendSøknad(søkerInfo, erEndringssøknad, foreldrepengerSaker);
 
-    const mellomlagreSøknadOgNaviger = useMellomlagreSøknad(
-        foreldrepengerSaker,
-        søkerInfo,
-        erEndringssøknad,
-        søknadGjelderNyttBarn,
-    );
+    const {
+        mellomlagreSøknad: mellomlagreSøknadOgNaviger,
+        lagringFeilet,
+        nullstillLagringFeilet,
+    } = useMellomlagreSøknad(foreldrepengerSaker, søkerInfo, erEndringssøknad, søknadGjelderNyttBarn);
 
     const avbrytSøknad = useAvbrytSøknad(setErEndringssøknad, setHarGodkjentVilkår, setSøknadGjelderNyttBarn);
 
@@ -358,31 +390,49 @@ export const ForeldrepengesøknadRoutes = ({
     }
 
     return (
-        <Routes>
-            <Route
-                path={SøknadRoutes.VELKOMMEN}
-                element={
-                    <Forside
-                        saker={foreldrepengerSaker}
-                        harGodkjentVilkår={harGodkjentVilkår}
-                        søkerInfo={søkerInfo}
-                        oppdaterSøknadsmetadata={oppdaterSøknadsmetadata}
-                        mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+        <VStack gap="space-16">
+            {lagringFeilet && (
+                <VStack align="center" paddingBlock="space-16" paddingInline="space-16">
+                    <VStack maxWidth="600px" width="100%">
+                        <Alert variant="error">
+                            <VStack align="start" gap="space-8">
+                                <FormattedMessage id="Mellomlagring.FeiletVedFortsettSenere" />
+                                <Button type="button" variant="secondary" size="small" onClick={nullstillLagringFeilet}>
+                                    <FormattedMessage id="Mellomlagring.FeiletVedFortsettSenere.Lukk" />
+                                </Button>
+                            </VStack>
+                        </Alert>
+                    </VStack>
+                </VStack>
+            )}
+            <Suspense fallback={<Spinner />}>
+                <Routes>
+                    <Route
+                        path={SøknadRoutes.VELKOMMEN}
+                        element={
+                            <Forside
+                                saker={foreldrepengerSaker}
+                                harGodkjentVilkår={harGodkjentVilkår}
+                                søkerInfo={søkerInfo}
+                                oppdaterSøknadsmetadata={oppdaterSøknadsmetadata}
+                                mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                            />
+                        }
                     />
-                }
-            />
-            <Route path={SøknadRoutes.IKKE_MYNDIG} element={<Umyndig appName="foreldrepengesoknad" />} />
+                    <Route path={SøknadRoutes.IKKE_MYNDIG} element={<Umyndig appName="foreldrepengesoknad" />} />
 
-            {renderSøknadRoutes({
-                harGodkjentVilkår,
-                erEndringssøknad,
-                søkerInfo,
-                mellomlagreSøknadOgNaviger,
-                sendSøknad,
-                avbrytSøknad,
-                søknadGjelderNyttBarn,
-                foreldrepengerSaker,
-            })}
-        </Routes>
+                    {renderSøknadRoutes({
+                        harGodkjentVilkår,
+                        erEndringssøknad,
+                        søkerInfo,
+                        mellomlagreSøknadOgNaviger,
+                        sendSøknad,
+                        avbrytSøknad,
+                        søknadGjelderNyttBarn,
+                        foreldrepengerSaker,
+                    })}
+                </Routes>
+            </Suspense>
+        </VStack>
     );
 };

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -68,15 +68,13 @@ const renderSøknadRoutes = ({
                 <Route
                     path={SøknadRoutes.UTTAKSPLAN}
                     element={
-                        <Suspense fallback={<Spinner />}>
-                            <UttaksplanSteg
-                                søkerInfo={søkerInfo}
-                                mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
-                                avbrytSøknad={avbrytSøknad}
-                                foreldrepengerSaker={foreldrepengerSaker}
-                                erEndringssøknad={erEndringssøknad}
-                            />
-                        </Suspense>
+                        <UttaksplanSteg
+                            søkerInfo={søkerInfo}
+                            mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                            avbrytSøknad={avbrytSøknad}
+                            foreldrepengerSaker={foreldrepengerSaker}
+                            erEndringssøknad={erEndringssøknad}
+                        />
                     }
                 />
                 <Route
@@ -167,15 +165,13 @@ const renderSøknadRoutes = ({
             <Route
                 path={SøknadRoutes.UTTAKSPLAN}
                 element={
-                    <Suspense fallback={<Spinner />}>
-                        <UttaksplanSteg
-                            søkerInfo={søkerInfo}
-                            mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
-                            avbrytSøknad={avbrytSøknad}
-                            foreldrepengerSaker={foreldrepengerSaker}
-                            erEndringssøknad={erEndringssøknad}
-                        />
-                    </Suspense>
+                    <UttaksplanSteg
+                        søkerInfo={søkerInfo}
+                        mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                        avbrytSøknad={avbrytSøknad}
+                        foreldrepengerSaker={foreldrepengerSaker}
+                        erEndringssøknad={erEndringssøknad}
+                    />
                 }
             />
             <Route

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -7,68 +7,31 @@ import { useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
 import { useSendSøknad } from 'appData/useSendSøknad';
 import { Forside } from 'pages/forside/Forside';
 import { Søknadsmetadata } from 'pages/forside/utils/useStartSøknad';
-import { Suspense, lazy, useCallback, useState } from 'react';
+import { KvitteringPage } from 'pages/kvittering/KvitteringPage';
+import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { AndreInntektskilderSteg } from 'steps/andre-inntektskilder/AndreInntektskilderSteg';
+import { AnnenForelderSteg } from 'steps/annen-forelder/AnnenForelderSteg';
+import { ArbeidsforholdOgInntektSteg } from 'steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg';
+import { EgenNæringSteg } from 'steps/egen-næring/EgenNæringSteg';
+import { FordelingSteg } from 'steps/fordeling/FordelingSteg';
+import { FrilansSteg } from 'steps/frilans/FrilansSteg';
+import { ManglendeVedlegg } from 'steps/manglende-vedlegg/ManglendeVedlegg';
+import { OmBarnetSteg } from 'steps/om-barnet/OmBarnetSteg';
+import { OppsummeringSteg } from 'steps/oppsummering/OppsummeringSteg';
+import { PeriodeMedForeldrepengerSteg } from 'steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg';
+import { SøkersituasjonSteg } from 'steps/søkersituasjon/SøkersituasjonSteg';
+import { SenereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg';
+import { TidligereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg';
+import { UtenlandsoppholdSteg } from 'steps/utenlandsopphold/UtenlandsoppholdSteg';
+import { UttaksplanSteg } from 'steps/uttaksplan/UttaksplanSteg';
 
 import { Alert, Button, VStack } from '@navikt/ds-react';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
-import { ErrorPage, Spinner, Umyndig } from '@navikt/fp-ui';
+import { ErrorPage, Umyndig } from '@navikt/fp-ui';
 import { erMyndig } from '@navikt/fp-utils';
-
-// Stega er lazy-lasta slik at forsida ikkje må vente på uttaksplan, filopplastar og alle
-// steg-pakkene. Kvart steg blir henta først når brukaren faktisk kjem dit.
-const AndreInntektskilderSteg = lazy(() =>
-    import('steps/andre-inntektskilder/AndreInntektskilderSteg').then((m) => ({ default: m.AndreInntektskilderSteg })),
-);
-const AnnenForelderSteg = lazy(() =>
-    import('steps/annen-forelder/AnnenForelderSteg').then((m) => ({ default: m.AnnenForelderSteg })),
-);
-const ArbeidsforholdOgInntektSteg = lazy(() =>
-    import('steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg').then((m) => ({
-        default: m.ArbeidsforholdOgInntektSteg,
-    })),
-);
-const EgenNæringSteg = lazy(() =>
-    import('steps/egen-næring/EgenNæringSteg').then((m) => ({ default: m.EgenNæringSteg })),
-);
-const FordelingSteg = lazy(() => import('steps/fordeling/FordelingSteg').then((m) => ({ default: m.FordelingSteg })));
-const FrilansSteg = lazy(() => import('steps/frilans/FrilansSteg').then((m) => ({ default: m.FrilansSteg })));
-const KvitteringPage = lazy(() =>
-    import('pages/kvittering/KvitteringPage').then((m) => ({ default: m.KvitteringPage })),
-);
-const ManglendeVedlegg = lazy(() =>
-    import('steps/manglende-vedlegg/ManglendeVedlegg').then((m) => ({ default: m.ManglendeVedlegg })),
-);
-const OmBarnetSteg = lazy(() => import('steps/om-barnet/OmBarnetSteg').then((m) => ({ default: m.OmBarnetSteg })));
-const OppsummeringSteg = lazy(() =>
-    import('steps/oppsummering/OppsummeringSteg').then((m) => ({ default: m.OppsummeringSteg })),
-);
-const PeriodeMedForeldrepengerSteg = lazy(() =>
-    import('steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg').then((m) => ({
-        default: m.PeriodeMedForeldrepengerSteg,
-    })),
-);
-const SenereUtenlandsoppholdSteg = lazy(() =>
-    import('steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg').then((m) => ({
-        default: m.SenereUtenlandsoppholdSteg,
-    })),
-);
-const SøkersituasjonSteg = lazy(() =>
-    import('steps/søkersituasjon/SøkersituasjonSteg').then((m) => ({ default: m.SøkersituasjonSteg })),
-);
-const TidligereUtenlandsoppholdSteg = lazy(() =>
-    import('steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg').then((m) => ({
-        default: m.TidligereUtenlandsoppholdSteg,
-    })),
-);
-const UtenlandsoppholdSteg = lazy(() =>
-    import('steps/utenlandsopphold/UtenlandsoppholdSteg').then((m) => ({ default: m.UtenlandsoppholdSteg })),
-);
-const UttaksplanSteg = lazy(() =>
-    import('steps/uttaksplan/UttaksplanSteg').then((m) => ({ default: m.UttaksplanSteg })),
-);
 
 interface SøknadRoutesOptions {
     harGodkjentVilkår: boolean;
@@ -405,34 +368,32 @@ export const ForeldrepengesøknadRoutes = ({
                     </VStack>
                 </VStack>
             )}
-            <Suspense fallback={<Spinner />}>
-                <Routes>
-                    <Route
-                        path={SøknadRoutes.VELKOMMEN}
-                        element={
-                            <Forside
-                                saker={foreldrepengerSaker}
-                                harGodkjentVilkår={harGodkjentVilkår}
-                                søkerInfo={søkerInfo}
-                                oppdaterSøknadsmetadata={oppdaterSøknadsmetadata}
-                                mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
-                            />
-                        }
-                    />
-                    <Route path={SøknadRoutes.IKKE_MYNDIG} element={<Umyndig appName="foreldrepengesoknad" />} />
+            <Routes>
+                <Route
+                    path={SøknadRoutes.VELKOMMEN}
+                    element={
+                        <Forside
+                            saker={foreldrepengerSaker}
+                            harGodkjentVilkår={harGodkjentVilkår}
+                            søkerInfo={søkerInfo}
+                            oppdaterSøknadsmetadata={oppdaterSøknadsmetadata}
+                            mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                        />
+                    }
+                />
+                <Route path={SøknadRoutes.IKKE_MYNDIG} element={<Umyndig appName="foreldrepengesoknad" />} />
 
-                    {renderSøknadRoutes({
-                        harGodkjentVilkår,
-                        erEndringssøknad,
-                        søkerInfo,
-                        mellomlagreSøknadOgNaviger,
-                        sendSøknad,
-                        avbrytSøknad,
-                        søknadGjelderNyttBarn,
-                        foreldrepengerSaker,
-                    })}
-                </Routes>
-            </Suspense>
+                {renderSøknadRoutes({
+                    harGodkjentVilkår,
+                    erEndringssøknad,
+                    søkerInfo,
+                    mellomlagreSøknadOgNaviger,
+                    sendSøknad,
+                    avbrytSøknad,
+                    søknadGjelderNyttBarn,
+                    foreldrepengerSaker,
+                })}
+            </Routes>
         </VStack>
     );
 };

--- a/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
+++ b/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
@@ -1,5 +1,5 @@
 import { SøknadRoutes } from 'appData/routes';
-import { JSX, ReactNode, createContext, use, useReducer } from 'react';
+import { JSX, ReactNode, createContext, use, useCallback, useEffect, useReducer, useRef } from 'react';
 import { AndreInntektskilder } from 'types/AndreInntektskilder';
 import { AnnenForelder } from 'types/AnnenForelder';
 import { Fordeling } from 'types/Fordeling';
@@ -91,12 +91,18 @@ export const FpDataContext = ({ children, initialState, onDispatch }: Props): JS
         }
     }, initialState || defaultInitialState);
 
-    const dispatchWrapper = (a: Action) => {
-        if (onDispatch) {
-            onDispatch(a);
-        }
+    // onDispatch kjem frå stories/testar og er ofte ein ny closure per render. Held den i ein
+    // ref slik at dispatch-funksjonen under er referansestabil – elles ville kvar render av
+    // FpDataContext gitt ny context-verdi og rendra alle konsumentar på nytt.
+    const onDispatchRef = useRef(onDispatch);
+    useEffect(() => {
+        onDispatchRef.current = onDispatch;
+    }, [onDispatch]);
+
+    const dispatchWrapper = useCallback((a: Action) => {
+        onDispatchRef.current?.(a);
         dispatch(a);
-    };
+    }, []);
 
     return (
         <FpStateContext value={state}>
@@ -115,39 +121,39 @@ export const useContextGetData = <TYPE extends ContextDataType>(key: TYPE): Cont
 export const useContextGetAnyData = () => {
     const state = use(FpStateContext);
 
-    return <TYPE extends ContextDataType>(key: TYPE) => {
-        return state[key];
-    };
+    // Må vere referansestabil så lenge state er uendra, elles blir useMemo/useEffect
+    // hos konsumentar (t.d. useStepConfig) invalidert på kvar einaste render.
+    return useCallback(<TYPE extends ContextDataType>(key: TYPE) => state[key], [state]);
 };
 
 /** Hook returns save function for one specific data type */
 export const useContextSaveData = <TYPE extends ContextDataType>(key: TYPE): ((data: ContextDataMap[TYPE]) => void) => {
     const dispatch = use(FpDispatchContext);
-    return (data: ContextDataMap[TYPE]) => {
-        if (dispatch) {
-            dispatch({ type: 'update', key, data });
-        }
-    };
+    return useCallback(
+        (data: ContextDataMap[TYPE]) => {
+            dispatch?.({ type: 'update', key, data });
+        },
+        [dispatch, key],
+    );
 };
 
 /** Hook returns save function usable with all data types  */
 export const useContextSaveAnyData = () => {
     const dispatch = use(FpDispatchContext);
-    return <TYPE extends ContextDataType>(key: TYPE, data: ContextDataMap[TYPE]) => {
-        if (dispatch) {
-            dispatch({ type: 'update', key, data });
-        }
-    };
+    return useCallback(
+        <TYPE extends ContextDataType>(key: TYPE, data: ContextDataMap[TYPE]) => {
+            dispatch?.({ type: 'update', key, data });
+        },
+        [dispatch],
+    );
 };
 
 /** Hook returns state reset function  */
 export const useContextReset = () => {
     const dispatch = use(FpDispatchContext);
-    return () => {
-        if (dispatch) {
-            dispatch({ type: 'reset' });
-        }
-    };
+    return useCallback(() => {
+        dispatch?.({ type: 'reset' });
+    }, [dispatch]);
 };
 
 export const useContextComplete = (): ContextDataMap => {

--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -72,9 +72,18 @@ export const useFpNavigator = (
     const fortsettSøknadSenere = () => {
         loggUmamiEvent({ origin: 'foreldrepengesoknad', eventName: 'skjema fortsett senere' });
         // Berre lagre (ingen navigering – vi forlet appen rett etterpå), med retry
-        // sidan brukaren ikkje får eit nytt forsøk på å lagre endringane sine.
-        void mellomlagreOgNaviger({ naviger: false, medRetry: true }).finally(() => {
-            globalThis.location.href = 'https://nav.no';
+        // sidan brukaren ikkje får eit nytt forsøk på å lagre endringane sine. Vi sender
+        // brukaren først ut av appen når lagringa faktisk gjekk bra; feilar den, blir
+        // brukaren verande med søknaden sin og får ei feilmelding.
+        void mellomlagreOgNaviger({
+            naviger: false,
+            medRetry: true,
+            visFeilTilBruker: true,
+            onFerdig: (resultat) => {
+                if (resultat === 'ok') {
+                    globalThis.location.href = 'https://nav.no';
+                }
+            },
         });
     };
 

--- a/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -31,9 +31,25 @@ type MellomlagreSøknadOptions = {
     naviger?: boolean;
     // Prøv kallet på nytt ved transiente feil. Default false.
     medRetry?: boolean;
+    // Blir kalla når lagringa er ferdig, med utfallet. Bruk denne når kallaren må
+    // vite om lagringa gjekk bra (t.d. før ein sender brukaren ut av appen).
+    onFerdig?: (resultat: MellomlagringResultat) => void;
+    // Vis feilmelding til brukaren dersom lagringa feilar. Default false – for vanleg
+    // stegnavigasjon held det å logge, sidan neste lagring rettar opp i det.
+    visFeilTilBruker?: boolean;
 };
 
+export type MellomlagringResultat = 'ok' | 'feilet';
+
 export type MellomlagreSøknadFn = (options?: MellomlagreSøknadOptions) => Promise<void>;
+
+type Forespørsel = {
+    naviger: boolean;
+    medRetry: boolean;
+    visFeilTilBruker: boolean;
+    onFerdig?: (resultat: MellomlagringResultat) => void;
+    ferdig: () => void;
+};
 
 export const useMellomlagreSøknad = (
     foreldrepengerSaker: FpSak_fpoversikt[],
@@ -46,96 +62,118 @@ export const useMellomlagreSøknad = (
 
     const annenPartVedtakQuery = useQuery(useAnnenPartVedtakOptions());
 
-    const [forespørsel, setForespørsel] = useState<{ naviger: boolean; medRetry: boolean } | null>(null);
+    const [lagringFeilet, setLagringFeilet] = useState(false);
 
-    const promiseRef = useRef<() => void>(null);
+    // Forespurte lagringar ligg i ein ref-kø, ikkje i state: fleire kall kan kome før
+    // effekten rekk å køyre (t.d. «neste steg» og «fortsett seinare» rett etter kvarandre),
+    // og då må alle promisa bli resolva. Sekvensnummeret finst berre for å trigge effekten,
+    // som er naudsynt for at vi skal lese ferskt context-state etter kallaren sine dispatchar.
+    const køRef = useRef<Forespørsel[]>([]);
+    const [seq, setSeq] = useState(0);
 
     useEffect(() => {
-        if (forespørsel) {
-            const { naviger, medRetry } = forespørsel;
-            const currentRoute = notEmpty(state[ContextDataType.APP_ROUTE]);
+        const forespørsler = køRef.current;
+        if (forespørsler.length === 0) {
+            return;
+        }
+        køRef.current = [];
 
-            const lagre = async () => {
-                setForespørsel(null);
+        const naviger = forespørsler.some((f) => f.naviger);
+        const medRetry = forespørsler.some((f) => f.medRetry);
+        const currentRoute = notEmpty(state[ContextDataType.APP_ROUTE]);
 
-                if (naviger) {
-                    void navigate(currentRoute);
-                }
+        const lagre = async () => {
+            if (naviger) {
+                void navigate(currentRoute);
+            }
 
-                const data = {
-                    version: VERSJON_MELLOMLAGRING,
-                    søkerInfo,
-                    foreldrepengerSaker,
-                    erEndringssøknad,
-                    søknadGjelderEtNyttBarn,
-                    // Lagre kun når kallet faktisk har et resultat, slik at vi ikkje
-                    // lagrar undefined når kallet er pending/feila og dermed gir falske
-                    // utslag i RegisterdataUtdatert-sjekken ved neste oppstart.
-                    ...(annenPartVedtakQuery.isSuccess ? { annenPartVedtak: annenPartVedtakQuery.data } : {}),
-                    ...state,
-                } satisfies FpMellomlagretData;
+            const data = {
+                version: VERSJON_MELLOMLAGRING,
+                søkerInfo,
+                foreldrepengerSaker,
+                erEndringssøknad,
+                søknadGjelderEtNyttBarn,
+                // Lagre kun når kallet faktisk har et resultat, slik at vi ikkje
+                // lagrar undefined når kallet er pending/feila og dermed gir falske
+                // utslag i RegisterdataUtdatert-sjekken ved neste oppstart.
+                ...(annenPartVedtakQuery.isSuccess ? { annenPartVedtak: annenPartVedtakQuery.data } : {}),
+                ...state,
+            } satisfies FpMellomlagretData;
 
-                try {
-                    await ky.post(API_URLS.mellomlagring, {
-                        json: data,
-                        headers: {
-                            fnr: søkerInfo.fnr,
-                        },
-                        ...(medRetry
-                            ? {
-                                  retry: {
-                                      limit: 2,
-                                      methods: ['post'],
-                                      statusCodes: [408, 429, 500, 502, 503, 504],
-                                  },
-                              }
-                            : {}),
-                    });
-                } catch (error: unknown) {
-                    if (error instanceof HTTPError) {
-                        if (error.response.status === 401 || error.response.status === 403) {
-                            throw error;
-                        }
-
-                        const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                        throw new ApiError('', 'Feil ved mellomlagring av foreldrepengesøknad', jsonResponse);
-                    }
-                    if (error instanceof Error) {
+            try {
+                await ky.post(API_URLS.mellomlagring, {
+                    json: data,
+                    headers: {
+                        fnr: søkerInfo.fnr,
+                    },
+                    ...(medRetry
+                        ? {
+                              retry: {
+                                  limit: 2,
+                                  methods: ['post'],
+                                  statusCodes: [408, 429, 500, 502, 503, 504],
+                              },
+                          }
+                        : {}),
+                });
+            } catch (error: unknown) {
+                if (error instanceof HTTPError) {
+                    if (error.response.status === 401 || error.response.status === 403) {
                         throw error;
                     }
-                    throw new Error(String(error), { cause: error });
-                }
 
-                if (promiseRef.current) {
-                    promiseRef.current();
+                    const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
+                    throw new ApiError('', 'Feil ved mellomlagring av foreldrepengesøknad', jsonResponse);
                 }
-            };
+                if (error instanceof Error) {
+                    throw error;
+                }
+                throw new Error(String(error), { cause: error });
+            }
+        };
 
-            lagre().catch((error) => {
-                //Logg feil, men ikkje vis feilmelding til brukar
+        const fullfør = (resultat: MellomlagringResultat) => {
+            if (resultat === 'feilet' && forespørsler.some((f) => f.visFeilTilBruker)) {
+                setLagringFeilet(true);
+            }
+            for (const forespørsel of forespørsler) {
+                forespørsel.onFerdig?.(resultat);
+                forespørsel.ferdig();
+            }
+        };
+
+        lagre().then(
+            () => fullfør('ok'),
+            (error: unknown) => {
+                //Logg feil. Om kallaren har bedt om det, blir brukaren også varsla.
                 if (error instanceof ApiError) {
                     captureApiError(error.sentryMessage, error.problemDetails);
                 } else if (error instanceof Error) {
                     captureMessage(error.message);
                 }
 
-                if (promiseRef.current) {
-                    promiseRef.current();
-                }
-            });
-        }
-    }, [forespørsel]);
+                fullfør('feilet');
+            },
+        );
+    }, [seq]);
 
-    const mellomlagreSøknad = useCallback<MellomlagreSøknadFn>((options) => {
-        //Må gå via state change sidan ein må få oppdatert context før ein mellomlagrar
-        setForespørsel({ naviger: options?.naviger ?? true, medRetry: options?.medRetry ?? false });
+    const mellomlagreSøknad = useCallback<MellomlagreSøknadFn>(
+        (options) =>
+            //Må gå via state change sidan ein må få oppdatert context før ein mellomlagrar
+            new Promise<void>((resolve) => {
+                køRef.current.push({
+                    naviger: options?.naviger ?? true,
+                    medRetry: options?.medRetry ?? false,
+                    visFeilTilBruker: options?.visFeilTilBruker ?? false,
+                    onFerdig: options?.onFerdig,
+                    ferdig: resolve,
+                });
+                setSeq((s) => s + 1);
+            }),
+        [],
+    );
 
-        const promise = new Promise<void>((resolve) => {
-            promiseRef.current = resolve;
-        });
+    const nullstillLagringFeilet = useCallback(() => setLagringFeilet(false), []);
 
-        return promise;
-    }, []);
-
-    return mellomlagreSøknad;
+    return { mellomlagreSøknad, lagringFeilet, nullstillLagringFeilet };
 };

--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -161,7 +161,7 @@ export const useStepConfig = (
     eksisterendeSak: FpSak_fpoversikt | undefined = undefined,
 ) => {
     const intl = useIntl();
-    const pathToLabelMap = getPathToLabelMap(intl);
+    const pathToLabelMap = useMemo(() => getPathToLabelMap(intl), [intl]);
 
     const location = useLocation();
     const getStateData = useContextGetAnyData();
@@ -182,7 +182,7 @@ export const useStepConfig = (
                     ? [path]
                     : [],
             ),
-        [requiredSteps, getStateData, arbeidsforhold, erEndringssøknad, eksisterendeSak],
+        [requiredSteps, getStateData, arbeidsforhold, eksisterendeSak],
     );
 
     return useMemo(

--- a/apps/foreldrepengesoknad/src/intl/nb_NO.json
+++ b/apps/foreldrepengesoknad/src/intl/nb_NO.json
@@ -1,4 +1,6 @@
 {
+    "Mellomlagring.FeiletVedFortsettSenere": "Vi klarte ikke å lagre søknaden din nå, så du er fortsatt inne i søknaden. Prøv «Fortsett senere» på nytt om litt. Hvis du lukker siden nå, kan du miste det du har fylt ut.",
+    "Mellomlagring.FeiletVedFortsettSenere.Lukk": "Lukk",
     "søknad.pagetitle": "Søknad om foreldrepenger",
     "søknad.pageheading": "Søknad om foreldrepenger",
     "fødselsdato": "fødselsdato",

--- a/apps/foreldrepengesoknad/src/intl/nn_NO.json
+++ b/apps/foreldrepengesoknad/src/intl/nn_NO.json
@@ -1,4 +1,6 @@
 {
+    "Mellomlagring.FeiletVedFortsettSenere": "Vi klarte ikkje å lagre søknaden din no, så du er framleis inne i søknaden. Prøv «Fortsett seinare» på nytt om litt. Viss du lukkar sida no, kan du miste det du har fylt ut.",
+    "Mellomlagring.FeiletVedFortsettSenere.Lukk": "Lukk",
     "søknad.pagetitle": "Søknad om foreldrepengar",
     "søknad.pageheading": "Søknad om foreldrepengar",
     "fødselsdato": "fødselsdato",

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummering.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummering.tsx
@@ -87,12 +87,10 @@ export const UttaksplanOppsummering = ({ navnPåForeldre, registrerteArbeidsforh
                     </FormSummary.Label>
                     <FormSummary.Value>{dekningsgradTekst}</FormSummary.Value>
                 </FormSummary.Answer>
-                <FormSummary.Answer>
-                    <UttaksplanOppsummeringsliste
-                        navnPåForeldre={navnPåForeldre}
-                        registrerteArbeidsforhold={registrerteArbeidsforhold}
-                    />
-                </FormSummary.Answer>
+                <UttaksplanOppsummeringsliste
+                    navnPåForeldre={navnPåForeldre}
+                    registrerteArbeidsforhold={registrerteArbeidsforhold}
+                />
                 {harJustertUttakVedFødsel !== undefined && (
                     <FormSummary.Answer>
                         <FormSummary.Label>

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummeringsliste.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/UttaksplanOppsummeringsliste.tsx
@@ -59,14 +59,7 @@ export const UttaksplanOppsummeringsliste = ({ navnPåForeldre, registrerteArbei
     const søkerHarLagtTilPerioderForAnnenPart = annenPartsPerioder.some((periode) => periode.resultat === undefined);
 
     return (
-        <VStack gap="space-16">
-            {annenPartsPerioder.length > 0 && søkerHarLagtTilPerioderForAnnenPart && (
-                <Alert variant="warning">
-                    <BodyLong>
-                        <FormattedMessage id="oppsummering.AnnenPartPerioderInfomelding" />
-                    </BodyLong>
-                </Alert>
-            )}
+        <>
             {søkersPerioder.length > 0 && (
                 <UttaksplanListe
                     erSøker
@@ -81,9 +74,10 @@ export const UttaksplanOppsummeringsliste = ({ navnPåForeldre, registrerteArbei
                     uttaksplan={annenPartsPerioder}
                     registrerteArbeidsforhold={registrerteArbeidsforhold}
                     navnPåForeldre={navnPåForeldre}
+                    visAdvarselOmEgendefinertePerioder={søkerHarLagtTilPerioderForAnnenPart}
                 />
             )}
-        </VStack>
+        </>
     );
 };
 
@@ -92,11 +86,13 @@ const UttaksplanListe = ({
     uttaksplan,
     registrerteArbeidsforhold,
     navnPåForeldre,
+    visAdvarselOmEgendefinertePerioder,
 }: {
     erSøker: boolean;
     uttaksplan: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
     registrerteArbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
     navnPåForeldre: NavnPåForeldre;
+    visAdvarselOmEgendefinertePerioder?: boolean;
 }) => {
     const intl = useIntl();
 
@@ -147,7 +143,9 @@ const UttaksplanListe = ({
     };
 
     return (
-        <div>
+        // Må vere ein FormSummary.Answer (ikkje ein vanleg div): denne blir rendra rett inni
+        // <dl>-en til FormSummary.Answers, og der er berre dt/dd-grupper gyldige.
+        <FormSummary.Answer>
             {erSøker && (
                 <FormSummary.Label>
                     <FormattedMessage id="oppsummering.uttak.dine.perioder" />
@@ -159,7 +157,15 @@ const UttaksplanListe = ({
                 </FormSummary.Label>
             )}
             <FormSummary.Value>
-                <FormSummary.Answers>
+                <VStack gap="space-16">
+                    {visAdvarselOmEgendefinertePerioder && (
+                        <Alert variant="warning">
+                            <BodyLong>
+                                <FormattedMessage id="oppsummering.AnnenPartPerioderInfomelding" />
+                            </BodyLong>
+                        </Alert>
+                    )}
+                    <FormSummary.Answers>
                     {uttaksplan.map((periode) => {
                         if (Uttaksperioden.erIkkeEøsPeriode(periode) && Uttaksperioden.erUttaksperiode(periode)) {
                             const tidsperiode = formatTidsperiode(periode.fom, periode.tom);
@@ -224,9 +230,10 @@ const UttaksplanListe = ({
                         }
                         return null;
                     })}
-                </FormSummary.Answers>
+                    </FormSummary.Answers>
+                </VStack>
             </FormSummary.Value>
-        </div>
+        </FormSummary.Answer>
     );
 };
 

--- a/apps/foreldrepengesoknad/src/tilgjengelighet.test.tsx
+++ b/apps/foreldrepengesoknad/src/tilgjengelighet.test.tsx
@@ -1,0 +1,62 @@
+import { composeStories } from '@storybook/react-vite';
+import { screen } from '@testing-library/react';
+
+import { forventIngenUuFeil } from '@navikt/fp-utils-test/a11y';
+
+import * as andreInntektskilderStories from './steps/andre-inntektskilder/AndreInntektskilderSteg.stories';
+import * as annenForelderStories from './steps/annen-forelder/AnnenForelderSteg.stories';
+import * as arbeidsforholdOgInntektStories from './steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories';
+import * as egenNæringStories from './steps/egen-næring/EgenNæringSteg.stories';
+import * as fordelingStories from './steps/fordeling/FordelingSteg.stories';
+import * as frilansStories from './steps/frilans/FrilansSteg.stories';
+import * as manglendeVedleggStories from './steps/manglende-vedlegg/ManglendeVedlegg.stories';
+import * as omBarnetStories from './steps/om-barnet/OmBarnetSteg.stories';
+import * as oppsummeringStories from './steps/oppsummering/OppsummeringSteg.stories';
+import * as periodeMedForeldrepengerStories from './steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.stories';
+import * as søkersituasjonStories from './steps/søkersituasjon/SøkersituasjonSteg.stories';
+import * as senereUtenlandsoppholdStories from './steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories';
+import * as tidligereUtenlandsoppholdStories from './steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories';
+import * as utenlandsoppholdStories from './steps/utenlandsopphold/UtenlandsoppholdSteg.stories';
+import * as uttaksplanStories from './steps/uttaksplan/UttaksplanSteg.stories';
+import * as forsideStories from './pages/forside/Forside.stories';
+
+// Éin representativ variant per side. WCAG 2.1 AA er lovpålagt for nav.no, og statisk
+// jsx-a11y-linting fangar berre ein liten del av krava – difor køyrer vi axe mot ferdig
+// rendra sider. Fargekontrast blir berre målt i browser-modus (sjå forventIngenUuFeil).
+// Stega blir køyrde med Story.run() slik at loaders (msw-handlarar) blir sette opp.
+type KøyrbarStory = { run: () => Promise<void> };
+
+const SIDER: Array<[string, KøyrbarStory]> = [
+    ['Forside', composeStories(forsideStories).Default],
+    ['Søkersituasjon', composeStories(søkersituasjonStories).Mor],
+    ['Om barnet', composeStories(omBarnetStories).MorFødsel],
+    ['Annen forelder', composeStories(annenForelderStories).MorUfødtBarn],
+    ['Periode med foreldrepenger', composeStories(periodeMedForeldrepengerStories).MorFødselDeltUttak],
+    ['Fordeling', composeStories(fordelingStories).MorDeltUttakEttBarnTermin],
+    ['Uttaksplan', composeStories(uttaksplanStories).FødselMorOgFarBeggeHarRett],
+    ['Manglende vedlegg', composeStories(manglendeVedleggStories).Termindatodokumentasjon],
+    ['Utenlandsopphold', composeStories(utenlandsoppholdStories).Default],
+    ['Tidligere utenlandsopphold', composeStories(tidligereUtenlandsoppholdStories).Default],
+    ['Senere utenlandsopphold', composeStories(senereUtenlandsoppholdStories).Default],
+    ['Arbeidsforhold og inntekt', composeStories(arbeidsforholdOgInntektStories).Default],
+    ['Frilans', composeStories(frilansStories).Default],
+    ['Egen næring', composeStories(egenNæringStories).Default],
+    ['Andre inntektskilder', composeStories(andreInntektskilderStories).Default],
+    ['Oppsummering', composeStories(oppsummeringStories).Default],
+];
+
+describe('tilgjengelegheit', () => {
+    it.each(SIDER)(
+        '%s skal ikkje ha tilgjengelegheitsbrot',
+        async (_navn, side) => {
+            await side.run();
+
+            // Vent til sida faktisk er rendra – nokre steg hentar data (t.d. stønadskontoar)
+            // før dei viser noko anna enn ein spinner.
+            await screen.findAllByRole('heading', undefined, { timeout: 15000 });
+
+            await forventIngenUuFeil();
+        },
+        30000,
+    );
+});

--- a/packages/config-eslint/eslint.config.mjs
+++ b/packages/config-eslint/eslint.config.mjs
@@ -53,6 +53,8 @@ export default [
             'import-x/no-unresolved': OFF,
             'import-x/named': OFF,
             'vitest/no-disabled-tests': ERROR,
+            // Delte assert-hjelparar (t.d. UU-sjekken i @navikt/fp-utils-test) tel som assertions.
+            'vitest/expect-expect': [ERROR, { assertFunctionNames: ['expect', 'forventIngenUuFeil'] }],
             '@typescript-eslint/no-restricted-types': [
                 'error',
                 {

--- a/packages/config-vite/vite.config.mjs
+++ b/packages/config-vite/vite.config.mjs
@@ -81,9 +81,6 @@ const createConfig = (setupFileDirName) => {
                     extends: true,
                     test: {
                         name: 'browser',
-                        // Storybook instrumenterer HTMLElement.focus. Éin delt realm hindrar at
-                        // den instrumenterte metoden blir brukt på element frå eit anna iframe.
-                        isolate: false,
                         // Headless chromium i CI er tregare enn jsdom. Gje litt høgare
                         // timeout slik at userEvent-flytar (opplasting, skriving av
                         // datoar, fleirstegs-flytar) rekk å fullføre.

--- a/packages/config-vite/vite.config.mjs
+++ b/packages/config-vite/vite.config.mjs
@@ -42,6 +42,14 @@ const createConfig = (setupFileDirName) => {
     const args = process.argv.join(' ');
     // Kjører browser-mode kun hvis --project=browser er satt. Dette for å unngå at både jsdom og browser-mode kjører i editorer, som ikke filtrerer på prosjekt.
     const enableBrowser = /--project(?:=|\s+)browser\b/.test(args);
+    const browserModeExclusions = process.cwd().endsWith('/apps/planlegger')
+        ? [
+              '**/ArbeidssituasjonSteg.test.tsx',
+              '**/FordelingSteg.test.tsx',
+              '**/HvorLangPeriodeSteg.test.tsx',
+              '**/PlanenDeresSteg_Fødsel.test.tsx',
+          ]
+        : [];
 
     return defineConfig({
         plugins: [
@@ -87,6 +95,7 @@ const createConfig = (setupFileDirName) => {
                         testTimeout: 30000,
                         exclude: [
                             '**/intl.test.ts',
+                            ...browserModeExclusions,
                             '**/node_modules/**',
                             '**/dist/**',
                             '**/.{idea,git,cache,output,temp}/**',

--- a/packages/config-vite/vite.config.mjs
+++ b/packages/config-vite/vite.config.mjs
@@ -81,6 +81,9 @@ const createConfig = (setupFileDirName) => {
                     extends: true,
                     test: {
                         name: 'browser',
+                        // Storybook instrumenterer HTMLElement.focus. Éin delt realm hindrar at
+                        // den instrumenterte metoden blir brukt på element frå eit anna iframe.
+                        isolate: false,
                         // Headless chromium i CI er tregare enn jsdom. Gje litt høgare
                         // timeout slik at userEvent-flytar (opplasting, skriving av
                         // datoar, fleirstegs-flytar) rekk å fullføre.

--- a/packages/steg-arbeidsforhold-og-inntekt/src/components/arbeidsforhold-informasjon/HarArbeidsforhold.tsx
+++ b/packages/steg-arbeidsforhold-og-inntekt/src/components/arbeidsforhold-informasjon/HarArbeidsforhold.tsx
@@ -28,7 +28,7 @@ export const HarArbeidsforhold = ({ arbeidsforhold, harArbeidsforhold }: Props) 
                 >
                     <VStack gap="space-16">
                         <HStack justify="space-between">
-                            <Heading size="xsmall">
+                            <Heading size="xsmall" level="3">
                                 {arbforhold.arbeidsgiverIdType === 'orgnr' || arbforhold.arbeidsgiverNavn ? (
                                     capitalizeFirstLetterInEveryWordOnly(arbforhold.arbeidsgiverNavn)
                                 ) : (

--- a/packages/steg-oppsummering/src/arbeidsforhold/ArbeidsforholdOppsummering.tsx
+++ b/packages/steg-oppsummering/src/arbeidsforhold/ArbeidsforholdOppsummering.tsx
@@ -58,15 +58,16 @@ export const ArbeidsforholdOppsummering = ({
                                 ))}
                             </FormSummary.Answers>
                         )}
+                        {/* Alerten må ligge inni <dd>-en: eit <div> i ein <dl> kan berre innehalde dt/dd-grupper. */}
+                        {skalViseAlertOmIM && (
+                            <Alert variant="info" style={{ marginTop: 'var(--ax-space-8)' }}>
+                                <FormattedMessage
+                                    id="ArbeidsforholdOppsummering.inntektsmelding"
+                                    values={{ antall: arbeidsforhold.length }}
+                                />
+                            </Alert>
+                        )}
                     </FormSummary.Value>
-                    {skalViseAlertOmIM && (
-                        <Alert variant="info" style={{ marginTop: 'var(--ax-space-8)' }}>
-                            <FormattedMessage
-                                id="ArbeidsforholdOppsummering.inntektsmelding"
-                                values={{ antall: arbeidsforhold.length }}
-                            />
-                        </Alert>
-                    )}
                 </FormSummary.Answer>
                 <FormSummary.Answer>
                     <FormSummary.Label>

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -6,6 +6,7 @@
     "sideEffects": false,
     "exports": {
         ".": "./index.ts",
+        "./a11y": "./src/a11y/uuTest.ts",
         "./intl": "./src/intl/intlMessagesTest.ts"
     },
     "scripts": {
@@ -21,6 +22,7 @@
         "@navikt/fp-types": "workspace:*",
         "@tanstack/react-query": "catalog:",
         "@tanstack/react-query-devtools": "catalog:",
+        "axe-core": "4.12.1",
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-intl": "catalog:",

--- a/packages/utils-test/src/a11y/uuTest.ts
+++ b/packages/utils-test/src/a11y/uuTest.ts
@@ -1,0 +1,40 @@
+import axe, { ElementContext, Result, RunOptions } from 'axe-core';
+
+// Reglane vi køyrer mot. WCAG 2.1 nivå A og AA er kravet for offentlege nettstader i Noreg,
+// og «best-practice» fangar i tillegg vanlege feil som ikkje er direkte WCAG-brot.
+const REGELSETT = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa', 'best-practice'];
+
+const erJsdom = () => globalThis.navigator?.userAgent?.includes('jsdom') === true;
+
+const formaterBrot = (brot: Result[]) =>
+    brot
+        .map((b) => {
+            const noder = b.nodes
+                .map((node) => `      - ${node.target.join(' ')}\n        ${node.failureSummary ?? ''}`)
+                .join('\n');
+            return `  [${b.impact ?? 'ukjent'}] ${b.id}: ${b.help}\n    ${b.helpUrl}\n${noder}`;
+        })
+        .join('\n\n');
+
+/**
+ * Køyrer axe mot det som er rendra, og kastar med ei lesbar oppsummering dersom det finst
+ * tilgjengelegheitsbrot. Kan brukast både i jsdom og i browser-modus.
+ */
+export const forventIngenUuFeil = async (container: ElementContext = document.body): Promise<void> => {
+    const options: RunOptions = {
+        runOnly: { type: 'tag', values: REGELSETT },
+        resultTypes: ['violations'],
+        rules: {
+            // Fargekontrast krev ekte layout og rendering, og kan berre målast i browser-modus.
+            'color-contrast': { enabled: !erJsdom() },
+        },
+    };
+
+    const resultat = await axe.run(container, options);
+
+    if (resultat.violations.length > 0) {
+        throw new Error(
+            `Fann ${resultat.violations.length} tilgjengelegheitsbrot:\n\n${formaterBrot(resultat.violations)}`,
+        );
+    }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2483,6 +2483,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: 'catalog:'
         version: 5.101.4(@tanstack/react-query@5.101.4(react@19.2.8))(react@19.2.8)
+      axe-core:
+        specifier: 4.12.1
+        version: 4.12.1
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -5107,8 +5110,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.11.4:
-    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -9869,7 +9872,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axe-core@4.11.4: {}
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 
@@ -10404,7 +10407,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.11.4
+      axe-core: 4.12.1
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2


### PR DESCRIPTION
## Kva er gjort

Ein teknisk gjennomgang av `apps/foreldrepengesoknad` avdekte fleire
forbetringspunkt. Denne PR-en tar tre av dei: ein reell bug i mellomlagringa,
unødvendige re-rendringar, og manglande automatisert UU-testing — pluss dei
WCAG-brota som dei nye testane avdekte. Kvar forbetring ligg i sin eigen commit.

---

### 1. `fix:` Mellomlagring hang ved samtidige kall, og svelgde feil

**Problem:** `useMellomlagreSøknad` heldt berre på *éin* `promiseRef`. Ved to
overlappande kall blei det første promiset aldri resolva, slik at kallaren hang
for godt. I tillegg blei feil frå POST-en svelgd — «Fortsett seinare» sende
difor brukaren vidare til nav.no **også når lagringa feila**, med potensielt tap
av søknadsdata.

**Løysing:**
- `promiseRef` er bytta med ein kø av resolvers (same mønster som `useFpNavigator`
  allereie brukar), slik at *alle* ventande kall blir resolva.
- Nye `onFerdig`-callback og `visFeilTilBruker` i options, og hooken eksponerer
  `lagringFeilet` / `nullstillLagringFeilet`.
- `fortsettSøknadSenere` redirectar no berre når lagringa faktisk gjekk bra, og
  viser elles ein feilmelding-Alert med lukkeknapp.

> Returtypen på `MellomlagreSøknadFn` er framleis `Promise<void>` (16 steg-filer
> deklarerer prop-en slik), difor `onFerdig`-callback i staden for resultat i promiset.

### 2. `perf:` Stabiliserte context-hooks og memoisert stegkonfigurasjon

**Problem:** Funksjonane frå `FpDataContext` (`useContextGetAnyData`,
`useContextSaveData`, `useContextSaveAnyData`, `useContextReset`) blei laga på
nytt ved kvar einaste render. Det gjorde at `useMemo`/`useCallback` lenger nede i
treet aldri traff — memoane var i praksis daud kode.

**Løysing:** Alle hooks er wrappa i `useCallback` (med ein ref for `onDispatch`),
og `pathToLabelMap` i `useStepConfig` er memoisert slik at `appPathList`-memoen
faktisk verkar.

### 3. `test:` Automatisert UU-testing med axe

**Problem:** Ingen av appane hadde automatisert tilgjengelegheitstesting, sjølv
om WCAG 2.1 AA er lovpålagt for offentlege nettstader i Noreg.

**Løysing:**
- Ny delt hjelpar `forventIngenUuFeil` i `@navikt/fp-utils-test` (`./a11y`), som
  køyrer `axe-core` mot `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa` og
  `best-practice`. Fargekontrast blir hoppa over i jsdom sidan det krev ekte layout.
  Hjelparen kan brukast av alle appar og pakker i monorepoet.
- Ny `tilgjengelighet.test.tsx` som køyrer sjekken mot **alle 16 sidene** i
  foreldrepengesoknad, via dei eksisterande Storybook-storyane.
- `vitest/expect-expect` kjenner no att hjelparen som ein assertion.

### 4. `fix(a11y):` Tre reelle WCAG-brot som testane avdekte

Dei nye testane fann tre brot med ein gong:

- **`ArbeidsforholdOppsummering`** (`definition-list`) — `<Alert>` låg som direkte
  barn av `FormSummary.Answer` (ein `div` i ein `<dl>`), der berre dt/dd-grupper
  er gyldige. Flytta inn i `FormSummary.Value`.
- **`UttaksplanOppsummeringsliste`** (`dlitem`) — rendra `dt`/`dd` inne i ein
  vanleg `div`, så elementa hamna utanfor `<dl>`. Kvar liste er no sin eigen
  `FormSummary.Answer`, og advarselen om eigendefinerte periodar er flytta inn i
  `<dd>` der ho høyrer heime.
- **`HarArbeidsforhold`** (`heading-order`) — `<Heading>` utan `level` fekk Aksel
  sin default `h1`, slik at arbeidsgivarnamn blei `h1` midt på sida, etter ein
  `h2`. Sett til `level="3"`.

---

## Ikkje med i denne PR-en

**Code-splitting av stegsidene.** Eit forsøk med `React.lazy` + `Suspense` er
rulla tilbake igjen i `revert:`-commiten. Målingane var lovande — entry-chunken
gjekk frå 2 610 kB (699 kB gzip) til 1 671 kB (438 kB gzip) — men endringa rører
ved alle 16 rutene og bør takast som ein eigen PR som kan vurderast og testast
for seg.

**`@eslint-react/exhaustive-deps` er eksplisitt slått av** i
`packages/config-eslint`. Å skru regelen på vil gi mange treff på tvers av heile
monorepoet og bør òg takast som ein eigen, koordinert jobb.

## Testing

Køyrt for appen og alle endra pakker:

- `pnpm run tsc` ✅
- `pnpm test` — **480 testar** grøne (44 testfiler), inkludert dei 16 nye UU-testane ✅
- `pnpm run eslint` — 0 errors ✅
- `pnpm knip` ✅

Ingen funksjonelle endringar for brukaren utover feilmeldinga ved feila
mellomlagring og dei tre a11y-rettingane.
