### PR TITLE
fix: filtrer bort alt fra dekoratøren uavhengig av filsti-mønster

### DIFF
--- a/packages/observability/src/filterUtils.ts
+++ b/packages/observability/src/filterUtils.ts
@@ -23,26 +23,25 @@ export interface StackFrame {
 /**
  * Sjekker om stackframes mangler opprinnelse i vår kode.
  *
- * Logikk: Hvis en frame er fra et asset (FARO: `/assets/*.js`) og matcher
- * FEIL_VI_VIL_LUKE_BORT, er det en uønsket asset-frame → return true (filtrer).
- * Hvis framen er fra våre egne assets (ikke i FEIL_VI_VIL_LUKE_BORT) → return false (ikke filtrer).
- * Hvis framen ikke er et asset (altså ikke fra vår bundle) → return true (filtrer).
+ * Logikk: Hvis en frame kommer fra dekoratøren (filnavnet inneholder noe fra
+ * FEIL_VI_VIL_LUKE_BORT, uavhengig av filtype/plassering) → return true (filtrer).
+ * Dette fanger opp alt fra dekoratøren, ikke bare bundlede `/assets/*.js`-chunks
+ * (f.eks. rå kildefiler som `personbruker/nav-dekoratoren/src/helpers/auth.ts`).
+ * Hvis framen er fra vårt eget asset (FARO: `/assets/*.js`) → return false (ikke filtrer).
+ * Hvis framen verken er fra dekoratøren eller vårt eget asset (altså ikke fra vår bundle) → return true (filtrer).
  *
  * Funksjonen returnerer true hvis minst én frame ikke har opprinnelse i vår kode,
- * eller hvis en frame kommer fra en uønsket asset.
+ * eller hvis en frame kommer fra dekoratøren.
  */
 export const harUtenforstaendeKodeOpprinnelse = (frames: StackFrame[]): boolean => {
     return frames.some((frame) => {
-        const assetFrame = frame.filename && /\/assets\/.*\.js$/.test(frame.filename);
-
-        if (assetFrame) {
-            const erUønsketAssetFrame = FEIL_VI_VIL_LUKE_BORT.some((feil) => frame.filename?.includes(feil));
-            if (erUønsketAssetFrame) {
-                return true;
-            }
-            return false;
+        const erDekoratørFrame = FEIL_VI_VIL_LUKE_BORT.some((feil) => frame.filename?.includes(feil));
+        if (erDekoratørFrame) {
+            return true;
         }
-        return true;
+
+        const assetFrame = frame.filename && /\/assets\/.*\.js$/.test(frame.filename);
+        return !assetFrame;
     });
 };
 


### PR DESCRIPTION
## Hva
Generaliserer dekoratør-filteret i \`harUtenforstaendeKodeOpprinnelse\` (\`packages/observability/src/filterUtils.ts\`) slik at det fanger opp **alle** stacktrace-frames som stammer fra dekoratøren, ikke bare bundlede \`/assets/*.js\`-chunks.

## Hvorfor
Vi observerte en exception (\"Failed to renew session\") fra dekoratørens auth-logikk (fanget opp via \`@nais/apm\`s console.error-interceptor) som ikke ble filtrert bort, fordi stacktracen pekte til rå kildefiler (\`personbruker/nav-dekoratoren/src/helpers/auth.ts\`) i stedet for et bundlet asset under \`/assets/\`.

I stedet for å hardkode mot dekoratørens feiltekster, filtrerer vi nå på **opprinnelses-sti** (\`FEIL_VI_VIL_LUKE_BORT\`) uavhengig av filtype/plassering — så alt som kommer fra dekoratøren luker vi bort, uansett hvordan det havner i Faro.

Eksisterende tester i \`initFaro.test.ts\` er verifisert grønne (20/20).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>