### PR TITLE
fix: legg til nav-dekoratoren i filter for kjente feil

### DIFF
--- a/packages/observability/src/filterUtils.ts
+++ b/packages/observability/src/filterUtils.ts
@@ -9,7 +9,7 @@
  * 401-filtrering holdes i hver init-fil siden mekanismen er ulik (Sentry har breadcrumbs, Faro har ikke).
  */
 
-const FEIL_VI_VIL_LUKE_BORT = ['personbruker/decorator-next'];
+const FEIL_VI_VIL_LUKE_BORT = ['personbruker/decorator-next', 'personbruker/nav-dekoratoren'];
 
 export const DISTRIBUTOR_PATTERN = /Request timeout \S*Distributor\.\S+/;
 


### PR DESCRIPTION
## Hva
Legger til `personbruker/nav-dekoratoren` i listen over kjente feil (`FEIL_VI_VIL_LUKE_BORT` i `filterUtils.ts`) som filtreres bort fra observability, på samme måte som `personbruker/decorator-next` allerede filtreres.

## Hvorfor
Vi ønsker ikke støy fra dekoratør-relaterte feil vi ikke kan gjøre noe med.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>