### PR TITLE
Tanstack forslag

### DIFF
--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -3,7 +3,7 @@ import { useAnnenPartVedtakOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useAvbrytSøknad } from 'appData/useAvbrytSøknad';
-import { useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
+import { MellomlagreSøknadFn, useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
 import { useSendSøknad } from 'appData/useSendSøknad';
 import { Forside } from 'pages/forside/Forside';
 import { Søknadsmetadata } from 'pages/forside/utils/useStartSøknad';
@@ -37,7 +37,7 @@ interface SøknadRoutesOptions {
     harGodkjentVilkår: boolean;
     erEndringssøknad: boolean;
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     sendSøknad: () => Promise<void>;
     avbrytSøknad: () => void;
     søknadGjelderNyttBarn?: boolean;

--- a/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
+++ b/apps/foreldrepengesoknad/src/app-data/FpDataContext.tsx
@@ -67,8 +67,25 @@ export type Action =
     | { type: 'reset' };
 type Dispatch = (action: Action) => void;
 
+const reduser = (oldState: ContextDataMap, action: Action): ContextDataMap => {
+    switch (action.type) {
+        case 'update':
+            return {
+                ...oldState,
+                [action.key]: action.data,
+            };
+        case 'reset':
+            return {};
+        default:
+            throw new Error();
+    }
+};
+
 const FpStateContext = createContext<ContextDataMap>(defaultInitialState);
 const FpDispatchContext = createContext<Dispatch | undefined>(undefined);
+
+// Held ein synkron spegel av state. Sjå kommentaren i dispatchWrapper.
+const FpLatestStateContext = createContext<{ current: ContextDataMap }>({ current: defaultInitialState });
 
 interface Props {
     children: ReactNode;
@@ -77,19 +94,8 @@ interface Props {
 }
 
 export const FpDataContext = ({ children, initialState, onDispatch }: Props): JSX.Element => {
-    const [state, dispatch] = useReducer((oldState: ContextDataMap, action: Action) => {
-        switch (action.type) {
-            case 'update':
-                return {
-                    ...oldState,
-                    [action.key]: action.data,
-                };
-            case 'reset':
-                return {};
-            default:
-                throw new Error();
-        }
-    }, initialState || defaultInitialState);
+    const startState = initialState || defaultInitialState;
+    const [state, dispatch] = useReducer(reduser, startState);
 
     // onDispatch kjem frå stories/testar og er ofte ein ny closure per render. Held den i ein
     // ref slik at dispatch-funksjonen under er referansestabil – elles ville kvar render av
@@ -99,14 +105,22 @@ export const FpDataContext = ({ children, initialState, onDispatch }: Props): JS
         onDispatchRef.current = onDispatch;
     }, [onDispatch]);
 
+    // Kode som lagrar rett etter ein dispatch (t.d. mellomlagring frå ein submit-handler)
+    // må sjå den ferske verdien med ein gong. React-state er først oppdatert i neste render,
+    // så vi speglar reduseraren synkront her.
+    const stateRef = useRef(startState);
+
     const dispatchWrapper = useCallback((a: Action) => {
+        stateRef.current = reduser(stateRef.current, a);
         onDispatchRef.current?.(a);
         dispatch(a);
     }, []);
 
     return (
         <FpStateContext value={state}>
-            <FpDispatchContext value={dispatchWrapper}>{children}</FpDispatchContext>
+            <FpLatestStateContext value={stateRef}>
+                <FpDispatchContext value={dispatchWrapper}>{children}</FpDispatchContext>
+            </FpLatestStateContext>
         </FpStateContext>
     );
 };
@@ -158,4 +172,15 @@ export const useContextReset = () => {
 
 export const useContextComplete = (): ContextDataMap => {
     return use(FpStateContext);
+};
+
+/**
+ * Returnerer ein funksjon som gir all context-data slik den er *no* – også når kallaren
+ * nettopp har dispatcha ei oppdatering i same hendingshandtering. Bruk denne når data
+ * skal sendast til backend rett etter ein dispatch (mellomlagring). Til rendering skal
+ * du bruke useContextGetData/useContextComplete, som gir React-state.
+ */
+export const useContextGetLatestComplete = (): (() => ContextDataMap) => {
+    const stateRef = use(FpLatestStateContext);
+    return useCallback(() => stateRef.current, [stateRef]);
 };

--- a/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useFpNavigator.ts
@@ -75,15 +75,10 @@ export const useFpNavigator = (
         // sidan brukaren ikkje får eit nytt forsøk på å lagre endringane sine. Vi sender
         // brukaren først ut av appen når lagringa faktisk gjekk bra; feilar den, blir
         // brukaren verande med søknaden sin og får ei feilmelding.
-        void mellomlagreOgNaviger({
-            naviger: false,
-            medRetry: true,
-            visFeilTilBruker: true,
-            onFerdig: (resultat) => {
-                if (resultat === 'ok') {
-                    globalThis.location.href = 'https://nav.no';
-                }
-            },
+        void mellomlagreOgNaviger({ naviger: false, medRetry: true, visFeilTilBruker: true }).then((resultat) => {
+            if (resultat === 'ok') {
+                globalThis.location.href = 'https://nav.no';
+            }
         });
     };
 

--- a/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { API_URLS, useAnnenPartVedtakOptions } from 'api/queries';
 import ky, { HTTPError } from 'ky';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { VERSJON_MELLOMLAGRING } from 'utils/mellomlagringUtils';
 
@@ -14,7 +14,7 @@ import {
 } from '@navikt/fp-types';
 import { notEmpty } from '@navikt/fp-validation';
 
-import { ContextDataMap, ContextDataType, useContextComplete } from './FpDataContext';
+import { ContextDataMap, ContextDataType, useContextGetLatestComplete } from './FpDataContext';
 
 export type FpMellomlagretData = {
     version: number;
@@ -31,9 +31,6 @@ type MellomlagreSøknadOptions = {
     naviger?: boolean;
     // Prøv kallet på nytt ved transiente feil. Default false.
     medRetry?: boolean;
-    // Blir kalla når lagringa er ferdig, med utfallet. Bruk denne når kallaren må
-    // vite om lagringa gjekk bra (t.d. før ein sender brukaren ut av appen).
-    onFerdig?: (resultat: MellomlagringResultat) => void;
     // Vis feilmelding til brukaren dersom lagringa feilar. Default false – for vanleg
     // stegnavigasjon held det å logge, sidan neste lagring rettar opp i det.
     visFeilTilBruker?: boolean;
@@ -41,14 +38,39 @@ type MellomlagreSøknadOptions = {
 
 export type MellomlagringResultat = 'ok' | 'feilet';
 
-export type MellomlagreSøknadFn = (options?: MellomlagreSøknadOptions) => Promise<void>;
+/**
+ * Lagrar søknaden og resolvar med utfallet. Kastar aldri, så kallarar som ikkje bryr seg
+ * om resultatet kan trygt gjere `void mellomlagreSøknad()`.
+ */
+export type MellomlagreSøknadFn = (options?: MellomlagreSøknadOptions) => Promise<MellomlagringResultat>;
 
-type Forespørsel = {
-    naviger: boolean;
-    medRetry: boolean;
-    visFeilTilBruker: boolean;
-    onFerdig?: (resultat: MellomlagringResultat) => void;
-    ferdig: () => void;
+const RETRY_OPTIONS = {
+    limit: 2,
+    methods: ['post'],
+    statusCodes: [408, 429, 500, 502, 503, 504],
+};
+
+const postMellomlagring = async (data: FpMellomlagretData, fnr: string, medRetry: boolean) => {
+    try {
+        await ky.post(API_URLS.mellomlagring, {
+            json: data,
+            headers: { fnr },
+            ...(medRetry ? { retry: RETRY_OPTIONS } : {}),
+        });
+    } catch (error: unknown) {
+        if (error instanceof HTTPError) {
+            if (error.response.status === 401 || error.response.status === 403) {
+                throw error;
+            }
+
+            const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
+            throw new ApiError('', 'Feil ved mellomlagring av foreldrepengesøknad', jsonResponse);
+        }
+        if (error instanceof Error) {
+            throw error;
+        }
+        throw new Error(String(error), { cause: error });
+    }
 };
 
 export const useMellomlagreSøknad = (
@@ -58,33 +80,22 @@ export const useMellomlagreSøknad = (
     søknadGjelderEtNyttBarn?: boolean,
 ) => {
     const navigate = useNavigate();
-    const state = useContextComplete();
+    // Kallarar dispatchar typisk context-oppdateringar rett før dei mellomlagrar, så vi må
+    // lese ferske data – ikkje React-state frå denne renderen.
+    const hentAlleData = useContextGetLatestComplete();
 
-    const annenPartVedtakQuery = useQuery(useAnnenPartVedtakOptions());
+    const annenPartVedtakOptions = useAnnenPartVedtakOptions();
+    const annenPartVedtakQuery = useQuery(annenPartVedtakOptions);
 
-    const [lagringFeilet, setLagringFeilet] = useState(false);
+    const mutation = useMutation({
+        // Felles scope gjer at TanStack køyrer overlappande lagringar serielt i den
+        // rekkjefølgja dei blei starta, i staden for at dei kappast om siste ord.
+        scope: { id: 'mellomlagring' },
+        mutationFn: async ({ naviger, medRetry }: Required<MellomlagreSøknadOptions>) => {
+            const state = hentAlleData();
 
-    // Forespurte lagringar ligg i ein ref-kø, ikkje i state: fleire kall kan kome før
-    // effekten rekk å køyre (t.d. «neste steg» og «fortsett seinare» rett etter kvarandre),
-    // og då må alle promisa bli resolva. Sekvensnummeret finst berre for å trigge effekten,
-    // som er naudsynt for at vi skal lese ferskt context-state etter kallaren sine dispatchar.
-    const køRef = useRef<Forespørsel[]>([]);
-    const [seq, setSeq] = useState(0);
-
-    useEffect(() => {
-        const forespørsler = køRef.current;
-        if (forespørsler.length === 0) {
-            return;
-        }
-        køRef.current = [];
-
-        const naviger = forespørsler.some((f) => f.naviger);
-        const medRetry = forespørsler.some((f) => f.medRetry);
-        const currentRoute = notEmpty(state[ContextDataType.APP_ROUTE]);
-
-        const lagre = async () => {
             if (naviger) {
-                void navigate(currentRoute);
+                void navigate(notEmpty(state[ContextDataType.APP_ROUTE]));
             }
 
             const data = {
@@ -100,80 +111,40 @@ export const useMellomlagreSøknad = (
                 ...state,
             } satisfies FpMellomlagretData;
 
-            try {
-                await ky.post(API_URLS.mellomlagring, {
-                    json: data,
-                    headers: {
-                        fnr: søkerInfo.fnr,
-                    },
-                    ...(medRetry
-                        ? {
-                              retry: {
-                                  limit: 2,
-                                  methods: ['post'],
-                                  statusCodes: [408, 429, 500, 502, 503, 504],
-                              },
-                          }
-                        : {}),
-                });
-            } catch (error: unknown) {
-                if (error instanceof HTTPError) {
-                    if (error.response.status === 401 || error.response.status === 403) {
-                        throw error;
-                    }
-
-                    const jsonResponse = error.data as FpSoknadProblemDetails | undefined;
-                    throw new ApiError('', 'Feil ved mellomlagring av foreldrepengesøknad', jsonResponse);
-                }
-                if (error instanceof Error) {
-                    throw error;
-                }
-                throw new Error(String(error), { cause: error });
+            await postMellomlagring(data, søkerInfo.fnr, medRetry);
+        },
+        onError: (error: unknown) => {
+            if (error instanceof ApiError) {
+                captureApiError(error.sentryMessage, error.problemDetails);
+            } else if (error instanceof Error) {
+                captureMessage(error.message);
             }
-        };
+        },
+    });
 
-        const fullfør = (resultat: MellomlagringResultat) => {
-            if (resultat === 'feilet' && forespørsler.some((f) => f.visFeilTilBruker)) {
-                setLagringFeilet(true);
-            }
-            for (const forespørsel of forespørsler) {
-                forespørsel.onFerdig?.(resultat);
-                forespørsel.ferdig();
-            }
-        };
-
-        lagre().then(
-            () => fullfør('ok'),
-            (error: unknown) => {
-                //Logg feil. Om kallaren har bedt om det, blir brukaren også varsla.
-                if (error instanceof ApiError) {
-                    captureApiError(error.sentryMessage, error.problemDetails);
-                } else if (error instanceof Error) {
-                    captureMessage(error.message);
-                }
-
-                fullfør('feilet');
-            },
-        );
-    }, [seq]);
+    const { mutateAsync } = mutation;
 
     const mellomlagreSøknad = useCallback<MellomlagreSøknadFn>(
-        (options) =>
-            //Må gå via state change sidan ein må få oppdatert context før ein mellomlagrar
-            new Promise<void>((resolve) => {
-                køRef.current.push({
+        async (options) => {
+            try {
+                await mutateAsync({
                     naviger: options?.naviger ?? true,
                     medRetry: options?.medRetry ?? false,
                     visFeilTilBruker: options?.visFeilTilBruker ?? false,
-                    onFerdig: options?.onFerdig,
-                    ferdig: resolve,
                 });
-                setSeq((s) => s + 1);
-            }),
-        [],
+                return 'ok';
+            } catch {
+                // Feilen er allereie logga i onError, og blir vist til brukaren via
+                // lagringFeilet dersom kallaren bad om det.
+                return 'feilet';
+            }
+        },
+        [mutateAsync],
     );
 
-    const nullstillLagringFeilet = useCallback(() => setLagringFeilet(false), []);
+    // Vanleg stegnavigasjon skal ikkje uroe brukaren – neste lagring rettar opp i det.
+    // Ei ny, vellukka lagring nullstiller mutasjonen og skjuler feilmeldinga automatisk.
+    const lagringFeilet = mutation.isError && (mutation.variables?.visFeilTilBruker ?? false);
 
-    return { mellomlagreSøknad, lagringFeilet, nullstillLagringFeilet };
+    return { mellomlagreSøknad, lagringFeilet, nullstillLagringFeilet: mutation.reset };
 };

--- a/apps/foreldrepengesoknad/src/pages/forside/Forside.stories.tsx
+++ b/apps/foreldrepengesoknad/src/pages/forside/Forside.stories.tsx
@@ -16,7 +16,7 @@ import { Forside } from './Forside';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultPerson = {

--- a/apps/foreldrepengesoknad/src/pages/forside/Forside.tsx
+++ b/apps/foreldrepengesoknad/src/pages/forside/Forside.tsx
@@ -1,4 +1,5 @@
 import { ContextDataType, useContextGetAnyData } from 'appData/FpDataContext';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -12,9 +13,9 @@ import { SkjemaRotLayout } from '@navikt/fp-ui';
 
 import { BarnVelger } from './BarnVelger';
 import { DinePlikter } from './dine-plikter/DinePlikter';
-import { getSelectableBarnOptions, sorterSelectableBarnEtterYngst } from './utils/forsideUtils';
 import { DinePersonopplysningerModal } from './modaler/DinePersonopplysningerModal';
 import { ForsideFormValues } from './types/ForsideFormValues';
+import { getSelectableBarnOptions, sorterSelectableBarnEtterYngst } from './utils/forsideUtils';
 import { useFjernPlanleggerDataFraUrl } from './utils/useFjernPlanleggerDataFraUrl';
 import { Søknadsmetadata, useStartSøknad } from './utils/useStartSøknad';
 
@@ -23,7 +24,7 @@ interface Props {
     harGodkjentVilkår: boolean;
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     oppdaterSøknadsmetadata: (metadata: Søknadsmetadata) => void;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
 }
 
 export const Forside = ({

--- a/apps/foreldrepengesoknad/src/pages/forside/utils/useStartSøknad.ts
+++ b/apps/foreldrepengesoknad/src/pages/forside/utils/useStartSøknad.ts
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextSaveAnyData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useSetSøknadsdata } from 'appData/useSetSøknadsdata';
 import { useIntl } from 'react-intl';
 import {
@@ -14,8 +15,8 @@ import { captureMessage } from '@navikt/fp-observability';
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt } from '@navikt/fp-types';
 
 import { ValgtBarn } from '../../../types/ValgtBarn';
-import { bestemSøknadsstart } from './forsideUtils';
 import { ForsideFormValues } from '../types/ForsideFormValues';
+import { bestemSøknadsstart } from './forsideUtils';
 
 export type Søknadsmetadata = {
     harGodkjentVilkår: boolean;
@@ -29,7 +30,7 @@ interface Args {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     harPlanleggerData: boolean;
     oppdaterSøknadsmetadata: (metadata: Søknadsmetadata) => void;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
 }
 
 /**
@@ -94,9 +95,7 @@ export const useStartSøknad = ({
     const startSøknad = (values: ForsideFormValues) => {
         // Skal i utgangspunktet ikke få submitte hvis denne ikke er true
         if (!values.harForståttRettigheterOgPlikter) {
-            captureMessage(
-                'harForståttRettigheterOgPlikter er falsy til tross for at formet skal ha validert den',
-            );
+            captureMessage('harForståttRettigheterOgPlikter er falsy til tross for at formet skal ha validert den');
             return;
         }
 

--- a/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.stories.tsx
@@ -9,7 +9,7 @@ import { AndreInntektskilderSteg } from './AndreInntektskilderSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.tsx
@@ -1,5 +1,6 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
@@ -15,7 +16,7 @@ import { AndreInntektskilderFieldArray } from './components/AndreInntektskilderF
 import { AndreInntekterFormValues } from './types/AndreInntekterFormValues';
 
 type Props = {
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
 };

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
@@ -17,7 +17,7 @@ import { AnnenForelderSteg } from './AnnenForelderSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultSøker = {

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useResetUttaksplanData } from 'appData/useResetUttaksplanData';
 import { useStepConfig } from 'appData/useStepConfig';
 import { isEqual } from 'es-toolkit';
@@ -36,7 +37,7 @@ const getRegistrertAnnenForelder = (
 
 type Props = {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
@@ -60,7 +60,7 @@ const DEFAULT_ARBEIDSFORHOLD = [
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 import { getAktiveArbeidsforhold } from 'utils/arbeidsforholdUtils';
@@ -17,7 +18,7 @@ import { getFamiliehendelsedato } from '@navikt/fp-utils';
 import { notEmpty } from '@navikt/fp-validation';
 
 type Props = {
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
 };

--- a/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
@@ -9,7 +9,7 @@ import { EgenNæringSteg } from './EgenNæringSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 
@@ -10,7 +11,7 @@ import { SkjemaRotLayout } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
 type Props = {
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
 };

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'api/queries';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import dayjs from 'dayjs';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
@@ -117,11 +118,11 @@ const søkerInfoMann = {
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {
-    mellomlagreSøknadOgNaviger?: () => Promise<void>;
+    mellomlagreSøknadOgNaviger?: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     gåTilNesteSide?: (action: Action) => void;
     søkersituasjon: SøkersituasjonFp;

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.tsx
@@ -6,6 +6,7 @@ import {
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useResetUttaksplanData } from 'appData/useResetUttaksplanData';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useEffect, useMemo } from 'react';
@@ -31,7 +32,7 @@ import { MorsSisteDag } from './mors-siste-dag/MorsSisteDag';
 type Props = {
     person: FpPersonopplysningerDto_fpoversikt;
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 
@@ -86,7 +87,17 @@ export const FordelingSteg = ({ person, arbeidsforhold, mellomlagreSøknadOgNavi
                       uttaksplanAnnenPart,
                   )
                 : [],
-        [valgtStønadskvote, minsterett, søkersituasjon, barn, navnMor, navnFarMedmor, annenForelder, intl, uttaksplanAnnenPart],
+        [
+            valgtStønadskvote,
+            minsterett,
+            søkersituasjon,
+            barn,
+            navnMor,
+            navnFarMedmor,
+            annenForelder,
+            intl,
+            uttaksplanAnnenPart,
+        ],
     );
     const ukerMedFellesperiode = valgtStønadskvote ? getAntallUkerFellesperiode(valgtStønadskvote) : 0;
     const dagerMedFellesperiode = ukerMedFellesperiode * 5;

--- a/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
@@ -9,7 +9,7 @@ import { FrilansSteg } from './FrilansSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 
@@ -10,7 +11,7 @@ import { SkjemaRotLayout } from '@navikt/fp-ui';
 import { notEmpty } from '@navikt/fp-validation';
 
 type Props = {
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
 };

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
@@ -26,7 +26,7 @@ import { ManglendeVedlegg } from './ManglendeVedlegg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultSøkerinfo = {

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.tsx
@@ -1,5 +1,6 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -63,7 +64,7 @@ import {
 type Props = {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     erEndringssøknad: boolean;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     foreldrepengerSaker?: FpSak_fpoversikt[];
 };

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.stories.tsx
@@ -17,7 +17,7 @@ import { OmBarnetSteg } from './OmBarnetSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultSøkerinfo = {

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useResetUttaksplanData } from 'appData/useResetUttaksplanData';
 import { useStepConfig } from 'appData/useStepConfig';
 import dayjs from 'dayjs';
@@ -85,7 +86,7 @@ const skalViseTermindato = (
 type Props = {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     søknadGjelderNyttBarn: boolean;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -32,7 +32,7 @@ import { OppsummeringSteg } from './OppsummeringSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultSøkerinfoMor = {

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { AnnenForelder, isAnnenForelderOppgitt } from 'types/AnnenForelder';
@@ -33,7 +34,7 @@ interface Props {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     erEndringssøknad: boolean;
     sendSøknad: () => Promise<void>;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     foreldrepengerSaker?: FpSak_fpoversikt[];
 }

--- a/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.stories.tsx
@@ -19,7 +19,7 @@ const STØNADSKONTO_URL = API_URLS.konto;
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const STØNADSKONTO_100 = {

--- a/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useIntl } from 'react-intl';
 import { isAnnenForelderOppgitt } from 'types/AnnenForelder';
@@ -21,7 +22,7 @@ import { InfoOmUtvidet80ProsentPeriode } from './InfoOmUtvidet80ProsentPeriode';
 
 type Props = {
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.stories.tsx
@@ -11,7 +11,7 @@ import { SøkersituasjonSteg } from './SøkersituasjonSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.tsx
@@ -1,5 +1,6 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useResetUttaksplanData } from 'appData/useResetUttaksplanData';
 import { useStepConfig } from 'appData/useStepConfig';
 import { useForm } from 'react-hook-form';
@@ -15,7 +16,7 @@ import { isRequired } from '@navikt/fp-validation';
 type Props = {
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
     kjønn: 'M' | 'K' | 'U';
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 
@@ -32,8 +33,7 @@ export const SøkersituasjonSteg = ({ arbeidsforhold, kjønn, mellomlagreSøknad
     const resetUttaksplanData = useResetUttaksplanData();
 
     const situasjonFraBarn = barn && isAdoptertBarn(barn) ? 'adopsjon' : 'fødsel';
-    const defaultSituasjon =
-        !søkersituasjon?.situasjon && kommerFraPlanlegger && barn ? situasjonFraBarn : undefined;
+    const defaultSituasjon = !søkersituasjon?.situasjon && kommerFraPlanlegger && barn ? situasjonFraBarn : undefined;
 
     const formMethods = useForm<SøkersituasjonFp>({
         defaultValues: søkersituasjon ?? (defaultSituasjon ? { situasjon: defaultSituasjon } : undefined),

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
@@ -13,7 +13,7 @@ import { SenereUtenlandsoppholdSteg } from './SenereUtenlandsoppholdSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultUtenlandsopphold = {

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.tsx
@@ -1,5 +1,6 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 
@@ -9,7 +10,7 @@ import { SkjemaRotLayout } from '@navikt/fp-ui';
 
 type Props = {
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
@@ -13,7 +13,7 @@ import { TidligereUtenlandsoppholdSteg } from './TidligereUtenlandsoppholdSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 const defaultUtenlandsopphold = {

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 
@@ -11,7 +12,7 @@ import { notEmpty } from '@navikt/fp-validation';
 
 type Props = {
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
@@ -9,7 +9,7 @@ import { UtenlandsoppholdSteg } from './UtenlandsoppholdSteg';
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.tsx
@@ -1,6 +1,7 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { FormattedMessage } from 'react-intl';
 
@@ -19,7 +20,7 @@ const utledNesteSide = (values: Utenlandsopphold) => {
 
 type Props = {
     arbeidsforhold: EksternArbeidsforholdDto_fpoversikt[];
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
 };
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanForm.tsx
@@ -1,5 +1,6 @@
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import dayjs from 'dayjs';
 import { ReactNode, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -34,7 +35,7 @@ type FormValues = {
 interface UttaksplanFormProps {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
     defaultUttaksperioder: Array<UttakPeriode_fpoversikt | UttakPeriodeAnnenpartEøs_fpoversikt>;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     setFeilmelding: (melding: ReactNode) => void;
     scrollToKvoteOppsummering: () => void;
@@ -69,7 +70,8 @@ export const UttaksplanForm = ({
             (p) =>
                 Uttaksperioden.erIkkeEøsPeriode(p) &&
                 (p.resultat === undefined ||
-                    (opprinneligPlan !== undefined && !opprinneligPlan.some((o) => erSammePeriodeInkludertDatoer(p, o)))),
+                    (opprinneligPlan !== undefined &&
+                        !opprinneligPlan.some((o) => erSammePeriodeInkludertDatoer(p, o)))),
         ) ?? [];
     const gjeldendeUttaksplan = erEndringssøknad ? uttaksplanMedKunNyePerioder : uttaksplan;
 

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'api/queries';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -65,11 +66,11 @@ const søkerInfoMann = {
 
 const promiseAction = () => () => {
     action('button-click')();
-    return Promise.resolve();
+    return Promise.resolve('ok' as const);
 };
 
 type StoryArgs = {
-    mellomlagreSøknadOgNaviger?: () => Promise<void>;
+    mellomlagreSøknadOgNaviger?: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     gåTilNesteSide?: (action: Action) => void;
     søkersituasjon: SøkersituasjonFp;

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAnnenPartVedtakOptions, useStønadsKontoerOptions } from 'api/queries';
 import { ContextDataType, useContextGetData, useContextSaveData } from 'appData/FpDataContext';
 import { useFpNavigator } from 'appData/useFpNavigator';
+import { MellomlagreSøknadFn } from 'appData/useMellomlagreSøknad';
 import { useStepConfig } from 'appData/useStepConfig';
 import { ReactNode, useCallback, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -37,7 +38,7 @@ import { useUttaksplanForslag } from './hooks/useUttaksplanForslag';
 
 interface Props {
     søkerInfo: FpPersonopplysningerDto_fpoversikt;
-    mellomlagreSøknadOgNaviger: () => Promise<void>;
+    mellomlagreSøknadOgNaviger: MellomlagreSøknadFn;
     avbrytSøknad: () => void;
     foreldrepengerSaker?: FpSak_fpoversikt[];
     erEndringssøknad: boolean;
@@ -79,7 +80,12 @@ export const UttaksplanSteg = ({
     );
 
     const stepConfig = useStepConfig(søkerInfo.arbeidsforhold, erEndringssøknad, eksisterendeSak);
-    const navigator = useFpNavigator(søkerInfo.arbeidsforhold, mellomlagreSøknadOgNaviger, erEndringssøknad, eksisterendeSak);
+    const navigator = useFpNavigator(
+        søkerInfo.arbeidsforhold,
+        mellomlagreSøknadOgNaviger,
+        erEndringssøknad,
+        eksisterendeSak,
+    );
 
     const oppgittAnnenForelder = isAnnenForelderOppgitt(annenForelder) ? annenForelder : undefined;
     const erAleneOmOmsorg = oppgittAnnenForelder ? oppgittAnnenForelder.erAleneOmOmsorg : true;


### PR DESCRIPTION
Tja, jeg vet ikke hvor mye bedre dette egentlig ble. Slipper litt useeffects og refs. Men som Claude sier 

 Traffic tradeoff: the old queue coalesced N overlapping calls into one POST;  scope  instead runs N sequential POSTs. Correct ordering, slightly more requests.

🤷 