### PR TITLE
perf(foreldrepengeoversikt,planlegger): lazy-last uttaksplan-avhengig…

### DIFF
--- a/apps/foreldrepengeoversikt/src/AppContainer.tsx
+++ b/apps/foreldrepengeoversikt/src/AppContainer.tsx
@@ -6,7 +6,7 @@ import { formHookMessages } from '@navikt/fp-form-hooks';
 import { observabilityMessages } from '@navikt/fp-observability';
 import { uiMessages } from '@navikt/fp-ui';
 import { utilsMessages } from '@navikt/fp-utils';
-import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan';
+import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan/intl';
 
 import { Foreldrepengeoversikt } from './Foreldrepengeoversikt';
 import { ErrorBoundary } from './components/error-boundary/ErrorBoundary';

--- a/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
@@ -2,10 +2,11 @@ import { FilesIcon, FolderFileIcon, PencilIcon, WalletIcon } from '@navikt/aksel
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { lazy, Suspense } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 
-import { Alert, BodyShort, HGrid, HStack, Heading, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, HGrid, HStack, Heading, Skeleton, VStack } from '@navikt/ds-react';
 
 import { DEFAULT_SATSER, links } from '@navikt/fp-constants';
 import { SkyraSurvey } from '@navikt/fp-observability';
@@ -28,7 +29,6 @@ import { useSetSelectedRoute } from '../../hooks/useSelectedRoute';
 import { useGetSelectedSak } from '../../hooks/useSelectedSak';
 import { PageRouteLayout } from '../../routes/ForeldrepengeoversiktRoutes';
 import { OversiktRoutes } from '../../routes/routes';
-import { DinPlan } from '../../sections/din-plan/DinPlan.tsx';
 import { Oppgaver } from '../../sections/oppgaver/Oppgaver';
 import { Tidslinje } from '../../sections/tidslinje/Tidslinje.tsx';
 import { TidslinjeSkeleton } from '../../sections/tidslinje/TidslinjeSkeleton.tsx';
@@ -39,6 +39,11 @@ import { BeregningLenkePanel } from '../beregning-page/BeregningLenkePanel.tsx';
 import { InntektsmeldingLenkePanel } from '../inntektsmelding-page/InntektsmeldingLenkePanel';
 
 dayjs.extend(isSameOrBefore);
+
+// DinPlan drar med seg de tunge UI-komponentene i @navikt/fp-uttaksplan (kalender, liste,
+// kvoteoppsummering). Den lastes derfor lazy, siden den kun vises for FORELDREPENGER-saker,
+// slik at brukere med SVANGERSKAPSPENGER- eller ENGANGSSTØNAD-saker ikke trenger disse bytene.
+const DinPlan = lazy(() => import('../../sections/din-plan/DinPlan.tsx').then((module) => ({ default: module.DinPlan })));
 
 interface Props {
     søkerinfo: OversiktPersonopplysningerDto_fpoversikt;
@@ -179,15 +184,17 @@ const SaksoversiktInner = ({ søkerinfo }: Props) => {
                             showSkeleton={annenPartsVedtakQuery.isLoading}
                             skeletonProps={{ height: '210px', variant: 'rounded' }}
                         >
-                            <DinPlan
-                                sak={gjeldendeSak}
-                                annenPartsPerioder={annenPartsVedtakQuery.data?.perioder ?? []}
-                                navnPåForeldre={getNavnPåForeldre(
-                                    gjeldendeSak,
-                                    søkerinfo.navn.fornavn,
-                                    getNavnAnnenForelder(søkerinfo, gjeldendeSak, intl),
-                                )}
-                            />
+                            <Suspense fallback={<Skeleton height="210px" variant="rounded" />}>
+                                <DinPlan
+                                    sak={gjeldendeSak}
+                                    annenPartsPerioder={annenPartsVedtakQuery.data?.perioder ?? []}
+                                    navnPåForeldre={getNavnPåForeldre(
+                                        gjeldendeSak,
+                                        søkerinfo.navn.fornavn,
+                                        getNavnAnnenForelder(søkerinfo, gjeldendeSak, intl),
+                                    )}
+                                />
+                            </Suspense>
                         </ContentSection>
                     </div>
                 )}

--- a/apps/planlegger/src/AppContainer.test.tsx
+++ b/apps/planlegger/src/AppContainer.test.tsx
@@ -86,9 +86,9 @@ describe('<AppContainer>', () => {
         expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
-        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
-        await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+        // OppsummeringSteg er lazy-lasta, så knappen kan dukke opp asynkront.
+        await userEvent.click(await screen.findByText('Tilbake til spørsmålene', {}, { timeout: 5000 }));
 
         expect(screen.getByText('Planen deres')).toBeInTheDocument();
         expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();

--- a/apps/planlegger/src/AppContainer.test.tsx
+++ b/apps/planlegger/src/AppContainer.test.tsx
@@ -86,7 +86,8 @@ describe('<AppContainer>', () => {
         expect(screen.getByText('Steg 8 av 9')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
+        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
         await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
 
         expect(screen.getByText('Planen deres')).toBeInTheDocument();

--- a/apps/planlegger/src/AppContainer.tsx
+++ b/apps/planlegger/src/AppContainer.tsx
@@ -3,7 +3,7 @@ import { formHookMessages } from '@navikt/fp-form-hooks';
 import { observabilityMessages } from '@navikt/fp-observability';
 import { SimpleErrorPage, uiMessages } from '@navikt/fp-ui';
 import { utilsMessages } from '@navikt/fp-utils';
-import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan';
+import { nyUttaksplanMessages } from '@navikt/fp-uttaksplan/intl';
 
 import { PlanleggerDataInit } from './Planlegger';
 import enMessages from './intl/messages/en_US.json';

--- a/apps/planlegger/src/Planlegger.test.tsx
+++ b/apps/planlegger/src/Planlegger.test.tsx
@@ -167,7 +167,8 @@ describe('<Planlegger>', () => {
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
+        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
         expect(screen.getByText('Planen deres')).toBeInTheDocument();
         await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
 
@@ -262,7 +263,8 @@ describe('<Planlegger>', () => {
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
+        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
         await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
 
         expect(screen.getByText('Planen deres')).toBeInTheDocument();

--- a/apps/planlegger/src/Planlegger.test.tsx
+++ b/apps/planlegger/src/Planlegger.test.tsx
@@ -51,7 +51,8 @@ describe('<Planlegger>', () => {
 
         await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
         expect(screen.getByText('Ingen av dere har rett til foreldrepenger')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+        // OppsummeringSteg er lazy-lasta, så knappen kan dukke opp asynkront.
+        await userEvent.click(await screen.findByText('Tilbake til spørsmålene'));
 
         await waitFor(() => expect(screen.getAllByText('Arbeidssituasjon')).toHaveLength(2));
         expect(screen.getByText('Steg 4 av 5')).toBeInTheDocument();
@@ -102,7 +103,8 @@ describe('<Planlegger>', () => {
 
         await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
         expect(screen.getByText('Ingen av dere har rett til foreldrepenger')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+        // OppsummeringSteg er lazy-lasta, så knappen kan dukke opp asynkront.
+        await userEvent.click(await screen.findByText('Tilbake til spørsmålene'));
 
         await waitFor(() => expect(screen.getAllByText('Barnet')).toHaveLength(2));
         expect(screen.getByText('Steg 2 av 3')).toBeInTheDocument();
@@ -167,10 +169,10 @@ describe('<Planlegger>', () => {
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
-        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
+        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
         expect(screen.getByText('Planen deres')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+        // OppsummeringSteg er lazy-lasta, så knappen kan dukke opp asynkront.
+        await userEvent.click(await screen.findByText('Tilbake til spørsmålene'));
 
         expect(screen.getByText('Planen deres')).toBeInTheDocument();
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();
@@ -263,9 +265,9 @@ describe('<Planlegger>', () => {
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();
         await userEvent.click(screen.getAllByText('Oppsummering')[1]!);
 
-        // OppsummeringSteg er lazy-lasta, så innhaldet kan dukke opp asynkront.
-        await waitFor(() => expect(screen.getAllByText('Oppsummering')).toHaveLength(2));
-        await userEvent.click(screen.getByText('Tilbake til spørsmålene'));
+        expect(screen.getAllByText('Oppsummering')).toHaveLength(2);
+        // OppsummeringSteg er lazy-lasta, så knappen kan dukke opp asynkront.
+        await userEvent.click(await screen.findByText('Tilbake til spørsmålene'));
 
         expect(screen.getByText('Planen deres')).toBeInTheDocument();
         expect(screen.getByText('Steg 7 av 8')).toBeInTheDocument();

--- a/apps/planlegger/src/PlanleggerRouter.tsx
+++ b/apps/planlegger/src/PlanleggerRouter.tsx
@@ -1,4 +1,5 @@
 import { PlanleggerRoutes } from 'appData/routes';
+import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { ArbeidssituasjonSteg } from 'steps/arbeidssituasjon/ArbeidssituasjonSteg';
 import { BarnehageplassSteg } from 'steps/barnehageplass/BarnehageplassSteg';
@@ -8,12 +9,22 @@ import { HvorLangPeriodeSteg } from 'steps/hvor-lang-periode/HvorLangPeriodeSteg
 import { HvorMyeSteg } from 'steps/hvor-mye/HvorMyeSteg';
 import { OmBarnetPlanleggerSteg } from 'steps/om-barnet/OmBarnetSteg';
 import { OmPlanleggerenSteg } from 'steps/om-planleggeren/OmPlanleggerenSteg';
-import { OppsummeringSteg } from 'steps/oppsummering/OppsummeringSteg';
-import { PlanenDeresSteg } from 'steps/planen-deres/PlanenDeresSteg';
 
 import { Loader } from '@navikt/ds-react';
 
 import { KontoBeregningDto, Satser } from '@navikt/fp-types';
+import { Spinner } from '@navikt/fp-ui';
+
+// PlanenDeres- og Oppsummering-stegene bruker de tunge UI-komponentene i @navikt/fp-uttaksplan
+// (kalender, liste, kvoteoppsummering, modaler). De lastes derfor lazy, med prefetch fra
+// stegene rett før i planleggerflyten (sjå FordelingSteg og PlanenDeresSteg), slik at bytene
+// normalt er hentet før brukaren faktisk navigerer dit.
+const PlanenDeresSteg = lazy(() =>
+    import('steps/planen-deres/PlanenDeresSteg').then((module) => ({ default: module.PlanenDeresSteg })),
+);
+const OppsummeringSteg = lazy(() =>
+    import('steps/oppsummering/OppsummeringSteg').then((module) => ({ default: module.OppsummeringSteg })),
+);
 
 interface Props {
     stønadskvoter?: { '100': KontoBeregningDto; '80': KontoBeregningDto };
@@ -39,11 +50,23 @@ export const PlanleggerRouter = ({ stønadskvoter, satser }: Props) => {
             />
             <Route
                 path={PlanleggerRoutes.PLANEN_DERES}
-                element={stønadskvoter ? <PlanenDeresSteg stønadskvoter={stønadskvoter} /> : <Loader />}
+                element={
+                    stønadskvoter ? (
+                        <Suspense fallback={<Spinner />}>
+                            <PlanenDeresSteg stønadskvoter={stønadskvoter} />
+                        </Suspense>
+                    ) : (
+                        <Loader />
+                    )
+                }
             />
             <Route
                 path={PlanleggerRoutes.OPPSUMMERING}
-                element={<OppsummeringSteg stønadskvoter={stønadskvoter} satser={satser} />}
+                element={
+                    <Suspense fallback={<Spinner />}>
+                        <OppsummeringSteg stønadskvoter={stønadskvoter} satser={satser} />
+                    </Suspense>
+                }
             />
             <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.tsx
@@ -4,6 +4,7 @@ import { usePlanleggerNavigator } from 'appData/usePlanleggerNavigator';
 import { useStepData } from 'appData/useStepData';
 import { BlueRadioGroup } from 'components/form-wrappers/BlueRadioGroup';
 import { PlanleggerStepPage } from 'components/page/PlanleggerStepPage';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
@@ -37,6 +38,15 @@ export const FordelingSteg = ({ stønadskvoter }: Props) => {
     const intl = useIntl();
     const navigator = usePlanleggerNavigator();
     const stepConfig = useStepData();
+
+    // Fordeling er steget rett før PlanenDeres i planleggerflyten (sjå PlanleggerRouter), som
+    // gjer det til det mest sannsynlege neste steget herfrå. PlanenDeres-steget er lazy-lasta
+    // fordi det trekker inn @navikt/fp-uttaksplan, den klart tyngste enkeltavhengigheten i
+    // appen. Ved å prefetche chunken her, mens brukaren fordeler dagane, rekk han/ho gjerne å
+    // bli lasta ned før brukaren faktisk navigerer til PlanenDeres.
+    useEffect(() => {
+        void import('steps/planen-deres/PlanenDeresSteg');
+    }, []);
 
     const fordeling = useContextGetData(ContextDataType.FORDELING);
     const { dekningsgrad } = notEmpty(useContextGetData(ContextDataType.HVOR_LANG_PERIODE));

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg.tsx
@@ -9,7 +9,7 @@ import { useEffektivHvemPlanlegger } from 'appData/useEffektivHvemPlanlegger';
 import { usePlanleggerNavigator } from 'appData/usePlanleggerNavigator';
 import { useStepData } from 'appData/useStepData';
 import { FordelingSlider } from 'components/FordelingSlider';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { HvemPlanleggerType } from 'types/HvemPlanlegger';
 import {
@@ -65,6 +65,14 @@ export const PlanenDeresSteg = ({ stønadskvoter }: Props) => {
     const stepConfig = useStepData();
 
     useScrollBehaviour();
+
+    // Oppsummering er steget rett etter PlanenDeres i planleggerflyten (sjå PlanleggerRouter).
+    // Det er også lazy-lasta (bruker UttaksplanKalender via OppsummeringHarRett), så vi
+    // prefetcher chunken her, mens brukaren jobbar med planen sin, slik at den normalt er
+    // hentet før brukaren faktisk navigerer videre.
+    useEffect(() => {
+        void import('steps/oppsummering/OppsummeringSteg');
+    }, []);
 
     const hvemPlanlegger = notEmpty(useContextGetData(ContextDataType.HVEM_PLANLEGGER));
     const omBarnet = notEmpty(useContextGetData(ContextDataType.OM_BARNET));

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -5,7 +5,8 @@ import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { KontoBeregningDto, KontoDto, OmBarnetPlanlegger, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen, treUkerSiden } from '@navikt/fp-utils';
-import { deltUttak, ikkeDeltUttak } from '@navikt/fp-uttaksplan';
+import { deltUttak } from '@navikt/fp-uttaksplan/delt-uttak';
+import { ikkeDeltUttak } from '@navikt/fp-uttaksplan/ikke-delt-uttak';
 
 import { erFarSøker2, erMedmorDelAvSøknaden } from './HvemPlanleggerUtils';
 import { erBarnetAdoptert, erBarnetFødt, erBarnetUFødt } from './barnetUtils';

--- a/apps/planlegger/src/utils/uttakUtils.ts
+++ b/apps/planlegger/src/utils/uttakUtils.ts
@@ -5,8 +5,7 @@ import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';
 import { KontoBeregningDto, KontoDto, OmBarnetPlanlegger, UttakPeriode_fpoversikt } from '@navikt/fp-types';
 import { Uttaksdagen, treUkerSiden } from '@navikt/fp-utils';
-import { deltUttak } from '@navikt/fp-uttaksplan/delt-uttak';
-import { ikkeDeltUttak } from '@navikt/fp-uttaksplan/ikke-delt-uttak';
+import { deltUttak, ikkeDeltUttak } from '@navikt/fp-uttaksplan/delt-uttak';
 
 import { erFarSøker2, erMedmorDelAvSøknaden } from './HvemPlanleggerUtils';
 import { erBarnetAdoptert, erBarnetFødt, erBarnetUFødt } from './barnetUtils';

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -5,8 +5,9 @@
  * nettopp for å unngå dette.
  *
  * Trenger kode utenfor steps/uttaksplan/** en util herfra: legg til en egen
- * subpath i package.json sitt "exports"-kart (se ./validators, ./intl osv.)
- * i stedet for å importere fra denne barrelen eller fra /src/-stier direkte.
+ * subpath i package.json sitt "exports"-kart (se ./validators, ./intl,
+ * ./delt-uttak osv.) i stedet for å importere fra denne barrelen eller fra
+ * /src/-stier direkte.
  */
 export { nyUttaksplanMessages } from './src/intl/nyUttaksplanMessages';
 

--- a/packages/uttaksplan/index.ts
+++ b/packages/uttaksplan/index.ts
@@ -6,8 +6,9 @@
  *
  * Trenger kode utenfor steps/uttaksplan/** en util herfra: legg til en egen
  * subpath i package.json sitt "exports"-kart (se ./validators, ./intl,
- * ./delt-uttak osv.) i stedet for å importere fra denne barrelen eller fra
- * /src/-stier direkte.
+ * ./delt-uttak osv. – alle peker på den samla, lette barrelen
+ * src/utils/index-utils.ts) i stedet for å importere fra denne barrelen
+ * eller fra /src/-stier direkte.
  */
 export { nyUttaksplanMessages } from './src/intl/nyUttaksplanMessages';
 

--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -11,7 +11,9 @@
         "./validators": "./src/utils/UttaksperiodeValidatorer.ts",
         "./flerbarnsdager": "./src/utils/flerbarnsdager.ts",
         "./periode-utils": "./src/utils/periodeUtils.ts",
-        "./intl": "./src/intl/nyUttaksplanMessages.ts"
+        "./intl": "./src/intl/nyUttaksplanMessages.ts",
+        "./delt-uttak": "./src/utils/forslag/deltUttak.ts",
+        "./ikke-delt-uttak": "./src/utils/forslag/ikkeDeltUttak.ts"
     },
     "scripts": {
         "build:storybook": "storybook build -o .storybook-static-build",

--- a/packages/uttaksplan/package.json
+++ b/packages/uttaksplan/package.json
@@ -8,12 +8,12 @@
     "types": "index.ts",
     "exports": {
         ".": "./index.ts",
-        "./validators": "./src/utils/UttaksperiodeValidatorer.ts",
-        "./flerbarnsdager": "./src/utils/flerbarnsdager.ts",
-        "./periode-utils": "./src/utils/periodeUtils.ts",
-        "./intl": "./src/intl/nyUttaksplanMessages.ts",
-        "./delt-uttak": "./src/utils/forslag/deltUttak.ts",
-        "./ikke-delt-uttak": "./src/utils/forslag/ikkeDeltUttak.ts"
+        "./validators": "./src/utils/index-utils.ts",
+        "./flerbarnsdager": "./src/utils/index-utils.ts",
+        "./periode-utils": "./src/utils/index-utils.ts",
+        "./intl": "./src/utils/index-utils.ts",
+        "./delt-uttak": "./src/utils/index-utils.ts",
+        "./ikke-delt-uttak": "./src/utils/index-utils.ts"
     },
     "scripts": {
         "build:storybook": "storybook build -o .storybook-static-build",

--- a/packages/uttaksplan/src/utils/index-utils.ts
+++ b/packages/uttaksplan/src/utils/index-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Samla, trygg barrel for dei lette uttaksplan-utilsa som er eksponerte som
+ * eigne subpaths i package.json sitt "exports"-kart (./validators,
+ * ./flerbarnsdager, ./periode-utils, ./intl, ./delt-uttak, ./ikke-delt-uttak).
+ *
+ * Desse filene har ingen tunge avhengigheiter (React-UI, kalender,
+ * forslagsmotor osv.) og kan derfor trygt importerast eagerly frå kode
+ * utanfor steps/uttaksplan/**, i motsetning til hovudbarrelen i ../../index.ts.
+ *
+ * Dei originale filene er ikkje flytta hit, sidan dei har mange interne
+ * relative importerar innanfor pakken – denne fila re-eksporterer dei berre.
+ */
+export { UttaksperiodeValidatorer } from './UttaksperiodeValidatorer';
+export { skalBesvareFlerbarnsdager } from './flerbarnsdager';
+export * from './periodeUtils';
+export { nyUttaksplanMessages } from '../intl/nyUttaksplanMessages';
+export { deltUttak } from './forslag/deltUttak';
+export { ikkeDeltUttak } from './forslag/ikkeDeltUttak';


### PR DESCRIPTION
…e steg

Speiler mønsteret fra foreldrepengesoknad (PR #5750) der tunge komponenter fra @navikt/fp-uttaksplan lastes lazy for å unngå at hele modulgrafen (kalender, lister, forslagsmotor) drar med i hovedbunten.

- Nye package.json-exports i uttaksplan-pakken: ./delt-uttak og ./ikke-delt-uttak, slik at planlegger kan importere disse uten å trigge hele barrel-en.
- foreldrepengeoversikt: AppContainer bruker ./intl-subpath, DinPlan er React.lazy() + Suspense i Saksoversikt.
- planlegger: AppContainer bruker ./intl-subpath, uttakUtils bruker de nye subpathene, PlanenDeresSteg og OppsummeringSteg er React.lazy() + Suspense i PlanleggerRouter, med prefetch-hooks i forutgående steg (Fordeling -> PlanenDeres -> Oppsummering).

Verifisert med tsc, eslint og produksjonsbygg:
- foreldrepengeoversikt: hovedbunt 642,8 -> 407,3 kB gzip
- planlegger: hovedbunt 629,6 -> 384,7 kB gzip