### PR TITLE
TFP-6022: informer om dokumentasjonskrav ved aktivitetskrav i førsteg…

### DIFF
--- a/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
+++ b/packages/uttaksplan/src/felles/LeggTilEllerEndrePeriodeFellesForm.tsx
@@ -311,6 +311,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
         stillingsprosentFarMedmor,
         skalDuKombinereArbeidOgUttakFarMedmor,
         ønskerFlerbarnsdager,
+        morsAktivitet,
     } = formMethods.watch();
 
     const feltSynlighet = useFeltSynlighet(valgtePerioder, {
@@ -327,7 +328,7 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
         ønskerFlerbarnsdager,
     });
 
-    const skjemaKontekstuelleAlerts = useSkjemaKontekstuelleAlerts(valgtePerioder);
+    const skjemaKontekstuelleAlerts = useSkjemaKontekstuelleAlerts(valgtePerioder, morsAktivitet);
 
     const erBareFarHarRett = søker === 'FAR_MEDMOR' && rettighetType === 'BARE_SØKER_RETT';
 
@@ -687,6 +688,11 @@ export const LeggTilEllerEndrePeriodeFellesForm = ({ valgtePerioder, resetFormVa
                             );
                         })}
                     </RhfSelect>
+                    {skjemaKontekstuelleAlerts.aktivitetskravDokumentasjon && (
+                        <Alert variant={skjemaKontekstuelleAlerts.aktivitetskravDokumentasjon.variant}>
+                            {skjemaKontekstuelleAlerts.aktivitetskravDokumentasjon.melding}
+                        </Alert>
+                    )}
                 </>
             )}
             {forelder === 'BEGGE' && (

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -414,6 +414,7 @@
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager": "Do you want to use multiple children days for this period?",
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager.Påkrevd": "You must answer the question about whether you want to use multiple children days for this period",
     "LeggTilEllerEndrePeriodeFellesForm.DagerReduseres": "Working in the period 3 weeks before the due date and 6 weeks after birth means that parental benefits will be reduced for the days you work without being able to take those days later.",
+    "LeggTilEllerEndrePeriodeFellesForm.AktivitetskravDokumentasjon": "We usually need documentation to process this. Before you submit the application, you'll be told what we need.",
     "UttaksplanListe.ManglerMorsAktivitet": "You must select mother's activity before proceeding.",
     "UttaksplanListe.ManglerGraderingsaktivitet": "You must select where you will work while receiving parental benefit before proceeding.",
     "LeggTilUtsettelsePanel.VelgÅrsak": "Choose why you want to postpone",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -414,6 +414,7 @@
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager": "Ønsker du å bruke flerbarnsdager for denne perioden?",
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager.Påkrevd": "Du må svare på spørsmålet om du ønsker å bruke flerbarnsdager for denne perioden",
     "LeggTilEllerEndrePeriodeFellesForm.DagerReduseres": "Arbeid i tidsrommet 3 uker før termin og 6 uker etter fødsel, betyr at foreldrepengene vil reduseres det du jobber uten at du får dagene til gode til senere.",
+    "LeggTilEllerEndrePeriodeFellesForm.AktivitetskravDokumentasjon": "Vi må vanligvis ha dokumentasjon for å kunne behandle dette. Før du sender søknaden får du beskjed om hva vi trenger.",
     "UttaksplanListe.ManglerMorsAktivitet": "Du må velge mors aktivitet før du går videre",
     "UttaksplanListe.ManglerGraderingsaktivitet": "Du må velge hvor du skal jobbe samtidig som du har foreldrepenger før du går videre",
     "LeggTilUtsettelsePanel.VelgÅrsak": "Velg hvorfor du skal utsette",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -414,6 +414,7 @@
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager": "Ønsker du å bruke flerbarnsdager for denne perioden?",
     "LeggTilEllerEndrePeriodeForm.ØnskerFlerbarnsdager.Påkrevd": "Du må svare på spørsmålet om du ønsker å bruke flerbarnsdager for denne perioden",
     "LeggTilEllerEndrePeriodeFellesForm.DagerReduseres": "Arbeid i tidsrommet 3 veker før termin og 6 veker etter fødsel, betyr at foreldrepengane vil reduseres det du jobbar utan at du får dagane til gode til seinere.",
+    "LeggTilEllerEndrePeriodeFellesForm.AktivitetskravDokumentasjon": "Vi må vanlegvis ha dokumentasjon for å kunne behandle dette. Før du sender søknaden får du beskjed om kva vi treng.",
     "UttaksplanListe.ManglerMorsAktivitet": "Du må velgja mors aktivitet før du går vidare",
     "UttaksplanListe.ManglerGraderingsaktivitet": "Du må velje kvar du skal jobbe samtidig som du har foreldrepengar før du går vidare",
     "LeggTilUtsettelsePanel.VelgÅrsak": "Velg kvifor du vil utsetja perioden",

--- a/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { BrukerRolleSak_fpoversikt, Familiesituasjon, RettighetType_fpoversikt } from '@navikt/fp-types';
+import { BrukerRolleSak_fpoversikt, Familiesituasjon, MorsAktivitet, RettighetType_fpoversikt } from '@navikt/fp-types';
 
 import { useUttaksplanData } from '../../context/UttaksplanDataContext';
 import { UttaksperiodeValidatorer } from '../../utils/UttaksperiodeValidatorer';
@@ -50,14 +50,23 @@ export const useBlokkerendeAlert = (input: {
  * Aktive kontekstuelle alerts i legg-til-/endre-skjemaet, ferdig pakket
  * med variant og melding. Konsumentene rendrer kun.
  */
-export const useSkjemaKontekstuelleAlerts = (valgtePerioder: Periode[]): SkjemaKontekstuelleAlerts => {
-    const { familiehendelsedato } = useUttaksplanData();
-    const ctx: KontekstuellAlertKontekst = { valgtePerioder, familiehendelsedato };
+export const useSkjemaKontekstuelleAlerts = (
+    valgtePerioder: Periode[],
+    morsAktivitet?: MorsAktivitet,
+): SkjemaKontekstuelleAlerts => {
+    const { familiehendelsedato, erEndringssøknad } = useUttaksplanData();
+    const ctx: KontekstuellAlertKontekst = { valgtePerioder, familiehendelsedato, morsAktivitet, erEndringssøknad };
     return {
         graderingDagerReduseres: KONTEKSTUELL_GRADERING_ALERT.skalVises(ctx)
             ? {
                   melding: KONTEKSTUELL_GRADERING_ALERT.getMelding(ctx),
                   variant: KONTEKSTUELL_GRADERING_ALERT.variant,
+              }
+            : undefined,
+        aktivitetskravDokumentasjon: AKTIVITETSKRAV_DOKUMENTASJON_ALERT.skalVises(ctx)
+            ? {
+                  melding: AKTIVITETSKRAV_DOKUMENTASJON_ALERT.getMelding(ctx),
+                  variant: AKTIVITETSKRAV_DOKUMENTASJON_ALERT.variant,
               }
             : undefined,
     };
@@ -172,7 +181,15 @@ export const BLOKKERENDE_ALERTS: ReadonlyArray<Alertregel<BlokkerendeAlertKontek
 type KontekstuellAlertKontekst = {
     valgtePerioder: Periode[];
     familiehendelsedato: string;
+    morsAktivitet?: MorsAktivitet;
+    erEndringssøknad: boolean;
 };
+
+const AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON: ReadonlyArray<MorsAktivitet> = [
+    'ARBEID',
+    'UTDANNING',
+    'ARBEID_OG_UTDANNING',
+];
 
 const KONTEKSTUELL_GRADERING_ALERT = lagAlertregel<KontekstuellAlertKontekst>({
     id: 'kontekstuelleAlerts.graderingDagerReduseres',
@@ -196,10 +213,38 @@ const KONTEKSTUELL_GRADERING_ALERT = lagAlertregel<KontekstuellAlertKontekst>({
         ),
 });
 
-export const KONTEKSTUELLE_ALERTS: ReadonlyArray<Alertregel<KontekstuellAlertKontekst>> = [KONTEKSTUELL_GRADERING_ALERT];
+const AKTIVITETSKRAV_DOKUMENTASJON_ALERT = lagAlertregel<KontekstuellAlertKontekst>({
+    id: 'kontekstuelleAlerts.aktivitetskravDokumentasjon',
+    beskrivelse:
+        'Brukeren har i en førstegangssøknad valgt et aktivitetskrav (arbeid, ' +
+        'utdanning eller arbeid og utdanning) for perioden. Denne typen aktivitet ' +
+        'krever normalt dokumentasjon, og planlagt aktivitet langt fram i tid kan ' +
+        'ofte ikke dokumenteres ennå. Alerten forbereder brukeren på at søknaden ' +
+        'kan bli liggende på vent i påvente av dokumentasjon, slik at brukeren kan ' +
+        'vurdere å søke i flere omganger i stedet.',
+    visningssteder: SKJEMA_VISNINGSSTEDER,
+    meldinger: [
+        <FormattedMessage
+            key="LeggTilEllerEndrePeriodeFellesForm.AktivitetskravDokumentasjon"
+            id="LeggTilEllerEndrePeriodeFellesForm.AktivitetskravDokumentasjon"
+        />,
+    ],
+    variant: 'info',
+    type: 'kontekstuell',
+    skalVises: (ctx) =>
+        !ctx.erEndringssøknad &&
+        ctx.morsAktivitet !== undefined &&
+        AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON.includes(ctx.morsAktivitet),
+});
+
+export const KONTEKSTUELLE_ALERTS: ReadonlyArray<Alertregel<KontekstuellAlertKontekst>> = [
+    KONTEKSTUELL_GRADERING_ALERT,
+    AKTIVITETSKRAV_DOKUMENTASJON_ALERT,
+];
 
 type SkjemaKontekstuelleAlerts = {
     graderingDagerReduseres?: { melding: ReactNode; variant: 'info' | 'warning' };
+    aktivitetskravDokumentasjon?: { melding: ReactNode; variant: 'info' | 'warning' };
 };
 
 /**

--- a/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
@@ -185,11 +185,9 @@ type KontekstuellAlertKontekst = {
     erEndringssøknad: boolean;
 };
 
-const AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON: readonly MorsAktivitet[] = [
-    'ARBEID',
-    'UTDANNING',
-    'ARBEID_OG_UTDANNING',
-];
+const AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON: ReadonlySet<MorsAktivitet> = new Set(
+    ['ARBEID', 'UTDANNING', 'ARBEID_OG_UTDANNING'] satisfies MorsAktivitet[],
+);
 
 const KONTEKSTUELL_GRADERING_ALERT = lagAlertregel<KontekstuellAlertKontekst>({
     id: 'kontekstuelleAlerts.graderingDagerReduseres',
@@ -234,7 +232,7 @@ const AKTIVITETSKRAV_DOKUMENTASJON_ALERT = lagAlertregel<KontekstuellAlertKontek
     skalVises: (ctx) =>
         !ctx.erEndringssøknad &&
         ctx.morsAktivitet !== undefined &&
-        AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON.includes(ctx.morsAktivitet),
+        AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON.has(ctx.morsAktivitet),
 });
 
 export const KONTEKSTUELLE_ALERTS: ReadonlyArray<Alertregel<KontekstuellAlertKontekst>> = [

--- a/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
+++ b/packages/uttaksplan/src/regler/alert/skjemaAlerts.tsx
@@ -185,7 +185,7 @@ type KontekstuellAlertKontekst = {
     erEndringssøknad: boolean;
 };
 
-const AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON: ReadonlyArray<MorsAktivitet> = [
+const AKTIVITETSKRAV_SOM_KREVER_DOKUMENTASJON: readonly MorsAktivitet[] = [
     'ARBEID',
     'UTDANNING',
     'ARBEID_OG_UTDANNING',


### PR DESCRIPTION
…angssøknad

Viser en infomelding i «hva vil du endre til»-panelet når søker (i en førstegangssøknad) velger aktivitetskrav arbeid, utdanning eller arbeid og utdanning for perioden. Meldingen forbereder brukeren på at dokumentasjon normalt kreves, slik at planlagt aktivitet langt fram i tid heller kan søkes om i en senere omgang.

https://jira.adeo.no/browse/TFP-6022