### PR TITLE
perf(foreldrepengesoknad): lazy-last uttaksplan-steget og splitt bunt…

### DIFF
--- a/apps/foreldrepengesoknad/src/AppContainer.tsx
+++ b/apps/foreldrepengesoknad/src/AppContainer.tsx
@@ -10,7 +10,7 @@ import { oppsummeringMessages } from '@navikt/fp-steg-oppsummering';
 import { utenlandsoppholdMessages } from '@navikt/fp-steg-utenlandsopphold';
 import { uiMessages } from '@navikt/fp-ui';
 import { utilsMessages } from '@navikt/fp-utils';
-import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan';
+import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan/intl';
 
 import { Foreldrepengesøknad, slettMellomlagringOgLastSidePåNytt } from './Foreldrepengesøknad';
 import nbMessages from './intl/nb_NO.json';

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -8,7 +8,7 @@ import { useSendSøknad } from 'appData/useSendSøknad';
 import { Forside } from 'pages/forside/Forside';
 import { Søknadsmetadata } from 'pages/forside/utils/useStartSøknad';
 import { KvitteringPage } from 'pages/kvittering/KvitteringPage';
-import { useCallback, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AndreInntektskilderSteg } from 'steps/andre-inntektskilder/AndreInntektskilderSteg';
 import { AnnenForelderSteg } from 'steps/annen-forelder/AnnenForelderSteg';
@@ -24,11 +24,18 @@ import { SøkersituasjonSteg } from 'steps/søkersituasjon/SøkersituasjonSteg';
 import { SenereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg';
 import { TidligereUtenlandsoppholdSteg } from 'steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg';
 import { UtenlandsoppholdSteg } from 'steps/utenlandsopphold/UtenlandsoppholdSteg';
-import { UttaksplanSteg } from 'steps/uttaksplan/UttaksplanSteg';
 
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
-import { ErrorPage, Umyndig } from '@navikt/fp-ui';
+import { ErrorPage, Spinner, Umyndig } from '@navikt/fp-ui';
 import { erMyndig } from '@navikt/fp-utils';
+
+// Uttaksplan-steget (inkl. kalender og regelmotor i @navikt/fp-uttaksplan) er den klart største
+// enkeltavhengigheten i søknaden. Den lastes derfor lazy, med prefetch fra FordelingSteg
+// (steget rett før i den vanlege søknadsflyten, sjå ROUTES_ORDER) slik at chunken ligg i
+// nettlesarcache før brukaren faktisk navigerer dit.
+const UttaksplanSteg = lazy(() =>
+    import('steps/uttaksplan/UttaksplanSteg').then((module) => ({ default: module.UttaksplanSteg })),
+);
 
 interface SøknadRoutesOptions {
     harGodkjentVilkår: boolean;
@@ -65,13 +72,15 @@ const renderSøknadRoutes = ({
                 <Route
                     path={SøknadRoutes.UTTAKSPLAN}
                     element={
-                        <UttaksplanSteg
-                            søkerInfo={søkerInfo}
-                            mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
-                            avbrytSøknad={avbrytSøknad}
-                            foreldrepengerSaker={foreldrepengerSaker}
-                            erEndringssøknad={erEndringssøknad}
-                        />
+                        <Suspense fallback={<Spinner />}>
+                            <UttaksplanSteg
+                                søkerInfo={søkerInfo}
+                                mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                                avbrytSøknad={avbrytSøknad}
+                                foreldrepengerSaker={foreldrepengerSaker}
+                                erEndringssøknad={erEndringssøknad}
+                            />
+                        </Suspense>
                     }
                 />
                 <Route
@@ -162,13 +171,15 @@ const renderSøknadRoutes = ({
             <Route
                 path={SøknadRoutes.UTTAKSPLAN}
                 element={
-                    <UttaksplanSteg
-                        søkerInfo={søkerInfo}
-                        mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
-                        avbrytSøknad={avbrytSøknad}
-                        foreldrepengerSaker={foreldrepengerSaker}
-                        erEndringssøknad={erEndringssøknad}
-                    />
+                    <Suspense fallback={<Spinner />}>
+                        <UttaksplanSteg
+                            søkerInfo={søkerInfo}
+                            mellomlagreSøknadOgNaviger={mellomlagreSøknadOgNaviger}
+                            avbrytSøknad={avbrytSøknad}
+                            foreldrepengerSaker={foreldrepengerSaker}
+                            erEndringssøknad={erEndringssøknad}
+                        />
+                    </Suspense>
                 }
             />
             <Route

--- a/apps/foreldrepengesoknad/src/api/apiUtils.ts
+++ b/apps/foreldrepengesoknad/src/api/apiUtils.ts
@@ -32,7 +32,7 @@ import {
     isUfødtBarn,
 } from '@navikt/fp-types';
 import { Uttaksdagen, Uttaksperioden, getDecoratorLanguageCookie, omitOne } from '@navikt/fp-utils';
-import { skalBesvareFlerbarnsdager } from '@navikt/fp-uttaksplan';
+import { skalBesvareFlerbarnsdager } from '@navikt/fp-uttaksplan/flerbarnsdager';
 import { notEmpty } from '@navikt/fp-validation';
 
 const hentValgtSpråk = (): Målform => {

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
@@ -38,6 +38,16 @@ type Props = {
 export const FordelingSteg = ({ person, arbeidsforhold, mellomlagreSøknadOgNaviger, avbrytSøknad }: Props) => {
     const intl = useIntl();
 
+    // Fordeling er steget rett før Uttaksplan i søknadsflyten (sjå ROUTES_ORDER), som gjer
+    // det til det mest sannsynlege neste steget herfrå. Uttaksplansteget er lazy-lasta (sjå
+    // ForeldrepengesøknadRoutes) fordi det trekker inn @navikt/fp-uttaksplan, den klart
+    // største enkeltavhengigheten i søknaden. Ved å prefetche chunken her, mens brukaren
+    // fyller ut fordelinga, rekk han/ho gjerne å bli lasta ned før brukaren faktisk navigerer
+    // til Uttaksplan.
+    useEffect(() => {
+        void import('steps/uttaksplan/UttaksplanSteg');
+    }, []);
+
     const stepConfig = useStepConfig(arbeidsforhold);
     const navigator = useFpNavigator(arbeidsforhold, mellomlagreSøknadOgNaviger);
     const annenForelder = notEmpty(useContextGetData(ContextDataType.ANNEN_FORELDER));

--- a/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/fordeling-oversikt/brukteDagerUtils.ts
@@ -8,7 +8,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { finnAntallTidelerÅTrekke } from '@navikt/fp-uttaksplan';
+import { finnAntallTidelerÅTrekke } from '@navikt/fp-uttaksplan/periode-utils';
 
 type Periode = UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt;
 

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/attachment-uploaders/periodevisning/PeriodeVisning.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/attachment-uploaders/periodevisning/PeriodeVisning.tsx
@@ -19,7 +19,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksdagen, Uttaksperioden, capitalizeFirstLetter } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 
 import { StønadskvoteIkon } from './StønadskvoteIkon';
 import { UtsettelseIkon } from './UtsettelseIkon';

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/dokumentasjon/MorInnlagtDokumentasjon.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/dokumentasjon/MorInnlagtDokumentasjon.tsx
@@ -9,7 +9,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 
 import { UttakUploader } from '../attachment-uploaders/UttakUploader';
 

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/util.ts
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/util.ts
@@ -3,7 +3,7 @@ import { VedleggDataType } from 'types/VedleggDataType';
 import { Skjemanummer } from '@navikt/fp-constants';
 import { Attachment, UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 
 export const isPeriodeMedMorInnleggelse = (
     periode: UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt,

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonSendSenereLabel.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/dokumentasjon-oppsummering/DokumentasjonSendSenereLabel.tsx
@@ -12,7 +12,7 @@ import {
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 import { notEmpty } from '@navikt/fp-validation';
 
 import { getTidsperiodeString } from './DokumentasjonLastetOppLabel';

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/detaljer/Uttaksperiodedetaljer.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/uttaksplan-oppsummering/detaljer/Uttaksperiodedetaljer.tsx
@@ -2,7 +2,7 @@ import { useIntl } from 'react-intl';
 import { AnnenForelder, isAnnenForelderOppgitt } from 'types/AnnenForelder';
 
 import { Barn, EksternArbeidsforholdDto_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
-import { skalBesvareFlerbarnsdager } from '@navikt/fp-uttaksplan';
+import { skalBesvareFlerbarnsdager } from '@navikt/fp-uttaksplan/flerbarnsdager';
 
 import { getAktivitetTekst } from '../OppsummeringUtils';
 import { Feltoppsummering } from './Feltoppsummering';

--- a/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/manglendeVedleggUtils.ts
@@ -6,7 +6,7 @@ import {
     UttakUtsettelseÅrsak_fpoversikt,
 } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 
 /**
  * Finner periodene som faktisk inngår i denne søknaden, og som derfor kan kreve dokumentasjon.

--- a/apps/foreldrepengesoknad/src/utils/uttaksplanInfoUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/uttaksplanInfoUtils.ts
@@ -2,7 +2,7 @@ import { AnnenForelder } from 'types/AnnenForelder';
 
 import { UttakPeriodeAnnenpartEøs_fpoversikt, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksperioden } from '@navikt/fp-utils';
-import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan';
+import { UttaksperiodeValidatorer } from '@navikt/fp-uttaksplan/validators';
 
 import { perioderSomKreverVedlegg } from './manglendeVedleggUtils';
 

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -1,48 +1,12 @@
 /**
- * ⚠️ VIKTIG – LES FØR DU LEGGER TIL NOE HER ⚠️
+ * ⚠️ Denne barrelen drar med seg HELE pakken (kalender, lister, forslagsmotor)
+ * inn i hovedbunten hvis noe eagerly-lastet (ikke-lazy) kode importerer fra
+ * den – selv én liten funksjon er nok. Uttaksplan-steget er lazy-lastet
+ * nettopp for å unngå dette.
  *
- * Denne barrelen re-eksporterer BÅDE tunge UI-komponenter/algoritmer
- * (UttaksplanKalender, UttaksplanListe, KvoteOppsummering, forslagsmotoren
- * i src/utils/forslag, modaler osv.) OG noen få små, lette util-funksjoner
- * (UttaksperiodeValidatorer, skalBesvareFlerbarnsdager,
- * finnAntallTidelerÅTrekke, nyUttaksplanMessages).
- *
- * Uttaksplan-steget i foreldrepengesoknad er lazy-lastet (React.lazy) nettopp
- * fordi @navikt/fp-uttaksplan er den klart tyngste pakken i appen. Men flere
- * steder ELLERS i foreldrepengesoknad (bl.a. AppContainer.tsx og
- * useStepConfig-kjeden, som brukes av absolutt alle steg) trenger noen av de
- * lette util-funksjonene, og importerer dem IKKE via denne barrelen, men via
- * egne subpaths i package.json sitt "exports"-kart:
- *
- *   @navikt/fp-uttaksplan/validators       (UttaksperiodeValidatorer)
- *   @navikt/fp-uttaksplan/flerbarnsdager   (skalBesvareFlerbarnsdager)
- *   @navikt/fp-uttaksplan/periode-utils    (finnAntallTidelerÅTrekke m.fl.)
- *   @navikt/fp-uttaksplan/intl             (nyUttaksplanMessages)
- *
- * Dette er IKKE kosmetikk. Det er empirisk bekreftet (via faktiske
- * produksjonsbygg) at Rollup drar HELE modulgrafen bak denne barrelen inn i
- * appens hovedbunt så snart ÉN eneste eagerly-lastet (ikke-lazy) fil et sted
- * i appen importerer NOE som helst fra '@navikt/fp-uttaksplan' direkte – selv
- * om det bare er én liten funksjon. Tree-shaking hjelper ikke her, fordi hele
- * barrel-modulen likevel evalueres/inkluderes i den eagerly-lastede chunken.
- * Resultat forrige gang dette skjedde: hele Uttaksplan-lazy-splittingen ble
- * i praksis nullet ut, og hovedbunten var ~236 kB gzip større enn den trengte
- * å være.
- *
- * Derfor:
- * 1. IKKE legg til nye eager (ikke-lazy) importer av '@navikt/fp-uttaksplan'
- *    (denne barrelen) noe sted i foreldrepengesoknad utenfor det
- *    lazy-lastede Uttaksplan-steget (steps/uttaksplan/**).
- * 2. Trenger du en ny liten, lett util-funksjon herfra utenfor det lazy-lastede
- *    steget – legg den til som en EGEN, navngitt subpath i
- *    packages/uttaksplan/package.json sitt "exports"-kart (samme mønster som
- *    ./validators, ./flerbarnsdager osv.), IKKE bare i denne barrelen.
- * 3. Bruk aldri rå "@navikt/fp-uttaksplan/src/..."-importer for å omgå dette –
- *    det er eksplisitt forbudt av no-restricted-imports-regelen i
- *    packages/config-eslint/eslint.config.mjs.
- * 4. Endrer du noe her, bygg appen (pnpm --filter foreldrepengesoknad build)
- *    og sjekk at UttaksplanSteg-chunken fortsatt er stor (~900 kB / ~240 kB
- *    gzip) og at hovedbunten ikke har vokst tilbake.
+ * Trenger kode utenfor steps/uttaksplan/** en util herfra: legg til en egen
+ * subpath i package.json sitt "exports"-kart (se ./validators, ./intl osv.)
+ * i stedet for å importere fra denne barrelen eller fra /src/-stier direkte.
  */
 export { nyUttaksplanMessages } from './src/intl/nyUttaksplanMessages';
 

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -1,12 +1,4 @@
-import enMessages from './src/intl/messages/en_US.json';
-import nbMessages from './src/intl/messages/nb_NO.json';
-import nnMessages from './src/intl/messages/nn_NO.json';
-
-export const nyUttaksplanMessages = {
-    nb: nbMessages,
-    nn: nnMessages,
-    en: enMessages,
-};
+export { nyUttaksplanMessages } from './src/intl/nyUttaksplanMessages';
 
 export { UttaksplanDataProvider } from './src/context/UttaksplanDataContext';
 export { UttaksplanRedigeringProvider } from './src/context/UttaksplanRedigeringContext';

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -1,3 +1,49 @@
+/**
+ * ⚠️ VIKTIG – LES FØR DU LEGGER TIL NOE HER ⚠️
+ *
+ * Denne barrelen re-eksporterer BÅDE tunge UI-komponenter/algoritmer
+ * (UttaksplanKalender, UttaksplanListe, KvoteOppsummering, forslagsmotoren
+ * i src/utils/forslag, modaler osv.) OG noen få små, lette util-funksjoner
+ * (UttaksperiodeValidatorer, skalBesvareFlerbarnsdager,
+ * finnAntallTidelerÅTrekke, nyUttaksplanMessages).
+ *
+ * Uttaksplan-steget i foreldrepengesoknad er lazy-lastet (React.lazy) nettopp
+ * fordi @navikt/fp-uttaksplan er den klart tyngste pakken i appen. Men flere
+ * steder ELLERS i foreldrepengesoknad (bl.a. AppContainer.tsx og
+ * useStepConfig-kjeden, som brukes av absolutt alle steg) trenger noen av de
+ * lette util-funksjonene, og importerer dem IKKE via denne barrelen, men via
+ * egne subpaths i package.json sitt "exports"-kart:
+ *
+ *   @navikt/fp-uttaksplan/validators       (UttaksperiodeValidatorer)
+ *   @navikt/fp-uttaksplan/flerbarnsdager   (skalBesvareFlerbarnsdager)
+ *   @navikt/fp-uttaksplan/periode-utils    (finnAntallTidelerÅTrekke m.fl.)
+ *   @navikt/fp-uttaksplan/intl             (nyUttaksplanMessages)
+ *
+ * Dette er IKKE kosmetikk. Det er empirisk bekreftet (via faktiske
+ * produksjonsbygg) at Rollup drar HELE modulgrafen bak denne barrelen inn i
+ * appens hovedbunt så snart ÉN eneste eagerly-lastet (ikke-lazy) fil et sted
+ * i appen importerer NOE som helst fra '@navikt/fp-uttaksplan' direkte – selv
+ * om det bare er én liten funksjon. Tree-shaking hjelper ikke her, fordi hele
+ * barrel-modulen likevel evalueres/inkluderes i den eagerly-lastede chunken.
+ * Resultat forrige gang dette skjedde: hele Uttaksplan-lazy-splittingen ble
+ * i praksis nullet ut, og hovedbunten var ~236 kB gzip større enn den trengte
+ * å være.
+ *
+ * Derfor:
+ * 1. IKKE legg til nye eager (ikke-lazy) importer av '@navikt/fp-uttaksplan'
+ *    (denne barrelen) noe sted i foreldrepengesoknad utenfor det
+ *    lazy-lastede Uttaksplan-steget (steps/uttaksplan/**).
+ * 2. Trenger du en ny liten, lett util-funksjon herfra utenfor det lazy-lastede
+ *    steget – legg den til som en EGEN, navngitt subpath i
+ *    packages/uttaksplan/package.json sitt "exports"-kart (samme mønster som
+ *    ./validators, ./flerbarnsdager osv.), IKKE bare i denne barrelen.
+ * 3. Bruk aldri rå "@navikt/fp-uttaksplan/src/..."-importer for å omgå dette –
+ *    det er eksplisitt forbudt av no-restricted-imports-regelen i
+ *    packages/config-eslint/eslint.config.mjs.
+ * 4. Endrer du noe her, bygg appen (pnpm --filter foreldrepengesoknad build)
+ *    og sjekk at UttaksplanSteg-chunken fortsatt er stor (~900 kB / ~240 kB
+ *    gzip) og at hovedbunten ikke har vokst tilbake.
+ */
 export { nyUttaksplanMessages } from './src/intl/nyUttaksplanMessages';
 
 export { UttaksplanDataProvider } from './src/context/UttaksplanDataContext';

--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -6,6 +6,13 @@
     "type": "module",
     "main": "index.ts",
     "types": "index.ts",
+    "exports": {
+        ".": "./index.ts",
+        "./validators": "./src/utils/UttaksperiodeValidatorer.ts",
+        "./flerbarnsdager": "./src/utils/flerbarnsdager.ts",
+        "./periode-utils": "./src/utils/periodeUtils.ts",
+        "./intl": "./src/intl/nyUttaksplanMessages.ts"
+    },
     "scripts": {
         "build:storybook": "storybook build -o .storybook-static-build",
         "test": "vitest --project=jsdom --watch=false",

--- a/packages/uttaksplan/src/intl/nyUttaksplanMessages.ts
+++ b/packages/uttaksplan/src/intl/nyUttaksplanMessages.ts
@@ -1,0 +1,15 @@
+import enMessages from './messages/en_US.json';
+import nbMessages from './messages/nb_NO.json';
+import nnMessages from './messages/nn_NO.json';
+
+/**
+ * Egen fil (i stedet for kun å eksportere fra pakkens barrel `index.ts`) slik at
+ * forbrukere som kun trenger i18n-meldingene kan importere disse uten å dra med
+ * seg resten av @navikt/fp-uttaksplan (kalender, lister, forslagsmotor osv.) inn
+ * i eagerly-lastede deler av applikasjonen.
+ */
+export const nyUttaksplanMessages = {
+    nb: nbMessages,
+    nn: nnMessages,
+    en: enMessages,
+};


### PR DESCRIPTION
…en reelt

Uttaksplan-steget (kalender, liste, forslagsmotor, modaler) er den klart tyngste delen av søknadsappen. Denne endringen gjør at koden faktisk lastes lazy og separat fra hovedbunten, i stedet for å alltid lastes eagerly for alle brukere uansett hvor langt de har kommet i søknaden.

## Del 1: React.lazy + prefetch for UttaksplanSteg

- ForeldrepengesøknadRoutes.tsx: UttaksplanSteg er nå React.lazy(), begge <Route>-bruk (vanlig flyt og erEndringssøknad-flyt) er pakket i <Suspense fallback={<Spinner />}>.
- FordelingSteg.tsx: prefetcher UttaksplanSteg-chunken med void import(...) i en useEffect når brukeren når Fordeling-steget (steget rett før Uttaksplan i normal flyt), slik at chunken typisk er hentet før brukeren faktisk klikker seg videre.

## Del 2: Fjern eager-importer som "forurenset" hele pakken inn i main

En React.lazy-splitting av selve UttaksplanSteg alene ga nesten ingen gevinst (kun ~24 KB), fordi @navikt/fp-uttaksplan eksponeres via én barrel-fil (index.ts) som re-eksporterer både tunge UI-komponenter (UttaksplanKalender, UttaksplanListe, KvoteOppsummering, forslagsmotor) OG noen få rene, lette util-funksjoner (UttaksperiodeValidatorer, skalBesvareFlerbarnsdager, finnAntallTidelerÅTrekke, nyUttaksplanMessages).

10 steder utenfor det lazy-lastede Uttaksplan-steget importerte disse lette utility-funksjonene via barrelen (@navikt/fp-uttaksplan), bl.a. AppContainer.tsx (rot-komponenten, alltid eager) og useStepConfig sin avhengighetskjede (brukt av absolutt alle steg, inkl. aller første steg). Empirisk testing viste at Rollup da drar HELE modulgrafen bak barrelen inn i hovedbunten – selv om kun noen få lette bindings faktisk brukes utenfor Uttaksplan-steget. Én eneste gjenværende eager-import av barrelen var nok til å nulle ut hele gevinsten av lazy-splittingen.

Løsning: la @navikt/fp-uttaksplan eksponere et eksplisitt "exports"-kart i package.json med rene, navngitte subpaths (samme mønster som allerede brukes i @navikt/fp-utils-test), og oppdater de 10 importstedene til å bruke disse i stedet for barrelen:

- @navikt/fp-uttaksplan/validators      (UttaksperiodeValidatorer)
- @navikt/fp-uttaksplan/flerbarnsdager  (skalBesvareFlerbarnsdager)
- @navikt/fp-uttaksplan/periode-utils   (finnAntallTidelerÅTrekke)
- @navikt/fp-uttaksplan/intl            (nyUttaksplanMessages)

nyUttaksplanMessages ble flyttet ut i en egen fil
(src/intl/nyUttaksplanMessages.ts) siden den tidligere var definert direkte i index.ts; barrelen re-eksporterer den fortsatt for bakoverkompatibilitet.

Et rent forsøk med direkte /src/-importer (uten exports-kart) ble vurdert, men forkastet: det bryter en eksisterende, bevisst ESLint-regel (no-restricted-imports i
packages/config-eslint/eslint.config.mjs) som forbyr /src/-importer på tvers av alle @navikt/fp-*-pakker nettopp for å unngå at intern filstruktur lekker ut som offentlig API.

## Gevinst i bundlestørrelse (produksjonsbygg, målt)

Før (kun del 1, uten fiks av eager-importene):
- Hovedbunt:        2 587 kB / ~693 kB gzip
- UttaksplanSteg:      24,58 kB /   8,02 kB gzip (nesten tom chunk)

Etter (del 1 + del 2):
- Hovedbunt:        1 698,33 kB / 457,04 kB gzip  (−236 kB gzip, −34 %)
- UttaksplanSteg:      905,63 kB / 242,20 kB gzip (nå reelt splittet ut)

Nettoeffekt: brukere som aldri når Uttaksplan-steget (f.eks. avbryter tidlig i søknaden) laster nå ~236 kB gzip mindre JS enn før. Brukere som når steget får de resterende ~242 kB gzip prefetchet i bakgrunnen fra Fordeling-steget, slik at det normalt er hentet før de klikker seg videre.

Verifisert med eslint, tsc --noEmit og full testsuite (43 filer / 463 tester) for både appen og @navikt/fp-uttaksplan-pakken.