### PR TITLE
refactor: bytt react-router-dom med react-router

### DIFF
--- a/apps/engangsstonad/package.json
+++ b/apps/engangsstonad/package.json
@@ -48,7 +48,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/engangsstonad/src/AppContainer.stories.tsx
+++ b/apps/engangsstonad/src/AppContainer.stories.tsx
@@ -4,7 +4,7 @@ import { Path } from 'appData/paths';
 import { API_URLS } from 'appData/queries';
 import { VERSJON_MELLOMLAGRING } from 'appData/useEsMellomlagring';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { EsPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';
 

--- a/apps/engangsstonad/src/EngangsstønadRoutes.tsx
+++ b/apps/engangsstonad/src/EngangsstønadRoutes.tsx
@@ -3,7 +3,7 @@ import { Path } from 'appData/paths';
 import { EsMellomlagretData, useEsMellomlagring } from 'appData/useEsMellomlagring';
 import { useEsSendSøknad } from 'appData/useEsSendSøknad';
 import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes, useNavigate } from 'react-router';
 
 import { EsPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';
 import { ErrorPage } from '@navikt/fp-ui';

--- a/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
+++ b/apps/engangsstonad/src/app-data/useEsMellomlagring.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { API_URLS } from 'appData/queries';
 import ky, { HTTPError } from 'ky';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ApiError, captureApiError, captureMessage } from '@navikt/fp-observability';
 import { EsPersonopplysningerDto_fpoversikt, FpSoknadProblemDetails } from '@navikt/fp-types';

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.test.tsx
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { API_URLS } from 'appData/queries';
 import ky, { type KyResponse } from 'ky';
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Dokumentasjon } from 'types/Dokumentasjon';
 
 import { AttachmentType, Skjemanummer } from '@navikt/fp-constants';

--- a/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
+++ b/apps/engangsstonad/src/app-data/useEsSendSøknad.ts
@@ -4,7 +4,7 @@ import { API_URLS } from 'appData/queries';
 import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Dokumentasjon, erTerminDokumentasjon } from 'types/Dokumentasjon';
 
 import { ApiError } from '@navikt/fp-observability';

--- a/apps/engangsstonad/src/app-data/useStepConfig.ts
+++ b/apps/engangsstonad/src/app-data/useStepConfig.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
-
+import { useLocation } from 'react-router';
 import { erTerminDokumentasjon } from 'types/Dokumentasjon';
 
 import { notEmpty } from '@navikt/fp-validation';

--- a/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/dokumentasjon/DokumentasjonSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Path } from 'appData/paths';
 import { API_URLS } from 'appData/queries';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { BarnDto } from '@navikt/fp-types';

--- a/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/om-barnet/OmBarnetSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Situasjon } from '@navikt/fp-types';

--- a/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/oppsummering/OppsummeringSteg.stories.tsx
@@ -3,7 +3,7 @@ import { ContextDataType, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import dayjs from 'dayjs';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Dokumentasjon } from 'types/Dokumentasjon';
 

--- a/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/sokersituasjon/SøkersituasjonSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { SøkersituasjonSteg } from './SøkersituasjonSteg';

--- a/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { SenereUtenlandsoppholdSteg } from './SenereUtenlandsoppholdSteg';

--- a/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { TidligereUtenlandsoppholdSteg } from './TidligereUtenlandsoppholdSteg';

--- a/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
+++ b/apps/engangsstonad/src/steg/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { UtenlandsoppholdSteg } from './UtenlandsoppholdSteg';

--- a/apps/engangsstonad/src/velkommen/Velkommen.stories.tsx
+++ b/apps/engangsstonad/src/velkommen/Velkommen.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, EsDataContext } from 'appData/EsDataContext';
 import { Path } from 'appData/paths';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Velkommen } from './Velkommen';

--- a/apps/foreldrepengeoversikt/package.json
+++ b/apps/foreldrepengeoversikt/package.json
@@ -48,7 +48,7 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/foreldrepengeoversikt/src/AppContainer.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/AppContainer.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { annenPartVedtak } from 'storybookData/annenPartVedtak/annenPartVedtak';
 import { dokumenter } from 'storybookData/dokumenter/dokumenter';
 import { manglendeVedlegg } from 'storybookData/manglendeVedlegg/manglendeVedlegg';

--- a/apps/foreldrepengeoversikt/src/AppContainer.tsx
+++ b/apps/foreldrepengeoversikt/src/AppContainer.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { AppShell, createDefaultQueryClient } from '@navikt/fp-app-shell';
 import { filopplasterMessages } from '@navikt/fp-filopplaster';

--- a/apps/foreldrepengeoversikt/src/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { endringFPSøknad, saker, sakerTidligFPSøknad, sakerVenterPåFpInntektsmelding } from 'storybookData/saker/saker';
 import { søkerinfo, søkerinfoUtenArbeidsforhold } from 'storybookData/sokerinfo/sokerinfo';
 

--- a/apps/foreldrepengeoversikt/src/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.tsx
+++ b/apps/foreldrepengeoversikt/src/components/bekreftelse-sendt-søknad/BekreftelseSendtSøknad.tsx
@@ -2,7 +2,7 @@ import { CheckmarkIcon } from '@navikt/aksel-icons';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
-import { Link as LinkInternal } from 'react-router-dom';
+import { Link as LinkInternal } from 'react-router';
 
 import {
     Accordion,

--- a/apps/foreldrepengeoversikt/src/components/breadcrumb/Breadcrumb.tsx
+++ b/apps/foreldrepengeoversikt/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { onBreadcrumbClick, setBreadcrumbs } from '@navikt/nav-dekoratoren-moduler';
 import { useIntl } from 'react-intl';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router';
 
 import { assertUnreachable } from '@navikt/fp-validation';
 

--- a/apps/foreldrepengeoversikt/src/components/har-ikke-saker/HarIkkeSaker.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/har-ikke-saker/HarIkkeSaker.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { HarIkkeSaker } from './HarIkkeSaker';
 

--- a/apps/foreldrepengeoversikt/src/components/har-saker/HarSaker.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/har-saker/HarSaker.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { saker } from 'storybookData/saker/saker';
 
 import { HarSaker } from './HarSaker';

--- a/apps/foreldrepengeoversikt/src/components/header/Header.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/header/Header.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { saker } from 'storybookData/saker/saker';
 
 import { withQueryClient } from '@navikt/fp-utils-test';

--- a/apps/foreldrepengeoversikt/src/components/header/Header.tsx
+++ b/apps/foreldrepengeoversikt/src/components/header/Header.tsx
@@ -2,7 +2,7 @@ import { BabyWrappedIcon, PersonPregnantIcon, StrollerIcon } from '@navikt/aksel
 import { useQuery } from '@tanstack/react-query';
 import { ReactNode, createElement } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Sak } from 'types/Sak.ts';
 
 import { Detail, HGrid, HStack, Heading, Show, VStack } from '@navikt/ds-react';

--- a/apps/foreldrepengeoversikt/src/components/lenke-panel/LenkePanel.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/lenke-panel/LenkePanel.stories.tsx
@@ -1,6 +1,6 @@
 import { StrollerIcon } from '@navikt/aksel-icons';
 import { StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { Tag, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/components/lenke-panel/LenkePanel.tsx
+++ b/apps/foreldrepengeoversikt/src/components/lenke-panel/LenkePanel.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightIcon } from '@navikt/aksel-icons';
 import classNames from 'classnames';
 import { ComponentType, ReactNode, SVGProps } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { BodyShort, HStack, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/components/minidialog-skjema/MinidialogSkjema.tsx
+++ b/apps/foreldrepengeoversikt/src/components/minidialog-skjema/MinidialogSkjema.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import ky from 'ky';
 import { FormEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 import {
     Alert,

--- a/apps/foreldrepengeoversikt/src/components/minidialog-skjema/minidialog-venter-på-svar/MinidialogVenterPåSvar.tsx
+++ b/apps/foreldrepengeoversikt/src/components/minidialog-skjema/minidialog-venter-på-svar/MinidialogVenterPåSvar.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 import { Alert, HStack, Link, Loader, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/components/sak-link/SakLink.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/sak-link/SakLink.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { saker } from 'storybookData/saker/saker';
 
 import { SakLink } from './SakLink';

--- a/apps/foreldrepengeoversikt/src/components/scroll-to-top/ScrollToTop.tsx
+++ b/apps/foreldrepengeoversikt/src/components/scroll-to-top/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 export const ScrollToTop = () => {
     const { pathname } = useLocation();

--- a/apps/foreldrepengeoversikt/src/components/snarveier/Snarveier.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/snarveier/Snarveier.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { saker } from 'storybookData/saker/saker';
 
 import { withQueryClient } from '@navikt/fp-utils-test';

--- a/apps/foreldrepengeoversikt/src/components/svangerskapspenger/Svangerskapspenger.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/svangerskapspenger/Svangerskapspenger.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { SAK_1, SAK_2, SAK_3, SAK_4 } from 'storybookData/saker/svpsaker';
 
 import { LayoutWrapper } from '../../sections/LayoutWrapper';

--- a/apps/foreldrepengeoversikt/src/components/søkelenker/SøkelenkerPanel.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/components/søkelenker/SøkelenkerPanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { LayoutWrapper } from '../../sections/LayoutWrapper';
 import { SøkelenkerPanel } from './SøkelenkerPanel';

--- a/apps/foreldrepengeoversikt/src/hooks/useSelectedSak.ts
+++ b/apps/foreldrepengeoversikt/src/hooks/useSelectedSak.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { hentSakerOptions } from '../api/queries.ts';
 import { getAlleYtelser, mapSakerDTOToSaker } from './../utils/sakerUtils';

--- a/apps/foreldrepengeoversikt/src/pages/beregning-page/BeregningPage.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/beregning-page/BeregningPage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import {
     saker_beregning_aap,
     saker_beregning_cross_year,

--- a/apps/foreldrepengeoversikt/src/pages/beregning-page/BeregningPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/beregning-page/BeregningPage.tsx
@@ -5,7 +5,7 @@ import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { groupBy, partition, sortBy, sumBy } from 'es-toolkit';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 import { Foreldrepengesak, SvangerskapspengeSak } from 'types/Sak.ts';
 
 import {

--- a/apps/foreldrepengeoversikt/src/pages/dokumenter-page/DokumenterPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/dokumenter-page/DokumenterPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 
 import { Alert, BodyLong, Button, Heading, Loader, Pagination, SortState, Table, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/pages/dokumenter-page/EttersendingPage.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/dokumenter-page/EttersendingPage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { dokumenter } from 'storybookData/dokumenter/dokumenter';
 
 import { withQueryClient } from '@navikt/fp-utils-test';

--- a/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { withQueryClient } from '@navikt/fp-utils-test';
 

--- a/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.test.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.test.tsx
@@ -11,8 +11,8 @@ afterEach(() => {
     document.body.replaceChildren();
 });
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useParams: () => ({ saksnummer: '1' }),

--- a/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/ettersending/EttersendingPage.tsx
@@ -2,7 +2,7 @@ import { PlusIcon } from '@navikt/aksel-icons';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { FormEvent, useState } from 'react';
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router';
 
 import {
     Alert,

--- a/apps/foreldrepengeoversikt/src/pages/forside/Forside.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/forside/Forside.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { manglendeVedlegg } from 'storybookData/manglendeVedlegg/manglendeVedlegg';
 import { saker } from 'storybookData/saker/saker';
 import { søkerinfo } from 'storybookData/sokerinfo/sokerinfo';

--- a/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingLenkePanel.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingLenkePanel.tsx
@@ -1,7 +1,7 @@
 import { SackKronerIcon } from '@navikt/aksel-icons';
 import { useQuery } from '@tanstack/react-query';
 import { useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { hentInntektsmelding } from '../../api/queries.ts';
 import { LenkePanel } from '../../components/lenke-panel/LenkePanel';

--- a/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingOversiktPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingOversiktPage.tsx
@@ -1,6 +1,6 @@
 import { Buildings3Icon } from '@navikt/aksel-icons';
 import { useQuery } from '@tanstack/react-query';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 
 import { Tag, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingPage.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingPage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { enBortfaltNaturalytelse } from 'storybookData/inntektsmeldinger/enBortfaltNaturalytelse';
 import { flereBortfalteNaturalytelser } from 'storybookData/inntektsmeldinger/flereBortfalteNaturalytelser';
 import { medDelvisRefusjon } from 'storybookData/inntektsmeldinger/medDelvisRefusjon';

--- a/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/inntektsmelding-page/InntektsmeldingPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 
 import { Alert, BodyShort, Box, Detail, HGrid, Heading, List, Loader, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/pages/minidialog-page/MinidialogPage.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/minidialog-page/MinidialogPage.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { saker } from 'storybookData/saker/saker';
 import { søkerinfo } from 'storybookData/sokerinfo/sokerinfo.ts';
 

--- a/apps/foreldrepengeoversikt/src/pages/minidialog-page/MinidialogPage.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/minidialog-page/MinidialogPage.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 
 import { Heading, Loader, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { annenPartVedtak } from 'storybookData/annenPartVedtak/annenPartVedtak';
 import { dokumenter } from 'storybookData/dokumenter/dokumenter';
 import { manglendeVedlegg } from 'storybookData/manglendeVedlegg/manglendeVedlegg';

--- a/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
+++ b/apps/foreldrepengeoversikt/src/pages/saksoversikt/Saksoversikt.tsx
@@ -2,9 +2,9 @@ import { FilesIcon, FolderFileIcon, PencilIcon, WalletIcon } from '@navikt/aksel
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Alert, BodyShort, HGrid, HStack, Heading, Skeleton, VStack } from '@navikt/ds-react';
 
@@ -43,7 +43,9 @@ dayjs.extend(isSameOrBefore);
 // DinPlan drar med seg de tunge UI-komponentene i @navikt/fp-uttaksplan (kalender, liste,
 // kvoteoppsummering). Den lastes derfor lazy, siden den kun vises for FORELDREPENGER-saker,
 // slik at brukere med SVANGERSKAPSPENGER- eller ENGANGSSTØNAD-saker ikke trenger disse bytene.
-const DinPlan = lazy(() => import('../../sections/din-plan/DinPlan.tsx').then((module) => ({ default: module.DinPlan })));
+const DinPlan = lazy(() =>
+    import('../../sections/din-plan/DinPlan.tsx').then((module) => ({ default: module.DinPlan })),
+);
 
 interface Props {
     søkerinfo: OversiktPersonopplysningerDto_fpoversikt;

--- a/apps/foreldrepengeoversikt/src/routes/ForeldrepengeoversiktRoutes.tsx
+++ b/apps/foreldrepengeoversikt/src/routes/ForeldrepengeoversiktRoutes.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useRef } from 'react';
-import { Navigate, Outlet, Route, Routes, useMatch, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useMatch, useNavigate } from 'react-router';
 
 import { OversiktPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';
 

--- a/apps/foreldrepengeoversikt/src/sections/oppgave-lenkepanel/OppgaveLenkepanel.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/oppgave-lenkepanel/OppgaveLenkepanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { OppgaveLenkepanel } from './OppgaveLenkepanel';
 

--- a/apps/foreldrepengeoversikt/src/sections/oppgaver/Oppgaver.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/oppgaver/Oppgaver.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { withQueryClient } from '@navikt/fp-utils-test';
 

--- a/apps/foreldrepengeoversikt/src/sections/tidslinje/DokumentHendelse.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/tidslinje/DokumentHendelse.tsx
@@ -1,7 +1,7 @@
 import { FileIcon } from '@navikt/aksel-icons';
 import { useQuery } from '@tanstack/react-query';
 import { FormattedMessage } from 'react-intl';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 
 import { HStack, Link } from '@navikt/ds-react';
 

--- a/apps/foreldrepengeoversikt/src/sections/tidslinje/Tidslinje.stories.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/tidslinje/Tidslinje.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { useQuery } from '@tanstack/react-query';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 import { manglendeVedlegg, manglendeVedlegg_FP } from 'storybookData/manglendeVedlegg/manglendeVedlegg';
 import {
     saker,

--- a/apps/foreldrepengeoversikt/src/sections/tidslinje/Tidslinje.tsx
+++ b/apps/foreldrepengeoversikt/src/sections/tidslinje/Tidslinje.tsx
@@ -16,7 +16,7 @@ import {
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link as LinkInternal } from 'react-router-dom';
+import { Link as LinkInternal } from 'react-router';
 
 import { BodyShort, Box, Button, Link, List, Process, ReadMore, VStack } from '@navikt/ds-react';
 

--- a/apps/foreldrepengesoknad/package.json
+++ b/apps/foreldrepengesoknad/package.json
@@ -56,7 +56,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/foreldrepengesoknad/src/AppContainer.stories.tsx
+++ b/apps/foreldrepengesoknad/src/AppContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'api/queries';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { annenPartVedtak } from 'storybookData/annenPartVedtak';
 import { kvittering } from 'storybookData/kvittering';
 import { saker } from 'storybookData/saker';

--- a/apps/foreldrepengesoknad/src/AppContainer.test.tsx
+++ b/apps/foreldrepengesoknad/src/AppContainer.test.tsx
@@ -2,7 +2,7 @@ import { composeStories, composeStory } from '@storybook/react-vite';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { DDMMYYYY_DATE_FORMAT } from '@navikt/fp-constants';
 

--- a/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
+++ b/apps/foreldrepengesoknad/src/ForeldrepengesøknadRoutes.tsx
@@ -10,7 +10,7 @@ import { Søknadsmetadata } from 'pages/forside/utils/useStartSøknad';
 import { KvitteringPage } from 'pages/kvittering/KvitteringPage';
 import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { AndreInntektskilderSteg } from 'steps/andre-inntektskilder/AndreInntektskilderSteg';
 import { AnnenForelderSteg } from 'steps/annen-forelder/AnnenForelderSteg';
 import { ArbeidsforholdOgInntektSteg } from 'steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg';

--- a/apps/foreldrepengesoknad/src/app-data/useAvbrytSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useAvbrytSøknad.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { API_URLS } from 'api/queries';
 import ky from 'ky';
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { loggUmamiEvent } from '@navikt/fp-observability';
 

--- a/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { API_URLS, useAnnenPartVedtakOptions } from 'api/queries';
 import ky, { HTTPError } from 'ky';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { VERSJON_MELLOMLAGRING } from 'utils/mellomlagringUtils';
 
 import { ApiError, captureApiError, captureMessage } from '@navikt/fp-observability';

--- a/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
+++ b/apps/foreldrepengesoknad/src/app-data/usePlanleggerDataFromUrl.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { BarnType } from '@navikt/fp-constants';
 import {

--- a/apps/foreldrepengesoknad/src/app-data/useSendSøknad.test.tsx
+++ b/apps/foreldrepengesoknad/src/app-data/useSendSøknad.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { API_URLS } from 'api/queries';
 import ky, { ResponsePromise } from 'ky';
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { AnnenInntektType, SluttpakkeInntekt } from 'types/AndreInntektskilder';
 import { AnnenForelder } from 'types/AnnenForelder';
 import { VedleggDataType } from 'types/VedleggDataType';

--- a/apps/foreldrepengesoknad/src/app-data/useSendSøknad.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useSendSøknad.ts
@@ -4,7 +4,7 @@ import { API_URLS } from 'api/queries';
 import { SøknadRoutes } from 'appData/routes';
 import ky, { HTTPError } from 'ky';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ApiError } from '@navikt/fp-observability';
 import { FpPersonopplysningerDto_fpoversikt, FpSak_fpoversikt, FpSoknadProblemDetails } from '@navikt/fp-types';

--- a/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/foreldrepengesoknad/src/app-data/useStepConfig.ts
@@ -1,7 +1,7 @@
 import { REQUIRED_APP_STEPS, REQUIRED_APP_STEPS_ENDRINGSSØKNAD, ROUTES_ORDER, SøknadRoutes } from 'appData/routes.ts';
 import { useMemo } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { skalViseOmsorgsovertakelseDokumentasjon } from 'steps/manglende-vedlegg/dokumentasjon/OmsorgsovertakelseDokumentasjon.tsx';
 import { skalViseTerminbekreftelseDokumentasjon } from 'steps/manglende-vedlegg/dokumentasjon/TerminbekreftelseDokumentasjon.tsx';
 import { AnnenInntektType } from 'types/AndreInntektskilder';

--- a/apps/foreldrepengesoknad/src/pages/forside/Forside.stories.tsx
+++ b/apps/foreldrepengesoknad/src/pages/forside/Forside.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import {

--- a/apps/foreldrepengesoknad/src/pages/forside/utils/useFjernPlanleggerDataFraUrl.ts
+++ b/apps/foreldrepengesoknad/src/pages/forside/utils/useFjernPlanleggerDataFraUrl.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 /**
  * Fjernar `planleggerData` frå URL-en når brukaren landar på forsida frå

--- a/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/andre-inntektskilder/AndreInntektskilderSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { AndreInntektskilderSteg } from './AndreInntektskilderSteg';

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { annenPartVedtak, avslåttAnnenPartVedtak } from 'storybookData/annenPartVedtak';
 import { AnnenForelder } from 'types/AnnenForelder';

--- a/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { BarnType } from '@navikt/fp-constants';

--- a/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { EgenNæringSteg } from './EgenNæringSteg';

--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.stories.tsx
@@ -5,7 +5,7 @@ import { SøknadRoutes } from 'appData/routes';
 import dayjs from 'dayjs';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { AnnenForelder } from 'types/AnnenForelder';
 

--- a/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { FrilansSteg } from './FrilansSteg';

--- a/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/manglende-vedlegg/ManglendeVedlegg.stories.tsx
@@ -5,7 +5,7 @@ import { SøknadRoutes } from 'appData/routes';
 import dayjs from 'dayjs';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { AndreInntektskilder, AnnenInntektType } from 'types/AndreInntektskilder';
 import { AnnenForelder } from 'types/AnnenForelder';

--- a/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/om-barnet/OmBarnetSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { annenPartVedtak } from 'storybookData/annenPartVedtak';
 import { AnnenForelder } from 'types/AnnenForelder';

--- a/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -6,7 +6,7 @@ import { SøknadRoutes } from 'appData/routes';
 import dayjs from 'dayjs';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { annenPartVedtak } from 'storybookData/annenPartVedtak';
 import { AndreInntektskilder, AnnenInntektType } from 'types/AndreInntektskilder';

--- a/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/periode-med-foreldrepenger/PeriodeMedForeldrepengerSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { AnnenForelder } from 'types/AnnenForelder';
 

--- a/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/søkersituasjon/SøkersituasjonSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { SøkersituasjonFp } from '@navikt/fp-types';

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Utenlandsopphold } from '@navikt/fp-types';

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Utenlandsopphold } from '@navikt/fp-types';

--- a/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { UtenlandsoppholdSteg } from './UtenlandsoppholdSteg';

--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/UttaksplanSteg.stories.tsx
@@ -4,7 +4,7 @@ import { Action, ContextDataType, FpDataContext } from 'appData/FpDataContext';
 import { SøknadRoutes } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { AnnenForelder } from 'types/AnnenForelder';
 import { FellesperiodeFordelingValg, Fordeling, OppstartValg } from 'types/Fordeling';

--- a/apps/planlegger/package.json
+++ b/apps/planlegger/package.json
@@ -48,7 +48,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/planlegger/src/AppContainer.stories.tsx
+++ b/apps/planlegger/src/AppContainer.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'appData/queries';
 import { HttpResponse, http } from 'msw';
 import { StrictMode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { KontoBeregningResultatDto } from '@navikt/fp-types';
 

--- a/apps/planlegger/src/Planlegger.stories.tsx
+++ b/apps/planlegger/src/Planlegger.stories.tsx
@@ -3,7 +3,7 @@ import { PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { API_URLS } from 'appData/queries';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps, StrictMode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { KontoBeregningResultatDto } from '@navikt/fp-types';
 import { ErrorBoundary } from '@navikt/fp-ui';

--- a/apps/planlegger/src/Planlegger.tsx
+++ b/apps/planlegger/src/Planlegger.tsx
@@ -9,7 +9,7 @@ import { API_URLS } from 'appData/queries';
 import ky from 'ky';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { erBarnetAdoptert, erBarnetFødt, erBarnetUFødt } from 'utils/barnetUtils';

--- a/apps/planlegger/src/PlanleggerRouter.tsx
+++ b/apps/planlegger/src/PlanleggerRouter.tsx
@@ -1,6 +1,6 @@
 import { PlanleggerRoutes } from 'appData/routes';
-import { lazy, Suspense } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 import { ArbeidssituasjonSteg } from 'steps/arbeidssituasjon/ArbeidssituasjonSteg';
 import { BarnehageplassSteg } from 'steps/barnehageplass/BarnehageplassSteg';
 import { FordelingSteg } from 'steps/fordeling/FordelingSteg';

--- a/apps/planlegger/src/app-data/usePlanleggerNavigator.ts
+++ b/apps/planlegger/src/app-data/usePlanleggerNavigator.ts
@@ -1,6 +1,6 @@
 import { PlanleggerRoutes } from 'appData/routes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { compressToUrl } from '@navikt/fp-utils';
 

--- a/apps/planlegger/src/app-data/useStepData.test.tsx
+++ b/apps/planlegger/src/app-data/useStepData.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import dayjs from 'dayjs';
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 

--- a/apps/planlegger/src/app-data/useStepData.ts
+++ b/apps/planlegger/src/app-data/useStepData.ts
@@ -2,7 +2,7 @@ import { PATH_ORDER, PlanleggerRoutes, REQUIRED_APP_STEPS } from 'appData/routes
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { erFlereSøkere } from 'utils/HvemPlanleggerUtils';

--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.stories.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 

--- a/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
+++ b/apps/planlegger/src/steps/arbeidssituasjon/ArbeidssituasjonSteg.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Arbeidsstatus } from 'types/Arbeidssituasjon';
 
 import * as stories from './ArbeidssituasjonSteg.stories';
@@ -15,8 +15,8 @@ const {
     ArbeidssituasjonMorOgMedmorUtenNavn,
 } = composeStories(stories);
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),

--- a/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.stories.tsx
+++ b/apps/planlegger/src/steps/barnehageplass/BarnehageplassSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.stories.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';

--- a/apps/planlegger/src/steps/fordeling/FordelingSteg.test.tsx
+++ b/apps/planlegger/src/steps/fordeling/FordelingSteg.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { BarnetErAdoptertPlanlegger } from '@navikt/fp-types';
 
@@ -18,8 +18,8 @@ const {
     FarOgFar,
 } = composeStories(stories);
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),
@@ -252,20 +252,14 @@ describe('<FordelingSteg>', () => {
         expect(await screen.findAllByText('Fordeling')).toHaveLength(2);
 
         expect(screen.getByText('Hvem skal starte permisjonen med foreldrepenger?')).toBeInTheDocument();
-        expect(
-            screen.getByText('Permisjonen kan tidligst starte ved omsorgsovertakelsen.'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Permisjonen kan tidligst starte ved omsorgsovertakelsen.')).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Petter Pjokk' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Espen Utvikler' })).toBeInTheDocument();
-        expect(
-            screen.getByText('Hvilken betydning har hvem som starter permisjonen?'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Hvilken betydning har hvem som starter permisjonen?')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Neste'));
 
-        expect(
-            await screen.findByText('Du må velge hvem som skal starte permisjonen.'),
-        ).toBeInTheDocument();
+        expect(await screen.findByText('Du må velge hvem som skal starte permisjonen.')).toBeInTheDocument();
         expect(navigateMock).not.toHaveBeenCalled();
     });
 
@@ -305,9 +299,7 @@ describe('<FordelingSteg>', () => {
 
         expect(await screen.findAllByText('Fordeling')).toHaveLength(2);
 
-        expect(
-            screen.queryByText('Hvem skal starte permisjonen med foreldrepenger?'),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Hvem skal starte permisjonen med foreldrepenger?')).not.toBeInTheDocument();
     });
 
     it('Skal vise spørsmål om hvem som starter permisjonen for mor og far ved adopsjon', async () => {

--- a/apps/planlegger/src/steps/hvem-planlegger/HvemPlanleggerSteg.stories.tsx
+++ b/apps/planlegger/src/steps/hvem-planlegger/HvemPlanleggerSteg.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataMap, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { HvemPlanleggerType } from 'types/HvemPlanlegger';
 
@@ -36,8 +36,17 @@ export const Default: Story = {
 export const MedEksisterendeData: Story = {
     args: {
         initialState: {
-            [ContextDataType.HVEM_PLANLEGGER]: { type: HvemPlanleggerType.MOR_OG_FAR, navnPåMor: 'Helga', navnPåFar: 'Espen' },
-            [ContextDataType.OM_BARNET]: { erFødsel: true, antallBarn: '1', erBarnetFødt: true, fødselsdato: '2024-01-01' },
+            [ContextDataType.HVEM_PLANLEGGER]: {
+                type: HvemPlanleggerType.MOR_OG_FAR,
+                navnPåMor: 'Helga',
+                navnPåFar: 'Espen',
+            },
+            [ContextDataType.OM_BARNET]: {
+                erFødsel: true,
+                antallBarn: '1',
+                erBarnetFødt: true,
+                fødselsdato: '2024-01-01',
+            },
         },
     },
 };

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';

--- a/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
+++ b/apps/planlegger/src/steps/hvor-lang-periode/HvorLangPeriodeSteg.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextDataType } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import * as stories from './HvorLangPeriodeSteg.stories';
 
@@ -16,8 +16,8 @@ const {
     FlereForsørgereEttBarnBeggeHarRettAdopsjon,
 } = composeStories(stories);
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),

--- a/apps/planlegger/src/steps/hvor-mye/HvorMyeSteg.stories.tsx
+++ b/apps/planlegger/src/steps/hvor-mye/HvorMyeSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';

--- a/apps/planlegger/src/steps/om-barnet/OmBarnetSteg.stories.tsx
+++ b/apps/planlegger/src/steps/om-barnet/OmBarnetSteg.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 

--- a/apps/planlegger/src/steps/om-planleggeren/OmPlanleggerenSteg.stories.tsx
+++ b/apps/planlegger/src/steps/om-planleggeren/OmPlanleggerenSteg.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { OmPlanleggerenSteg } from './OmPlanleggerenSteg';

--- a/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/planlegger/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';
 import { HvorMye } from 'types/HvorMye';

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.stories.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Adopsjon.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.stories.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, PlanleggerDataContext } from 'appData/PlanleggerDataContext';
 import { PlanleggerRoutes } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { Arbeidssituasjon, Arbeidsstatus } from 'types/Arbeidssituasjon';
 import { HvemPlanlegger, HvemPlanleggerType } from 'types/HvemPlanlegger';

--- a/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.test.tsx
+++ b/apps/planlegger/src/steps/planen-deres/PlanenDeresSteg_Fødsel.test.tsx
@@ -8,8 +8,8 @@ import { DELT_UTTAK_80_TO_BARN, DELT_UTTAK_100_TO_BARN } from '@navikt/fp-utils-
 import { endreFordelingMedSlider } from '../../../vitest/testHelpers';
 import * as stories from './PlanenDeresSteg_Fødsel.stories';
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),
@@ -683,7 +683,7 @@ describe('<PlanenDeresSteg - fødsel>', () => {
     });
 
     it('skal lagre planforslaget til context ved navigering til oppsummering uten at brukeren har gjort endringer', async () => {
-        const { useNavigate } = await import('react-router-dom');
+        const { useNavigate } = await import('react-router');
         const navigateMock = vi.fn();
         vi.mocked(useNavigate).mockReturnValue(navigateMock);
 

--- a/apps/svangerskapspengesoknad/package.json
+++ b/apps/svangerskapspengesoknad/package.json
@@ -52,7 +52,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/svangerskapspengesoknad/src/AppContainer.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/AppContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'appData/queries';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { SvpPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';
 

--- a/apps/svangerskapspengesoknad/src/SvangerskapspengesøknadRoutes.tsx
+++ b/apps/svangerskapspengesoknad/src/SvangerskapspengesøknadRoutes.tsx
@@ -4,7 +4,7 @@ import { useAvbrytSøknad } from 'appData/useAvbrytSøknad';
 import { SvpMellomlagretData, useMellomlagreSøknad } from 'appData/useMellomlagreSøknad';
 import { useSendSøknad } from 'appData/useSendSøknad';
 import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes, useNavigate } from 'react-router';
 
 import { SvpPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';
 import { ErrorPage } from '@navikt/fp-ui';

--- a/apps/svangerskapspengesoknad/src/app-data/useAvbrytSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useAvbrytSøknad.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { API_URLS } from 'appData/queries';
 import ky from 'ky';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { loggUmamiEvent } from '@navikt/fp-observability';
 

--- a/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useMellomlagreSøknad.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { API_URLS } from 'appData/queries';
 import ky, { HTTPError } from 'ky';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ApiError, captureApiError, captureMessage } from '@navikt/fp-observability';
 import { FpSoknadProblemDetails, SvpPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/app-data/useSendSøknad.test.tsx
+++ b/apps/svangerskapspengesoknad/src/app-data/useSendSøknad.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { API_URLS } from 'appData/queries';
 import ky, { ResponsePromise } from 'ky';
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ArbeidIUtlandet, ArbeidIUtlandetType } from 'types/ArbeidIUtlandet';
 import { AvtaltFeriePerArbeidsgiver } from 'types/AvtaltFerie';
 import {

--- a/apps/svangerskapspengesoknad/src/app-data/useSendSøknad.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useSendSøknad.ts
@@ -4,7 +4,7 @@ import { SøknadRoute } from 'appData/routes';
 import ky, { HTTPError } from 'ky';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ApiError } from '@navikt/fp-observability';
 import { FpSoknadProblemDetails, SvpPersonopplysningerDto_fpoversikt } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/app-data/useStepConfig.ts
+++ b/apps/svangerskapspengesoknad/src/app-data/useStepConfig.ts
@@ -1,5 +1,5 @@
 import { IntlShape, useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
     Arbeidsforholdstype,
     DelivisTilretteleggingPeriodeType,

--- a/apps/svangerskapspengesoknad/src/steps/arbeid-i-utlandet/ArbeidIUtlandetSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/arbeid-i-utlandet/ArbeidIUtlandetSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { EksternArbeidsforholdDto_fpoversikt } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/arbeidsforhold-og-inntekt/ArbeidsforholdOgInntektSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { EksternArbeidsforholdDto_fpoversikt } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/steps/barnet/BarnetSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/barnet/BarnetSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { BarnetSteg } from './BarnetSteg';

--- a/apps/svangerskapspengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/egen-næring/EgenNæringSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { EgenNæringSteg } from './EgenNæringSteg';

--- a/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute, TILRETTELEGGING_PARAM, addTilretteleggingIdToRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { action } from 'storybook/actions';
 import { TilOgMedDatoType } from 'types/Tilrettelegging';
 

--- a/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/ferie/FerieSteg.tsx
@@ -6,7 +6,7 @@ import { useSvpNavigator } from 'appData/useSvpNavigator';
 import dayjs from 'dayjs';
 import { useFieldArray, useForm, useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { getSisteDagForSvangerskapspenger } from 'utils/dateUtils';
 import { getNesteTilretteleggingId, getTypeArbeidForTilrettelegging } from 'utils/tilretteleggingUtils';
 

--- a/apps/svangerskapspengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/frilans/FrilansSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { FrilansSteg } from './FrilansSteg';

--- a/apps/svangerskapspengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/oppsummering/OppsummeringSteg.stories.tsx
@@ -3,7 +3,7 @@ import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext'
 import { SøknadRoute } from 'appData/routes';
 import dayjs from 'dayjs';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { ArbeidIUtlandetType } from 'types/ArbeidIUtlandet';
 import { DelivisTilretteleggingPeriodeType, TilOgMedDatoType } from 'types/Tilrettelegging';

--- a/apps/svangerskapspengesoknad/src/steps/perioder/PerioderSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/perioder/PerioderSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute, TILRETTELEGGING_PARAM, addTilretteleggingIdToRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { action } from 'storybook/actions';
 import { Barn } from 'types/Barn';
 import { DelivisTilretteleggingPeriodeType, DelvisTilrettelegging, IngenTilrettelegging } from 'types/Tilrettelegging';

--- a/apps/svangerskapspengesoknad/src/steps/perioder/PerioderSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/perioder/PerioderSteg.tsx
@@ -4,7 +4,7 @@ import { useStepConfig } from 'appData/useStepConfig';
 import { useSvpNavigator } from 'appData/useSvpNavigator';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { PeriodeMedVariasjon } from 'types/Tilrettelegging';
 import { getKanHaSvpFremTilTreUkerFørTermin } from 'utils/dateUtils';
 import {

--- a/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.stories.tsx
@@ -4,7 +4,7 @@ import { API_URLS } from 'appData/queries';
 import { SøknadRoute, TILRETTELEGGING_PARAM, addTilretteleggingIdToRoute } from 'appData/routes';
 import { HttpResponse, http } from 'msw';
 import { ComponentProps } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { AttachmentType, Skjemanummer } from '@navikt/fp-constants';

--- a/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/skjema/SkjemaSteg.tsx
@@ -6,7 +6,7 @@ import { useSvpNavigator } from 'appData/useSvpNavigator';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { getArbeidsgiverNavnForTilrettelegging, getTypeArbeidForTilrettelegging } from 'utils/tilretteleggingUtils';
 
 import { Link, VStack } from '@navikt/ds-react';

--- a/apps/svangerskapspengesoknad/src/steps/tilrettelegging/TilretteleggingSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/tilrettelegging/TilretteleggingSteg.stories.tsx
@@ -3,7 +3,7 @@ import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext'
 import { SøknadRoute, TILRETTELEGGING_PARAM, addTilretteleggingIdToRoute } from 'appData/routes';
 import dayjs from 'dayjs';
 import { ComponentProps } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { ISO_DATE_FORMAT } from '@navikt/fp-constants';

--- a/apps/svangerskapspengesoknad/src/steps/tilrettelegging/TilretteleggingSteg.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/tilrettelegging/TilretteleggingSteg.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import { omit } from 'es-toolkit';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
     Arbeidsforholdstype,
     DelivisTilretteleggingPeriodeType,

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-senere/SenereUtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Utenlandsopphold } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold-tidligere/TidligereUtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { Utenlandsopphold } from '@navikt/fp-types';

--- a/apps/svangerskapspengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/utenlandsopphold/UtenlandsoppholdSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 
 import { UtenlandsoppholdSteg } from './UtenlandsoppholdSteg';

--- a/apps/svangerskapspengesoknad/src/steps/velg-arbeidsforhold/VelgArbeidSteg.stories.tsx
+++ b/apps/svangerskapspengesoknad/src/steps/velg-arbeidsforhold/VelgArbeidSteg.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { Action, ContextDataType, SvpDataContext } from 'appData/SvpDataContext';
 import { SøknadRoute } from 'appData/routes';
 import { ComponentProps } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { action } from 'storybook/actions';
 import { DelvisTilrettelegging, IngenTilrettelegging } from 'types/Tilrettelegging';
 

--- a/apps/veiviser-fp-eller-es/package.json
+++ b/apps/veiviser-fp-eller-es/package.json
@@ -43,7 +43,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/veiviser-fp-eller-es/src/AppContainer.stories.tsx
+++ b/apps/veiviser-fp-eller-es/src/AppContainer.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { StrictMode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { AppContainer } from './AppContainer';
 

--- a/apps/veiviser-fp-eller-es/src/FpEllerEsRouter.tsx
+++ b/apps/veiviser-fp-eller-es/src/FpEllerEsRouter.tsx
@@ -1,6 +1,6 @@
 import { FpEllerEsRoutes } from 'appData/routes';
 import { useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { Satser } from '@navikt/fp-types';
 

--- a/apps/veiviser-fp-eller-es/src/app-data/useVeiviserNavigator.ts
+++ b/apps/veiviser-fp-eller-es/src/app-data/useVeiviserNavigator.ts
@@ -1,6 +1,6 @@
 import { FpEllerEsRoutes } from 'appData/routes';
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const useVeiviserNavigator = () => {
     const navigate = useNavigate();

--- a/apps/veiviser-fp-eller-es/src/pages/forside/FpEllerEsForside.stories.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/forside/FpEllerEsForside.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { FpEllerEsRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { FpEllerEsForside } from './FpEllerEsForside';
 

--- a/apps/veiviser-fp-eller-es/src/pages/forside/FpEllerEsForside.test.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/forside/FpEllerEsForside.test.tsx
@@ -2,14 +2,14 @@ import { composeStories } from '@storybook/react-vite';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FpEllerEsRoutes } from 'appData/routes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import * as stories from './FpEllerEsForside.stories';
 
 const { Default } = composeStories(stories);
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),

--- a/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.stories.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/oppsummering/OppsummeringFpEllerEsSide.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { FpEllerEsRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { DEFAULT_SATSER } from '@navikt/fp-constants';
 

--- a/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.stories.tsx
+++ b/apps/veiviser-fp-eller-es/src/pages/situasjon/SituasjonSide.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { FpEllerEsRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { DEFAULT_SATSER } from '@navikt/fp-constants';
 

--- a/apps/veiviser-hvor-mye/package.json
+++ b/apps/veiviser-hvor-mye/package.json
@@ -45,7 +45,7 @@
         "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-intl": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/veiviser-hvor-mye/src/AppContainer.stories.tsx
+++ b/apps/veiviser-hvor-mye/src/AppContainer.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { API_URLS } from 'appData/queries';
 import { HttpResponse, http } from 'msw';
 import { StrictMode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import type { KontoBeregningResultatDto } from '@navikt/fp-types';
 

--- a/apps/veiviser-hvor-mye/src/HvorMyeRouter.tsx
+++ b/apps/veiviser-hvor-mye/src/HvorMyeRouter.tsx
@@ -1,6 +1,6 @@
 import { HvorMyeRoutes } from 'appData/routes';
 import { useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { KontoBeregningDto, Satser } from '@navikt/fp-types';
 

--- a/apps/veiviser-hvor-mye/src/app-data/useVeiviserNavigator.ts
+++ b/apps/veiviser-hvor-mye/src/app-data/useVeiviserNavigator.ts
@@ -1,6 +1,6 @@
 import { HvorMyeRoutes } from 'appData/routes';
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const useVeiviserNavigator = () => {
     const navigate = useNavigate();

--- a/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.stories.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/arbeidssituasjon/ArbeidssituasjonSide.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HvorMyeRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { DEFAULT_SATSER } from '@navikt/fp-constants';
 

--- a/apps/veiviser-hvor-mye/src/pages/forside/HvorMyeForside.stories.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/forside/HvorMyeForside.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HvorMyeRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { HvorMyeForside } from './HvorMyeForside';
 

--- a/apps/veiviser-hvor-mye/src/pages/forside/HvorMyeForside.test.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/forside/HvorMyeForside.test.tsx
@@ -2,14 +2,14 @@ import { composeStories } from '@storybook/react-vite';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HvorMyeRoutes } from 'appData/routes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import * as stories from './HvorMyeForside.stories';
 
 const { Default } = composeStories(stories);
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return {
         ...actual,
         useNavigate: vi.fn(),

--- a/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.stories.tsx
+++ b/apps/veiviser-hvor-mye/src/pages/oppsummering/OppsummeringSide.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { HvorMyeRoutes } from 'appData/routes';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { DEFAULT_SATSER } from '@navikt/fp-constants';
 import { KontoBeregningDto } from '@navikt/fp-types';

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -27,7 +27,7 @@
         "ky": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",
-        "react-router-dom": "catalog:"
+        "react-router": "catalog:"
     },
     "devDependencies": {
         "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/app-shell/src/AppShell.tsx
+++ b/packages/app-shell/src/AppShell.tsx
@@ -3,7 +3,7 @@ import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import dayjs from 'dayjs';
 import { type ReactElement, type ReactNode, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { Provider, Theme } from '@navikt/ds-react';
 import { en, nb, nn } from '@navikt/ds-react/locales';

--- a/packages/app-shell/src/bootstrapApp.tsx
+++ b/packages/app-shell/src/bootstrapApp.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import * as countries from 'i18n-iso-countries';
 import { type ReactElement, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import { initFaro, initSentry } from '@navikt/fp-observability';
 import type { LocaleAll } from '@navikt/fp-types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3622,8 +3622,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.127.0':
     resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3634,8 +3646,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.127.0':
     resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3646,8 +3670,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
     resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3658,8 +3694,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
     resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3672,8 +3721,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3686,8 +3749,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -3700,8 +3777,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3714,8 +3805,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3725,8 +3829,19 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
     resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3737,8 +3852,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
     resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -8499,49 +8626,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.127.0':
@@ -8551,13 +8726,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
     optional: true
 
   '@oxc-project/types@0.127.0': {}
@@ -11372,6 +11563,27 @@ snapshots:
   oxc-parser@0.142.0:
     dependencies:
       '@oxc-project/types': 0.142.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
 
   oxc-resolver@11.24.2:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ catalogs:
     react-intl:
       specifier: 10.1.19
       version: 10.1.19
-    react-router-dom:
+    react-router:
       specifier: 7.18.2
       version: 7.18.2
     storybook-react-intl:
@@ -250,7 +250,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -404,7 +404,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -591,7 +591,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -748,7 +748,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -917,7 +917,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -1056,7 +1056,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -1198,7 +1198,7 @@ importers:
       react-intl:
         specifier: 'catalog:'
         version: 10.1.19(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -1322,7 +1322,7 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
-      react-router-dom:
+      react-router:
         specifier: 'catalog:'
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
@@ -3622,20 +3622,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.142.0':
-    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
   '@oxc-parser/binding-android-arm64@0.127.0':
     resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.142.0':
-    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3646,20 +3634,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.142.0':
-    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@oxc-parser/binding-darwin-x64@0.127.0':
     resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.142.0':
-    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3670,20 +3646,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.142.0':
-    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
     resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
-    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3694,21 +3658,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
-    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
     resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
-    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3721,22 +3672,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
-    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
-    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3749,22 +3686,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
-    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
-    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -3777,22 +3700,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
-    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
-    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3805,21 +3714,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.142.0':
-    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-openharmony-arm64@0.142.0':
-    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3829,19 +3725,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-wasm32-wasi@0.142.0':
-    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
     resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
-    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3852,20 +3737,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
-    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
     resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
-    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -8626,97 +8499,49 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-android-arm64@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-android-arm64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-darwin-x64@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.142.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.127.0':
@@ -8726,29 +8551,13 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.142.0':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
-    optional: true
-
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
     optional: true
 
   '@oxc-project/types@0.127.0': {}
@@ -11563,27 +11372,6 @@ snapshots:
   oxc-parser@0.142.0:
     dependencies:
       '@oxc-project/types': 0.142.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.142.0
-      '@oxc-parser/binding-android-arm64': 0.142.0
-      '@oxc-parser/binding-darwin-arm64': 0.142.0
-      '@oxc-parser/binding-darwin-x64': 0.142.0
-      '@oxc-parser/binding-freebsd-x64': 0.142.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
-      '@oxc-parser/binding-linux-x64-musl': 0.142.0
-      '@oxc-parser/binding-openharmony-arm64': 0.142.0
-      '@oxc-parser/binding-wasm32-wasi': 0.142.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
 
   oxc-resolver@11.24.2:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   react-dom: 19.2.8
   react-hook-form: 7.84.0
   react-intl: 10.1.19
-  react-router-dom: 7.18.2
+  react-router: 7.18.2
   storybook: 10.4.6
   storybook-react-intl: 10.2.1
   tailwindcss: 4.3.3


### PR DESCRIPTION
## Sammendrag
- Bytter alle imports fra `react-router-dom` til `react-router` (kildefiler i alle apper og pakker)
- Erstatter `react-router-dom` med `react-router` i katalogen (`pnpm-workspace.yaml`) og i alle relevante `package.json`

I react-router v7 er pakkene forenklet slik at alt kan importeres direkte fra
`react-router`. Katalogen lå allerede på 7.18.2. Speiler navikt/fp-frontend#7487.

`react-router-dom` finnes fortsatt transitivt via `@nais/apm`/`@grafana/faro-react` (valgfri peer), men er ikke lenger en direkte avhengighet.

## Validering
- `pnpm install`
- `pnpm run tsc` (turbo, 24 pakker – alle grønne)
- `pnpm exec lint-staged` (prettier)
- Ikke kjørt: `pnpm knip` fordi den kræsjer med en native oxc-parser-panic i dette miljøet (samme feil på uendret `master`, ikke relatert til denne endringen)
