### PR TITLE
FAGSYSTEM-440281 Fjern feilaktig overføringsårsak ved bytte til eigen…

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.test.ts
@@ -79,4 +79,42 @@ describe('mapFraFormValuesTilUttakPeriode', () => {
 
         expect(periode?.gradering?.aktivitet).toEqual({ type: 'ANNET' });
     });
+
+    it('nullstiller overføringÅrsak for far/medmor når kontoType endres frå MØDREKVOTE (overføring) til FEDREKVOTE (eigen kvote)', () => {
+        // Reproduserer feilen der ei "overta mødrekvote"-periode blir endra til fedrekvote,
+        // men overføringsårsak heng igjen i form-state og blir feilaktig sendt med vidare.
+        const values = {
+            forelder: 'FAR_MEDMOR',
+            kontoTypeFarMedmor: 'FEDREKVOTE',
+            overføringsårsak: 'SYKDOM_ANNEN_FORELDER',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'FAR_MEDMOR', true);
+
+        expect(periode?.overføringÅrsak).toBeUndefined();
+    });
+
+    it('nullstiller overføringÅrsak for mor når kontoType endres frå FEDREKVOTE (overføring) til MØDREKVOTE (eigen kvote)', () => {
+        const values = {
+            forelder: 'MOR',
+            kontoTypeMor: 'MØDREKVOTE',
+            overføringsårsak: 'INSTITUSJONSOPPHOLD_ANNEN_FORELDER',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'MOR', true);
+
+        expect(periode?.overføringÅrsak).toBeUndefined();
+    });
+
+    it('beheld overføringÅrsak for far/medmor når kontoType framleis er MØDREKVOTE (reell overføring)', () => {
+        const values = {
+            forelder: 'FAR_MEDMOR',
+            kontoTypeFarMedmor: 'MØDREKVOTE',
+            overføringsårsak: 'SYKDOM_ANNEN_FORELDER',
+        } satisfies LeggTilEllerEndrePeriodeFormFormValues;
+
+        const [periode] = mapFraFormValuesTilUttakPeriode(values, PERIODE, 'FAR_MEDMOR', true);
+
+        expect(periode?.overføringÅrsak).toBe('SYKDOM_ANNEN_FORELDER');
+    });
 });

--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -921,7 +921,7 @@ export const mapFraFormValuesTilUttakPeriode = (
                     : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentMor) : undefined,
-            overføringÅrsak: values.overføringsårsak,
+            overføringÅrsak: erOverføringMor ? values.overføringsårsak : undefined,
             flerbarnsdager: values.ønskerFlerbarnsdager ?? false,
         });
     }
@@ -948,7 +948,7 @@ export const mapFraFormValuesTilUttakPeriode = (
                     : undefined,
             samtidigUttak:
                 values.forelder === 'BEGGE' ? getFloatFromString(values.samtidigUttaksprosentFarMedmor) : undefined,
-            overføringÅrsak: values.overføringsårsak,
+            overføringÅrsak: erOverføringFarMedmor ? values.overføringsårsak : undefined,
             flerbarnsdager: values.ønskerFlerbarnsdager ?? false,
         });
     }


### PR DESCRIPTION
… kvotetype

Når ein forelder endra periode frå å overta den andre forelderens kvote
(t.d. mødrekvote) til eiga kvote (t.d. fedrekvote) i
LeggTilEllerEndrePeriodeFellesForm, vart overføringsårsak frå skjema-state
sendt vidare uendra i mapFraFormValuesTilUttakPeriode. Dette skjedde fordi
overføringÅrsak vart sett ubetinget, uavhengig av om kontoType faktisk
representerte ei overføring.

erOverføringsperiode() sjekkar berre om overføringÅrsak !== undefined, så
PDF-en viste feilaktig "Overføring av Fedrekvote" i staden for "Fedrekvote"
når ein far/medmor endra frå MØDREKVOTE til FEDREKVOTE (eller mor frå
FEDREKVOTE til MØDREKVOTE) på same periode.

Set no overføringÅrsak til undefined med mindre kontoType faktisk er den
andre forelderens kvotetype (erOverføringMor / erOverføringFarMedmor),
same mønster som allereie brukt for gradering. Legg til regresjonstestar
som dekker scenarioet frå feilmeldinga.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
