### PR TITLE
TFP-7090: Hindre konto-kall uten familiehendelsesdato i planleggeren

### DIFF
--- a/apps/planlegger/src/Planlegger.stories.tsx
+++ b/apps/planlegger/src/Planlegger.stories.tsx
@@ -119,6 +119,26 @@ export const DefaultMockaStønadskvoterOgSatser: Story = {
     },
 };
 
+export const MedValidertKontoKall: Story = {
+    ...Default,
+
+    beforeEach({ msw }) {
+        msw.use(
+            http.post(API_URLS.konto, async ({ request }) => {
+                const body = (await request.json()) as {
+                    fødselsdato?: string;
+                    termindato?: string;
+                    omsorgsovertakelseDato?: string;
+                };
+                if (!body.fødselsdato && !body.termindato && !body.omsorgsovertakelseDato) {
+                    return new HttpResponse(null, { status: 500 });
+                }
+                return HttpResponse.json(STØNADSKVOTER);
+            }),
+        );
+    },
+};
+
 export const FarFarMockaStønadskvoterOgSatser: Story = {
     ...Default,
 

--- a/apps/planlegger/src/Planlegger.test.tsx
+++ b/apps/planlegger/src/Planlegger.test.tsx
@@ -8,7 +8,8 @@ import { DDMMYYYY_DATE_FORMAT } from '@navikt/fp-constants';
 import { endreFordelingMedSlider } from '../vitest/testHelpers';
 import * as stories from './Planlegger.stories';
 
-const { DefaultMockaStønadskvoterOgSatser, FarFarMockaStønadskvoterOgSatser } = composeStories(stories);
+const { DefaultMockaStønadskvoterOgSatser, FarFarMockaStønadskvoterOgSatser, MedValidertKontoKall } =
+    composeStories(stories);
 
 describe('<Planlegger>', () => {
     it('skal gå rett til oppsummering når ingen av foreldrene har rett', async () => {
@@ -298,5 +299,47 @@ describe('<Planlegger>', () => {
         await userEvent.click(screen.getByText('Forrige'));
 
         expect(screen.getByText('Planleggeren består av to deler:')).toBeInTheDocument();
+    });
+
+    it('skal ikke vise feilside når bruker går tilbake fra om-barnet etter å ha endret til født uten å fylle inn fødselsdato', async () => {
+        await MedValidertKontoKall.run();
+
+        expect(await screen.findByText('Planleggeren består av to deler:')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Start'));
+
+        await waitFor(() => expect(screen.getAllByText('Hvem planlegger?')).toHaveLength(2));
+        await userEvent.click(screen.getByText('Mor og far'));
+        await userEvent.click(screen.getByText('Neste'));
+
+        await waitFor(() => expect(screen.getAllByText('Barnet')).toHaveLength(2));
+        await userEvent.click(screen.getByText('Fødsel'));
+        await userEvent.click(screen.getByText('Ett'));
+        await userEvent.click(screen.getByText('Nei'));
+        const termindato = screen.getByLabelText('Når er termindato?');
+        await userEvent.type(termindato, dayjs().add(20, 'week').format(DDMMYYYY_DATE_FORMAT));
+        fireEvent.blur(termindato);
+        await userEvent.click(screen.getByText('Neste'));
+
+        await waitFor(() => expect(screen.getAllByText('Barnehageplass')).toHaveLength(2));
+        await userEvent.click(screen.getByText('Neste'));
+
+        await waitFor(() => expect(screen.getAllByText('Arbeidssituasjon')).toHaveLength(2));
+        await userEvent.click(
+            screen.getByText('Har jobbet minst 6 av de siste 10 månedene og har tjent 68 275 kr eller mer det siste året'),
+        );
+        await userEvent.click(screen.getByText('Ja'));
+        await userEvent.click(screen.getByText('Forrige'));
+
+        await waitFor(() => expect(screen.getAllByText('Barnehageplass')).toHaveLength(2));
+        await userEvent.click(screen.getByText('Forrige'));
+
+        await waitFor(() => expect(screen.getAllByText('Barnet')).toHaveLength(2));
+        await userEvent.click(screen.getByText('Ja'));
+
+        await userEvent.click(screen.getByText('Forrige'));
+
+        expect(
+            screen.queryByText('Beklager, det ser ut som at noe har gått galt på grunn av en teknisk feil hos Nav'),
+        ).not.toBeInTheDocument();
     });
 });

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -65,6 +65,12 @@ const getStønadskvoter = async (
     return ky.post(API_URLS.konto, { json: params }).json<KontoBeregningResultatDto>();
 };
 
+const harGyldigDato = (omBarnet?: OmBarnetPlanlegger): boolean =>
+    !!omBarnet &&
+    ((erBarnetFødt(omBarnet) && !!omBarnet.fødselsdato) ||
+        (erBarnetUFødt(omBarnet) && !!omBarnet.termindato) ||
+        (erBarnetAdoptert(omBarnet) && !!omBarnet.overtakelsesdato));
+
 export const PlanleggerDataFetcher = () => {
     const omBarnet = useContextGetData(ContextDataType.OM_BARNET);
     const arbeidssituasjon = useContextGetData(ContextDataType.ARBEIDSSITUASJON);
@@ -75,7 +81,7 @@ export const PlanleggerDataFetcher = () => {
     const stønadskvoterData = useQuery({
         queryKey: ['KVOTER', omBarnet, arbeidssituasjon, hvemPlanlegger],
         queryFn: () => getStønadskvoter(omBarnet, arbeidssituasjon, hvemPlanlegger),
-        enabled: hvemHarRett !== undefined && hvemHarRett !== 'ingenHarRett',
+        enabled: hvemHarRett !== undefined && hvemHarRett !== 'ingenHarRett' && harGyldigDato(omBarnet),
         select: (data: KontoBeregningResultatDto): KontoBeregningResultatDto => {
             // TODO (TOR) Dette bør ligga i backend. Verkar pussig å henta kontoar for far-og-far, og så modifisera det her
 


### PR DESCRIPTION
* Konto-kallet ble trigget når bruker gikk tilbake fra om-barnet etter å ha endret fødselsstatus uten å fylle inn dato, fordi saveDataOnPreviousClick lagret ufullstendig tilstand til kontekst
* Lagt til harGyldigDato-sjekk i enabled-betingelsen slik at queryen ikke kjøres før en gyldig dato faktisk finnes i omBarnet
* Lagt til integrasjonstest som dekker bug-scenariet

Feilen skjer hvis man gjør følgende: 
> 1. Fyll ut hvem-planlegger (mor og far)
> 2. Om-barnet: velg Nei på «Er barnet født?» + fyll inn termindato
> 3. Gjennom barnehageplass → arbeidssituasjon (fyll inn, slik at queryen enablees)
> 4. Gå tilbake til om-barnet
> 5. Endre «Er barnet født?» fra Nei → Ja
> 6. Ikke fyll inn fødselsdato
> 7. Klikk «Tilbake»-knappen (ikke steg-indikatoren)
> 
> → Da ser du POST til  konto  med 500 i Network-fanen.  fødselsdato=null ,  termindato=null  (sendes ikke lenger fordi  erBarnetFødt  nå er  true ),  omsorgsovertakelseDato=null .

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>