### PR TITLE
TFP-7083: vis foreldrenavn i staden for Mødrekvote/Fedrekvote for far…

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
@@ -483,6 +483,8 @@ describe('Fordeling - FarMedmorAleneomsorgEttBarnTerminEtterWLB', () => {
     const mellomlagreSøknadOgNaviger = vi.fn();
 
     it('skal vise riktig informasjon til far med aleneomsorg med fødte tvillinger', async () => {
+        MockDate.set(new Date('2024-09-12'));
+
         await FarMedmorAleneomsorgEttBarnTerminEtterWLB.run({
             args: {
                 ...FarMedmorAleneomsorgEttBarnTerminEtterWLB.args,
@@ -490,8 +492,6 @@ describe('Fordeling - FarMedmorAleneomsorgEttBarnTerminEtterWLB', () => {
                 mellomlagreSøknadOgNaviger,
             },
         });
-
-        MockDate.set(new Date('2024-09-12'));
 
         expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
         expect(screen.getByText('46 uker til deg')).toBeInTheDocument();

--- a/packages/uttaksplan/src/KvoteOppsummering.stories.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.stories.tsx
@@ -88,6 +88,18 @@ export const BeggeRettMorIngenDagerBrukt: Story = {
     },
 };
 
+export const BeggeRettFarOgFarIngenDagerBrukt: Story = {
+    args: {
+        ...BeggeRettMorIngenDagerBrukt.args,
+        foreldreInfo: {
+            ...DEFAULT_FORELDRE_INFO,
+            rettighetType: 'BEGGE_RETT',
+            søker: 'FAR_MEDMOR',
+            erFarOgFar: true,
+        },
+    },
+};
+
 export const BeggeRettMorAlleDagerBrukt: Story = {
     args: {
         valgtStønadskvote: kontoNårBeggeHarRett,

--- a/packages/uttaksplan/src/KvoteOppsummering.test.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.test.tsx
@@ -15,6 +15,7 @@ const {
     BeggeRettMorForMangeDagerBrukt,
     BeggeRettMorOgMedmorMorIngenDagerBrukt,
     BeggeRettMorIngenDagerBrukt,
+    BeggeRettFarOgFarIngenDagerBrukt,
     MorHarPrematuruker,
     BeggeRettMangeOvertrukneDagerMedOverføringsÅrsak,
     BeggeRettMedFriUtsettelseAnnenPart,
@@ -121,6 +122,19 @@ describe('<KvoteOppsummering >', () => {
         await userEvent.click(expandButton);
         expect(screen.getAllByText('Fedrekvote - 15 uker')).toHaveLength(1);
         expect(screen.queryByText('Medmorkvote')).not.toBeInTheDocument();
+    });
+
+    it('<BeggeRettFarOgFarIngenDagerBrukt - skal vise genitivnavn for begge kvoter >', async () => {
+        render(<BeggeRettFarOgFarIngenDagerBrukt />);
+        expect(screen.getByText('Det er 49 uker igjen som kan legges til i planen')).toBeInTheDocument();
+
+        const expandButton = screen.getByRole('button', { expanded: false });
+        await userEvent.click(expandButton);
+
+        expect(screen.getAllByText('Helgas kvote - 15 uker')).toHaveLength(1);
+        expect(screen.getAllByText('Espens kvote - 15 uker')).toHaveLength(1);
+        expect(screen.queryByText('Mødrekvote')).not.toBeInTheDocument();
+        expect(screen.queryByText('Fedrekvote')).not.toBeInTheDocument();
     });
 
     it('<MorHarPrematuruker - 8 uker og 3 dager av fellesperioden skal være brukt opp av pleiepenger >', async () => {

--- a/packages/uttaksplan/src/KvoteOppsummering.tsx
+++ b/packages/uttaksplan/src/KvoteOppsummering.tsx
@@ -7,10 +7,11 @@ import { BodyShort, ExpansionCard, HGrid, HStack, VStack } from '@navikt/ds-reac
 import {
     KontoDto,
     KontoTypeUttak,
+    NavnPåForeldre,
     UttakPeriodeAnnenpartEøs_fpoversikt,
     UttakPeriode_fpoversikt,
 } from '@navikt/fp-types';
-import { formatOppramsing } from '@navikt/fp-utils';
+import { capitalizeFirstLetter, formatOppramsing, getNavnGenitivEierform } from '@navikt/fp-utils';
 
 import { useUttaksplanData } from './context/UttaksplanDataContext';
 import { erVanligUttakPeriode } from './types/UttaksplanPeriode';
@@ -628,7 +629,7 @@ const StandardVisning = ({
         familiesituasjon,
         familiehendelsedato,
         valgtStønadskvote,
-        foreldreInfo: { erMedmorDelAvSøknaden },
+        foreldreInfo: { erMedmorDelAvSøknaden, erFarOgFar, navnPåForeldre },
     } = useUttaksplanData();
     const harAktivitetsfriKvote = valgtStønadskvote.kontoer.some((k) => k.konto === 'AKTIVITETSFRI_KVOTE');
 
@@ -664,6 +665,8 @@ const StandardVisning = ({
                         kontoType={konto.konto}
                         erMedmorDelAvSøknaden={erMedmorDelAvSøknaden}
                         harAktivitetsfriKvote={harAktivitetsfriKvote}
+                        erFarOgFar={erFarOgFar}
+                        navnPåForeldre={navnPåForeldre}
                     />
                     {' - '}
                     {getVarighetString(konto.dager, intl)}
@@ -734,11 +737,31 @@ const VisningsnavnForKvote = ({
     kontoType,
     erMedmorDelAvSøknaden,
     harAktivitetsfriKvote,
+    erFarOgFar,
+    navnPåForeldre,
 }: {
     kontoType: KontoTypeUttak;
     erMedmorDelAvSøknaden?: boolean;
     harAktivitetsfriKvote?: boolean;
+    erFarOgFar?: boolean;
+    navnPåForeldre: NavnPåForeldre;
 }) => {
+    const intl = useIntl();
+
+    // Når begge foreldrene er fedre (f.eks. adopsjon) representerer ikke MØDREKVOTE/FEDREKVOTE
+    // en mor og en far, men to fedre – så vi viser forelderens faktiske navn i stedet for de
+    // generiske "Mødrekvote"/"Fedrekvote"-tekstene. Se getForelderVisningsnavnForFarOgFar for
+    // tilsvarende mønster brukt andre steder i uttaksplanen.
+    if (erFarOgFar && (kontoType === 'MØDREKVOTE' || kontoType === 'FEDREKVOTE')) {
+        const navn = kontoType === 'MØDREKVOTE' ? navnPåForeldre.mor : navnPåForeldre.farMedmor;
+        return (
+            <FormattedMessage
+                id="kvote.kvote.ForeldreNavn"
+                values={{ navn: getNavnGenitivEierform(capitalizeFirstLetter(navn), intl.locale) }}
+            />
+        );
+    }
+
     switch (kontoType) {
         case 'AKTIVITETSFRI_KVOTE':
             return <FormattedMessage id="kvote.kvote.ForeldrepengerUtenAktivitetskrav" />;

--- a/packages/uttaksplan/src/intl/messages/en_US.json
+++ b/packages/uttaksplan/src/intl/messages/en_US.json
@@ -119,6 +119,7 @@
     "kvote.kvote.Fedrekvote": "Father's quota",
     "kvote.kvote.Medmorkvote": "Co-Mother's quota",
     "kvote.kvote.Mødrekvote": "Mother's quota",
+    "kvote.kvote.ForeldreNavn": "{navn} quota",
     "kvote.kvote.ForeldrepengerFørFødsel": "Parental benefits before birth",
     "kvote.kvote.Foreldrepenger": "Parental benefits",
     "kvote.kvote.Fellesperioder": "Shared periods",

--- a/packages/uttaksplan/src/intl/messages/nb_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nb_NO.json
@@ -119,6 +119,7 @@
     "kvote.kvote.Fedrekvote": "Fedrekvote",
     "kvote.kvote.Medmorkvote": "Medmorkvote",
     "kvote.kvote.Mødrekvote": "Mødrekvote",
+    "kvote.kvote.ForeldreNavn": "{navn} kvote",
     "kvote.kvote.ForeldrepengerFørFødsel": "Foreldrepenger før fødsel",
     "kvote.kvote.Foreldrepenger": "Foreldrepenger",
     "kvote.kvote.Fellesperioder": "Fellesperioder",

--- a/packages/uttaksplan/src/intl/messages/nn_NO.json
+++ b/packages/uttaksplan/src/intl/messages/nn_NO.json
@@ -119,6 +119,7 @@
     "kvote.kvote.Fedrekvote": "Fedrekvote",
     "kvote.kvote.Medmorkvote": "Medmorkvote",
     "kvote.kvote.Mødrekvote": "Mødrekvote",
+    "kvote.kvote.ForeldreNavn": "{navn} kvote",
     "kvote.kvote.ForeldrepengerFørFødsel": "Foreldrepengar før fødsel",
     "kvote.kvote.Foreldrepenger": "Foreldrepengar",
     "kvote.kvote.Fellesperioder": "Fellesperiodar",


### PR DESCRIPTION
…/far

I kvoteoversikten vart MØDREKVOTE og FEDREKVOTE alltid vist med dei generiske tekstane «Mødrekvote»/«Fedrekvote», sjølv når begge foreldra er fedre (t.d. adopsjon). Følgjer same mønster som elles i uttaksplanen (erFarOgFar) og viser i staden forelderens faktiske namn i genitivform.

https://jira.adeo.no/browse/TFP-7083