### PR TITLE
TFP-5892: la far/medmor starte to uker før fødsel når fødsel er før t…

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/fordeling/FordelingSteg.test.tsx
@@ -1299,7 +1299,9 @@ describe('Fordeling - FarMedmorSøkerDeltUttakEttBarnFødtPrematurt', () => {
         expect(screen.getByText('Jeg vil velge en annen dato')).toBeInTheDocument();
     });
 
-    it('skal ikke kunne begynne uttaket før fødselsdato', async () => {
+    it('skal ikke kunne begynne uttaket tidligere enn to uker før fødselsdato', async () => {
+        // Barnet er født mer enn to uker før termin (prematurt). Far/medmor skal da kunne starte
+        // to uker før fødselsdatoen, ikke først fra fødselsdatoen. Se TFP-5892.
         MockDate.set(new Date('2024-02-25'));
         await FarMedmorSøkerDeltUttakEttBarnFødtPrematurt.run({
             args: {
@@ -1311,10 +1313,10 @@ describe('Fordeling - FarMedmorSøkerDeltUttakEttBarnFødtPrematurt', () => {
         expect(await screen.findAllByText('Fordeling av foreldrepenger')).toHaveLength(2);
         await userEvent.click(screen.getByText('Jeg vil velge en annen dato'));
         const oppstart = screen.getByLabelText('Hvilken dato vil du starte?');
-        await userEvent.type(oppstart, '20.02.2024');
+        await userEvent.type(oppstart, '06.02.2024');
         fireEvent.blur(oppstart);
         await userEvent.click(screen.getByText('Neste steg'));
-        expect(screen.getAllByText('Oppstartsdato for foreldrepenger kan være tidligst 21.02.2024.')).toHaveLength(2);
+        expect(screen.getAllByText('Oppstartsdato for foreldrepenger kan være tidligst 07.02.2024.')).toHaveLength(2);
     });
 });
 

--- a/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.test.ts
+++ b/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.test.ts
@@ -1,0 +1,28 @@
+import { getFørsteUttaksdag2UkerFørFødsel } from './arbeidsforholdUtils';
+
+describe('arbeidsforholdUtils', () => {
+    describe('getFørsteUttaksdag2UkerFørFødsel', () => {
+        it('skal gi to uker før termin når fødsel skjer på termindato', () => {
+            // Mandag 8. januar er nærmeste ukedag på/etter søndag 7. januar (termin 21.01 - 2 uker).
+            expect(getFørsteUttaksdag2UkerFørFødsel('2024-01-21', '2024-01-21')).toEqual('2024-01-08');
+        });
+
+        it('skal gi to uker før termin når fødsel skjer etter termin', () => {
+            const termindato = '2024-01-21';
+            const fødselsdato = '2024-02-04';
+            expect(getFørsteUttaksdag2UkerFørFødsel(fødselsdato, termindato)).toEqual('2024-01-08');
+        });
+
+        it('skal gi to uker før fødsel når barnet er født mer enn to uker før termin', () => {
+            // Regression test for TFP-5892: fødsel skjer 6 uker før termin. Da skal far/medmor
+            // kunne starte to uker før fødselsdatoen, ikke først fra fødselsdatoen.
+            const termindato = '2024-03-03';
+            const fødselsdato = '2024-01-21';
+            expect(getFørsteUttaksdag2UkerFørFødsel(fødselsdato, termindato)).toEqual('2024-01-08');
+        });
+
+        it('skal falle tilbake til to uker før fødsel når termindato mangler', () => {
+            expect(getFørsteUttaksdag2UkerFørFødsel('2024-01-21', undefined)).toEqual('2024-01-08');
+        });
+    });
+});

--- a/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
@@ -15,10 +15,11 @@ export const getFørsteUttaksdag2UkerFørFødsel = (
     // tidligste dato. Uten dette blir tidligste dato feil dersom barnet er født mer enn to uker før termin,
     // fordi fødselsdatoen da er tidligere enn termindato minus to uker, og vi må derfor regne to uker tilbake fra fødsel.
     const familiehendelsesdatoMinusToUker = dayjs(familiehendelsesdato).subtract(ANTALL_DAGER_TO_UKER, 'day');
+    const termindatoMinusToUker = termindato ? dayjs(termindato).subtract(ANTALL_DAGER_TO_UKER, 'day') : undefined;
     const datoÅRegneFra =
-        termindato === undefined
+        termindatoMinusToUker === undefined
             ? familiehendelsesdatoMinusToUker
-            : dayjs.min(dayjs(termindato).subtract(ANTALL_DAGER_TO_UKER, 'day'), familiehendelsesdatoMinusToUker);
+            : dayjs.min(termindatoMinusToUker, familiehendelsesdatoMinusToUker);
     return Uttaksdagen.denneEllerNeste(datoÅRegneFra.format(ISO_DATE_FORMAT)).getDato();
 };
 

--- a/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
@@ -12,8 +12,8 @@ export const getFørsteUttaksdag2UkerFørFødsel = (
     termindato: string | undefined,
 ): string => {
     // Far/medmor skal kunne starte to uker før termin eller to uker før fødsel, avhengig av hva som gir
-    // tidligst dato. Uten dette blir tidligste dato feil dersom barnet er født mer enn to uker før termin,
-    // fordi (rå) fødselsdato da vil være senere enn termindato minus to uker.
+    // tidligste dato. Uten dette blir tidligste dato feil dersom barnet er født mer enn to uker før termin,
+    // fordi fødselsdatoen da er tidligere enn termindato minus to uker, og vi må derfor regne to uker tilbake fra fødsel.
     const familiehendelsesdatoMinusToUker = dayjs(familiehendelsesdato).subtract(ANTALL_DAGER_TO_UKER, 'day');
     const datoÅRegneFra =
         termindato === undefined

--- a/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
+++ b/apps/foreldrepengesoknad/src/utils/arbeidsforholdUtils.ts
@@ -11,11 +11,14 @@ export const getFørsteUttaksdag2UkerFørFødsel = (
     familiehendelsesdato: string,
     termindato: string | undefined,
 ): string => {
-    const terminEllerFamHendelsesdatoMinusToUker =
+    // Far/medmor skal kunne starte to uker før termin eller to uker før fødsel, avhengig av hva som gir
+    // tidligst dato. Uten dette blir tidligste dato feil dersom barnet er født mer enn to uker før termin,
+    // fordi (rå) fødselsdato da vil være senere enn termindato minus to uker.
+    const familiehendelsesdatoMinusToUker = dayjs(familiehendelsesdato).subtract(ANTALL_DAGER_TO_UKER, 'day');
+    const datoÅRegneFra =
         termindato === undefined
-            ? dayjs(familiehendelsesdato).subtract(ANTALL_DAGER_TO_UKER, 'day')
-            : dayjs(termindato).subtract(ANTALL_DAGER_TO_UKER, 'day');
-    const datoÅRegneFra = dayjs.min(terminEllerFamHendelsesdatoMinusToUker, dayjs(familiehendelsesdato));
+            ? familiehendelsesdatoMinusToUker
+            : dayjs.min(dayjs(termindato).subtract(ANTALL_DAGER_TO_UKER, 'day'), familiehendelsesdatoMinusToUker);
     return Uttaksdagen.denneEllerNeste(datoÅRegneFra.format(ISO_DATE_FORMAT)).getDato();
 };
 


### PR DESCRIPTION
…ermin

getFørsteUttaksdag2UkerFørFødsel sammenlignet termindato-2uker mot rå fødselsdato i stedet for fødselsdato-2uker. Når barnet ble født mer enn to uker før termin, ga dette feilaktig fødselsdatoen som tidligste mulige startdato i stedet for to uker før fødsel, i dropdownen «Hvilken dato vil du starte?».

https://jira.adeo.no/browse/TFP-5892