### PR TITLE
TFP-7090: Fiks manglende dato for IkkeUtfyltTypeBarn

### DIFF
--- a/apps/foreldrepengesoknad/src/api/getStønadskvoteParams.test.ts
+++ b/apps/foreldrepengesoknad/src/api/getStønadskvoteParams.test.ts
@@ -1,0 +1,104 @@
+import { AnnenForelder } from 'types/AnnenForelder';
+
+import { BarnType } from '@navikt/fp-constants';
+import { Barn, SøkersituasjonFp } from '@navikt/fp-types';
+
+import { getStønadskvoteParams } from './getStønadskvoteParams';
+
+const MOR_SØKERSITUASJON: SøkersituasjonFp = { situasjon: 'fødsel', rolle: 'mor' };
+
+const ANNEN_FORELDER_OPPGITT: AnnenForelder = {
+    kanIkkeOppgis: false,
+    fornavn: 'Per',
+    etternavn: 'Persen',
+    fnr: '12345678910',
+    erAleneOmOmsorg: false,
+    harRettPåForeldrepengerINorge: true,
+};
+
+describe('getStønadskvoteParams', () => {
+    it('skal sette fødselsdato for FødtBarn', () => {
+        const barn = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: ['2024-01-15'],
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined);
+
+        expect(params.fødselsdato).toBe('2024-01-15');
+        expect(params.termindato).toBeUndefined();
+        expect(params.omsorgsovertakelseDato).toBeUndefined();
+    });
+
+    it('skal sette fødselsdato for IkkeUtfyltTypeBarn med fødselsdatoer', () => {
+        const barn = {
+            type: BarnType.IKKE_UTFYLT,
+            antallBarn: 1,
+            fødselsdatoer: ['2024-03-10'],
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined);
+
+        expect(params.fødselsdato).toBe('2024-03-10');
+        expect(params.termindato).toBeUndefined();
+        expect(params.omsorgsovertakelseDato).toBeUndefined();
+    });
+
+    it('skal returnere undefined fødselsdato for IkkeUtfyltTypeBarn uten fødselsdatoer', () => {
+        const barn = {
+            type: BarnType.IKKE_UTFYLT,
+            antallBarn: 1,
+            fødselsdatoer: [],
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined);
+
+        expect(params.fødselsdato).toBeUndefined();
+        expect(params.termindato).toBeUndefined();
+        expect(params.omsorgsovertakelseDato).toBeUndefined();
+    });
+
+    it('skal sette termindato for UfødtBarn', () => {
+        const barn = {
+            type: BarnType.UFØDT,
+            antallBarn: 1,
+            termindato: '2024-06-01',
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined);
+
+        expect(params.fødselsdato).toBeUndefined();
+        expect(params.termindato).toBe('2024-06-01');
+        expect(params.omsorgsovertakelseDato).toBeUndefined();
+    });
+
+    it('skal bruke termindato fra saksgrunnlag fremfor barn.termindato for FødtBarn', () => {
+        const barn = {
+            type: BarnType.FØDT,
+            antallBarn: 1,
+            fødselsdatoer: ['2024-01-15'],
+            termindato: '2024-01-20',
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined, '2024-01-18');
+
+        expect(params.fødselsdato).toBe('2024-01-15');
+        expect(params.termindato).toBe('2024-01-18');
+    });
+
+    it('skal sette omsorgsovertakelseDato for AdoptertBarn', () => {
+        const barn = {
+            type: BarnType.ADOPTERT_ANNET_BARN,
+            antallBarn: 1,
+            adopsjonsdato: '2024-02-01',
+            fødselsdatoer: ['2022-05-10'],
+        } satisfies Barn;
+
+        const params = getStønadskvoteParams(barn, ANNEN_FORELDER_OPPGITT, MOR_SØKERSITUASJON, undefined);
+
+        expect(params.fødselsdato).toBeUndefined();
+        expect(params.termindato).toBeUndefined();
+        expect(params.omsorgsovertakelseDato).toBe('2024-02-01');
+    });
+});

--- a/apps/foreldrepengesoknad/src/api/getStønadskvoteParams.ts
+++ b/apps/foreldrepengesoknad/src/api/getStønadskvoteParams.ts
@@ -12,6 +12,7 @@ import {
     SøkersituasjonFp,
     isAdoptertBarn,
     isFødtBarn,
+    isIkkeUtfyltTypeBarn,
     isUfødtBarn,
 } from '@navikt/fp-types';
 
@@ -140,7 +141,7 @@ export const getStønadskvoteParams = (
         ),
         brukerrolle: søkerErFarEllerMedmor ? 'FAR' : 'MOR',
         antallBarn: saksgrunnlagsAntallBarn,
-        fødselsdato: isFødtBarn(barn) ? barn.fødselsdatoer[0] : undefined,
+        fødselsdato: isFødtBarn(barn) || isIkkeUtfyltTypeBarn(barn) ? barn.fødselsdatoer[0] : undefined,
         termindato: getTermindatoSomSkalBrukes(barn, saksgrunnlagsTermindato),
         omsorgsovertakelseDato: isAdoptertBarn(barn) ? barn.adopsjonsdato : undefined,
         morHarUføretrygd: getErMorUfør(annenForelder, søkerErFarEllerMedmor),

--- a/apps/foreldrepengesoknad/src/api/queries.ts
+++ b/apps/foreldrepengesoknad/src/api/queries.ts
@@ -14,6 +14,7 @@ import {
     KontoBeregningResultatDto,
     MorArbeidRequest_fpoversikt,
     Saker_fpoversikt,
+    isIkkeUtfyltTypeBarn,
 } from '@navikt/fp-types';
 import { notEmpty } from '@navikt/fp-validation';
 
@@ -124,7 +125,7 @@ export const useStønadsKontoerOptions = () => {
         valgtSak?.familiehendelse.termindato,
     );
 
-    return tilgjengeligeStønadskvoterOptions(stønadskvoteParams);
+    return { ...tilgjengeligeStønadskvoterOptions(stønadskvoteParams), enabled: !isIkkeUtfyltTypeBarn(barn) };
 };
 
 export const useAnnenPartVedtakOptions = () => {


### PR DESCRIPTION
* IkkeUtfyltTypeBarn oppstår når et ValgtBarn mangler både fødselsdatoer og termindato.
* IkkeUtfyltTypeBarn ble ikke håndtert i getStønadskvoteParams, så alle tre datofeltene ble undefined
* Inkluder isIkkeUtfyltTypeBarn i fødselsdato-guard tilsvarende getFamiliehendelsedato
* Deaktiver konto-queryen når barn er IkkeUtfyltTypeBarn
* Legger til tester for datohåndtering per barntype