### PR TITLE
fix(uttaksplan): sperr ferie/opphold for mor de første seks ukene ett…

### DIFF
--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -14,6 +14,7 @@
     "uttaksplan.valgPanel.utsettelse": "Postponement can only be added when days have been selected in the 6-week period after birth",
     "uttaksplan.valgPanel.pause": "Pause can only be added when days have been selected after the 6-week period following birth",
     "uttaksplan.valgPanel.ferie": "Vacation and periods without parental benefits can only be added in the 6-week period after birth or before",
+    "uttaksplan.valgPanel.ferieMor": "Vacation and periods without parental benefits cannot be added in the first six weeks after birth/due date. Use postponement instead.",
     "uttaksplan.valgPanel.leggTilPeriode": "Add period with parental benefits",
     "uttaksplan.valgPanel.leggTilPeriode.endre": "Period with parental benefits",
     "uttaksplan.valgPanel.leggTilFerie": "Add holiday",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -14,6 +14,7 @@
     "uttaksplan.valgPanel.utsettelse": "Utsettelse kan kun legges til når en har valgt dager i 6-ukersperioden etter fødsel/termin",
     "uttaksplan.valgPanel.pause": "Pause kan kun legges til når en har valgt dager etter 6-ukersperioden etter fødsel/termin",
     "uttaksplan.valgPanel.ferie": "Ferie og perioder uten foreldrepenger kan kun legges til i 6-ukersperioden etter fødsel/termin eller før",
+    "uttaksplan.valgPanel.ferieMor": "Ferie og perioder uten foreldrepenger kan ikke legges til i de første seks ukene etter fødsel/termin. Bruk utsettelse i stedet.",
     "uttaksplan.valgPanel.leggTilPeriode": "Legge til periode med foreldrepenger",
     "uttaksplan.valgPanel.leggTilPeriode.endre": "Periode med foreldrepenger",
     "uttaksplan.valgPanel.leggTilFerie": "Legge til ferie",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -14,6 +14,7 @@
     "uttaksplan.valgPanel.utsettelse": "Utsettelse kan kun leggast til når ein har valgt dagar i 6-vekersperioden etter fødsel/termin",
     "uttaksplan.valgPanel.pause": "Pause kan kun leggast til når ein har valgt dagar etter 6-vekersperioden etter fødsel/termin",
     "uttaksplan.valgPanel.ferie": "Ferie og periodar utan foreldrepengar kan kun leggast til i 6-vekersperioden etter fødsel/termin eller før",
+    "uttaksplan.valgPanel.ferieMor": "Ferie og periodar utan foreldrepengar kan ikkje leggast til i dei første seks vekene etter fødsel/termin. Bruk utsettelse i staden.",
     "uttaksplan.valgPanel.leggTilPeriode": "Legg til periode med foreldrepengar",
     "uttaksplan.valgPanel.leggTilPeriode.endre": "Periode med foreldrepengar",
     "uttaksplan.valgPanel.leggTilFerie": "Legg til ferie",

--- a/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
+++ b/packages/uttaksplan/src/liste/legg-til-endre-periode-panel/LeggTilEllerEndrePeriodeListPanel.tsx
@@ -131,6 +131,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         uttakPerioder,
         foreldreInfo: { søker, rettighetType },
         familiehendelsedato,
+        familiesituasjon,
         erPeriodeneTilAnnenPartLåst,
         kanVelgeArbeidsgiver,
     } = useUttaksplanData();
@@ -293,6 +294,7 @@ export const LeggTilEllerEndrePeriodeListPanel = ({
         tomValue,
         perioder,
         familiehendelsedato,
+        familiesituasjon,
         søker,
         rettighetType,
     });

--- a/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.test.ts
+++ b/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.test.ts
@@ -16,7 +16,7 @@ type Input = {
     nyHvaVilDuGjøre: 'LEGG_TIL_FERIE' | 'LEGG_TIL_UTSETTELSE' | 'LEGG_TIL_PAUSE' | 'LEGG_TIL_OPPHOLD' | 'LEGG_TIL_PERIODE' | undefined;
     fomValue: string | undefined;
     tomValue: string | undefined;
-    perioder: { fom: string; tom: string }[];
+    perioder: Array<{ fom: string; tom: string }>;
     familiehendelsedato: string;
     familiesituasjon: Familiesituasjon;
     søker: BrukerRolleSak_fpoversikt;

--- a/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.test.ts
+++ b/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.test.ts
@@ -1,0 +1,120 @@
+import { createIntl, createIntlCache } from 'react-intl';
+import { describe, expect, it } from 'vitest';
+
+import type { BrukerRolleSak_fpoversikt, Familiesituasjon, RettighetType_fpoversikt } from '@navikt/fp-types';
+
+import messages from '../../intl/messages/nb_NO.json';
+import { lagHvaVilDuGjøreRegler } from './hvaVilDuGjøre';
+
+const cache = createIntlCache();
+const intlMock = createIntl({ locale: 'nb', defaultLocale: 'nb', messages }, cache);
+
+// Torsdag. Seks uker etter blir 2024-09-10.
+const FAMILIEHENDELSESDATO = '2024-07-30';
+
+type Input = {
+    nyHvaVilDuGjøre: 'LEGG_TIL_FERIE' | 'LEGG_TIL_UTSETTELSE' | 'LEGG_TIL_PAUSE' | 'LEGG_TIL_OPPHOLD' | 'LEGG_TIL_PERIODE' | undefined;
+    fomValue: string | undefined;
+    tomValue: string | undefined;
+    perioder: { fom: string; tom: string }[];
+    familiehendelsedato: string;
+    familiesituasjon: Familiesituasjon;
+    søker: BrukerRolleSak_fpoversikt;
+    rettighetType: RettighetType_fpoversikt;
+};
+
+const lagInput = (overrides: Partial<Input> = {}): Input => ({
+    nyHvaVilDuGjøre: undefined,
+    fomValue: undefined,
+    tomValue: undefined,
+    perioder: [],
+    familiehendelsedato: FAMILIEHENDELSESDATO,
+    familiesituasjon: 'termin',
+    søker: 'MOR',
+    rettighetType: 'BEGGE_RETT',
+    ...overrides,
+});
+
+const evaluer = (input: Input): string | undefined => {
+    const regler = lagHvaVilDuGjøreRegler(intlMock);
+    return regler.find((regel) => regel.erBrutt(input))?.feilmelding;
+};
+
+const FERIE_MOR_FEILMELDING =
+    'Ferie og perioder uten foreldrepenger kan ikke legges til i de første seks ukene etter fødsel/termin. Bruk utsettelse i stedet.';
+
+describe('hvaVilDuGjøre — ferie/opphold kan ikke legges i de første seks ukene for mor', () => {
+    it('skal melde feil når mor velger «Legg til ferie» innenfor de første seks ukene', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_FERIE',
+                fomValue: '2024-08-31',
+                tomValue: '2024-09-04',
+            }),
+        );
+
+        expect(feil).toBe(FERIE_MOR_FEILMELDING);
+    });
+
+    it('skal melde feil når mor velger «Legg til opphold» innenfor de første seks ukene', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_OPPHOLD',
+                fomValue: '2024-08-31',
+                tomValue: '2024-09-04',
+            }),
+        );
+
+        expect(feil).toBe(FERIE_MOR_FEILMELDING);
+    });
+
+    it('skal ikke melde feil når mor velger «Legg til ferie» etter de første seks ukene', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_FERIE',
+                fomValue: '2024-09-16',
+                tomValue: '2024-09-20',
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikke gjelde ved adopsjon', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_FERIE',
+                fomValue: '2024-08-31',
+                tomValue: '2024-09-04',
+                familiesituasjon: 'adopsjon',
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikke gjelde for far/medmor', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_FERIE',
+                fomValue: '2024-08-31',
+                tomValue: '2024-09-04',
+                søker: 'FAR_MEDMOR',
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+
+    it('skal ikke gjelde for «Legg til utsettelse»', () => {
+        const feil = evaluer(
+            lagInput({
+                nyHvaVilDuGjøre: 'LEGG_TIL_UTSETTELSE',
+                fomValue: '2024-08-31',
+                tomValue: '2024-09-04',
+            }),
+        );
+
+        expect(feil).toBeUndefined();
+    });
+});

--- a/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.ts
+++ b/packages/uttaksplan/src/regler/felt/hvaVilDuGjøre.ts
@@ -1,6 +1,6 @@
 import { IntlShape } from 'react-intl';
 
-import { BrukerRolleSak_fpoversikt, RettighetType_fpoversikt } from '@navikt/fp-types';
+import { BrukerRolleSak_fpoversikt, Familiesituasjon, RettighetType_fpoversikt } from '@navikt/fp-types';
 
 import { UttaksperiodeValidatorer } from '../../utils/UttaksperiodeValidatorer';
 import { Feltregel, Periode } from '../types';
@@ -26,6 +26,7 @@ type HvaVilDuGjøreInput = {
     tomValue: string | undefined;
     perioder: Periode[];
     familiehendelsedato: string;
+    familiesituasjon: Familiesituasjon;
     søker: BrukerRolleSak_fpoversikt;
     rettighetType: RettighetType_fpoversikt;
 };
@@ -59,6 +60,22 @@ export const lagHvaVilDuGjøreRegler = (intl: IntlShape): ReadonlyArray<Feltrege
                 input.familiehendelsedato,
             ),
         feilmelding: intl.formatMessage({ id: 'uttaksplan.valgPanel.pause' }),
+    },
+    {
+        id: 'hvaVilDuGjøre.ferieEllerOppholdKanIkkeLeggesIFørsteSeksUkerEtterFødselForMor',
+        beskrivelse:
+            'For mor (ikke ved adopsjon) kan «Legg til ferie» eller «Legg til opphold» ikke plasseres innenfor ' +
+            'de første seks ukene etter familiehendelsesdato — der er mødrekvoten forbeholdt mor, og «Legg til ' +
+            'utsettelse» (barn/bruker innlagt eller bruker sykdom/skade) er det eneste gyldige alternativet.',
+        erBrutt: (input) =>
+            (input.nyHvaVilDuGjøre === 'LEGG_TIL_FERIE' || input.nyHvaVilDuGjøre === 'LEGG_TIL_OPPHOLD') &&
+            input.søker === 'MOR' &&
+            input.familiesituasjon !== 'adopsjon' &&
+            UttaksperiodeValidatorer.erNoenPerioderInnenforIntervalletFamDatoOgSeksUkerEtterFamDato(
+                valgtPeriode(input),
+                input.familiehendelsedato,
+            ),
+        feilmelding: intl.formatMessage({ id: 'uttaksplan.valgPanel.ferieMor' }),
     },
     {
         id: 'hvaVilDuGjøre.ferieEllerOppholdMåLiggeFørSeksUkerEtterFødselForFarMedmorBareSøkerRett',

--- a/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.test.ts
+++ b/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BrukerRolleSak_fpoversikt, Familiesituasjon, RettighetType_fpoversikt } from '@navikt/fp-types';
+
+import { Periode } from '../types';
+import {
+    VIS_LEGG_TIL_FERIE_VALG,
+    VIS_LEGG_TIL_OPPHOLD_VALG,
+    VIS_LEGG_TIL_PAUSE_VALG,
+    VIS_LEGG_TIL_UTSETTELSE_VALG,
+} from './hvaVilDuGjøreValg';
+
+// Torsdag. Seks uker etter blir 2024-09-10.
+const FAMILIEHENDELSESDATO = '2024-07-30';
+
+type Kontekst = {
+    søker: BrukerRolleSak_fpoversikt;
+    rettighetType: RettighetType_fpoversikt;
+    familiesituasjon: Familiesituasjon;
+    familiehendelsedato: string;
+    valgtePerioder: Periode[];
+};
+
+const lagKontekst = (overrides: Partial<Kontekst> = {}): Kontekst => ({
+    søker: 'MOR',
+    rettighetType: 'BEGGE_RETT',
+    familiesituasjon: 'termin',
+    familiehendelsedato: FAMILIEHENDELSESDATO,
+    valgtePerioder: [],
+    ...overrides,
+});
+
+describe('hvaVilDuGjøreValg', () => {
+    describe('mor med periode innenfor de første seks ukene etter familiehendelsesdato', () => {
+        const kontekst = lagKontekst({
+            søker: 'MOR',
+            valgtePerioder: [{ fom: '2024-08-31', tom: '2024-09-04' }],
+        });
+
+        it('skal vise «Legg til utsettelse»', () => {
+            expect(VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(kontekst)).toBe(true);
+        });
+
+        it('skal ikke vise «Legg til ferie» — kun utsettelse (sykdom/innlagt) er gyldig her', () => {
+            expect(VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst)).toBe(false);
+        });
+
+        it('skal ikke vise «Legg til periode uten foreldrepenger»', () => {
+            expect(VIS_LEGG_TIL_OPPHOLD_VALG.skalVises(kontekst)).toBe(false);
+        });
+
+        it('skal ikke vise «Legg til pause»', () => {
+            expect(VIS_LEGG_TIL_PAUSE_VALG.skalVises(kontekst)).toBe(false);
+        });
+    });
+
+    describe('mor med periode etter de første seks ukene etter familiehendelsesdato', () => {
+        const kontekst = lagKontekst({
+            søker: 'MOR',
+            valgtePerioder: [{ fom: '2024-09-16', tom: '2024-09-20' }],
+        });
+
+        it('skal ikke vise «Legg til utsettelse»', () => {
+            expect(VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(kontekst)).toBe(false);
+        });
+
+        it('skal vise «Legg til ferie»', () => {
+            expect(VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst)).toBe(true);
+        });
+
+        it('skal vise «Legg til periode uten foreldrepenger»', () => {
+            expect(VIS_LEGG_TIL_OPPHOLD_VALG.skalVises(kontekst)).toBe(true);
+        });
+    });
+
+    describe('mor ved adopsjon, periode innenfor det som ville vært seks-ukersvinduet', () => {
+        const kontekst = lagKontekst({
+            søker: 'MOR',
+            familiesituasjon: 'adopsjon',
+            valgtePerioder: [{ fom: '2024-08-31', tom: '2024-09-04' }],
+        });
+
+        it('skal ikke vise «Legg til utsettelse», siden regelen ikke gjelder adopsjon', () => {
+            expect(VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(kontekst)).toBe(false);
+        });
+
+        it('skal vise «Legg til ferie», siden mor-restriksjonen ikke gjelder adopsjon', () => {
+            expect(VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst)).toBe(true);
+        });
+    });
+
+    describe('far/medmor med BARE_SØKER_RETT', () => {
+        it('skal vise «Legg til ferie» for periode i de første seks ukene, siden pause ikke er gyldig der', () => {
+            const kontekst = lagKontekst({
+                søker: 'FAR_MEDMOR',
+                rettighetType: 'BARE_SØKER_RETT',
+                valgtePerioder: [{ fom: '2024-08-31', tom: '2024-09-04' }],
+            });
+
+            expect(VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst)).toBe(true);
+            expect(VIS_LEGG_TIL_PAUSE_VALG.skalVises(kontekst)).toBe(false);
+        });
+
+        it('skal ikke vise «Legg til ferie» for periode etter seks uker, siden pause er gyldig der i stedet', () => {
+            const kontekst = lagKontekst({
+                søker: 'FAR_MEDMOR',
+                rettighetType: 'BARE_SØKER_RETT',
+                valgtePerioder: [{ fom: '2024-09-16', tom: '2024-09-20' }],
+            });
+
+            expect(VIS_LEGG_TIL_FERIE_VALG.skalVises(kontekst)).toBe(false);
+            expect(VIS_LEGG_TIL_PAUSE_VALG.skalVises(kontekst)).toBe(true);
+        });
+    });
+});

--- a/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
+++ b/packages/uttaksplan/src/regler/synlighet/hvaVilDuGjøreValg.ts
@@ -44,10 +44,13 @@ export const useHvaVilDuGjøreValgSynlighet = (valgtePerioder: Periode[]): HvaVi
 export const VIS_LEGG_TIL_FERIE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
     id: 'hvaVilDuGjøreValg.visLeggTilFerie',
     beskrivelse:
-        '«Legge til ferie» vises for alle søkere, med ett unntak: for far/medmor med BARE_SØKER_RETT skjules ' +
-        'alternativet når hele det valgte tidsrommet ligger på eller etter seks uker etter familiehendelsesdato ' +
-        '— ferie er da ikke aktuelt, og pause er det riktige valget i stedet.',
-    skalVises: (k) => !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
+        '«Legge til ferie» vises for alle søkere, med to unntak: (1) for mor (ikke ved adopsjon) skjules ' +
+        'alternativet når det valgte tidsrommet ligger innenfor de første seks ukene etter familiehendelsesdato ' +
+        '— der er utsettelse (barn/bruker innlagt eller bruker sykdom/skade) det eneste gyldige valget, ikke ' +
+        'ferie. (2) For far/medmor med BARE_SØKER_RETT skjules alternativet når hele det valgte tidsrommet ' +
+        'ligger på eller etter seks uker etter familiehendelsesdato — ferie er da ikke aktuelt, og pause er det ' +
+        'riktige valget i stedet.',
+    skalVises: (k) => !VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(k) && !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
 };
 
 export const VIS_LEGG_TIL_UTSETTELSE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
@@ -82,10 +85,11 @@ export const VIS_LEGG_TIL_PAUSE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst
 export const VIS_LEGG_TIL_OPPHOLD_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {
     id: 'hvaVilDuGjøreValg.visLeggTilOpphold',
     beskrivelse:
-        '«Legge til periode uten foreldrepenger» vises for alle søkere, med samme unntak som ferie: for ' +
+        '«Legge til periode uten foreldrepenger» vises for alle søkere, med samme unntak som ferie: for mor ' +
+        '(ikke ved adopsjon) skjules alternativet i de første seks ukene etter familiehendelsesdato, og for ' +
         'far/medmor med BARE_SØKER_RETT skjules alternativet når hele det valgte tidsrommet ligger på eller ' +
         'etter seks uker etter familiehendelsesdato.',
-    skalVises: (k) => !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
+    skalVises: (k) => !VIS_LEGG_TIL_UTSETTELSE_VALG.skalVises(k) && !erFerieEllerOppholdSkjultForFarMedmorBareRett(k),
 };
 
 export const VIS_LEGG_TIL_PERIODE_VALG: Synlighetsregel<HvaVilDuGjøreValgKontekst> = {


### PR DESCRIPTION
…er fødsel/termin

I listepanelets «Hva vil du gjøre»-valg ble «Legg til ferie» og «Legg til periode uten foreldrepenger» vist for mor uansett tidsrom, uavhengig av om «Legg til utsettelse» også var aktuelt. Det gjorde det mulig for mor å legge inn ren ferie (LOVBESTEMT_FERIE) i de første seks ukene etter fødsel/termin i stedet for å måtte oppgi en gyldig utsettelsesårsak (barn innlagt, bruker innlagt eller bruker sykdom/skade).

Kalendervisningens redigeringspanel hadde allerede riktig oppførsel via gjensidig utelukkelse mellom Utsettelse- og Ferie-knappen; samme prinsipp er nå brukt i listepanelet:
- hvaVilDuGjøreValg.ts: skjuler Ferie/Opphold for mor (ikke adopsjon) når valgt periode ligger innenfor seks-ukersvinduet.
- hvaVilDuGjøre.ts: ny feltregel som gir feilmelding dersom mor likevel forsøker å sende inn ferie/opphold i denne perioden.
- Nye intl-nøkler for feilmeldingen i alle tre språkfiler.
- Nye tester for synlighets- og feltreglene.