### PR TITLE
fix: fjern klikk-skjold-div-er og flytt stopPropagation til Chips.Removable

### DIFF
--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -222,18 +222,19 @@ const HeaderForDesktop = () => {
                         <FormattedMessage id="RedigeringPanel.EndreTil" />
                     </Heading>
                 </HStack>
-                <div onClick={(e) => e.stopPropagation()} role="presentation">
-                    <Chips size="small">
-                        <Chips.Removable onDelete={() => setValgtePerioder([])}>
-                            {intl.formatMessage(
-                                { id: 'RedigeringPanel.ValgteDager' },
-                                {
-                                    varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
-                                },
-                            )}
-                        </Chips.Removable>
-                    </Chips>
-                </div>
+                <Chips size="small">
+                    <Chips.Removable
+                        onDelete={() => setValgtePerioder([])}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {intl.formatMessage(
+                            { id: 'RedigeringPanel.ValgteDager' },
+                            {
+                                varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
+                            },
+                        )}
+                    </Chips.Removable>
+                </Chips>
             </VStack>
         </Box>
     );
@@ -278,38 +279,40 @@ const HeaderForMobil = ({
                             <FormattedMessage id="RedigeringPanel.EndreTil" />
                         </Heading>
                         {erMinimert && (
-                            <div onClick={(e) => e.stopPropagation()} role="presentation">
-                                <Chips size="small">
-                                    <Chips.Removable onDelete={() => setValgtePerioder([])}>
-                                        {intl.formatMessage(
-                                            { id: 'RedigeringPanel.ValgteDager' },
-                                            {
-                                                varighet: getVarighetString(
-                                                    finnAntallDager(sammenslåtteValgtePerioder),
-                                                    intl,
-                                                ),
-                                            },
-                                        )}
-                                    </Chips.Removable>
-                                </Chips>
-                            </div>
+                            <Chips size="small">
+                                <Chips.Removable
+                                    onDelete={() => setValgtePerioder([])}
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    {intl.formatMessage(
+                                        { id: 'RedigeringPanel.ValgteDager' },
+                                        {
+                                            varighet: getVarighetString(
+                                                finnAntallDager(sammenslåtteValgtePerioder),
+                                                intl,
+                                            ),
+                                        },
+                                    )}
+                                </Chips.Removable>
+                            </Chips>
                         )}
                     </HStack>
                 </HStack>
 
                 {!erMinimert && (
-                    <div onClick={(e) => e.stopPropagation()} role="presentation">
-                        <Chips size="small">
-                            <Chips.Removable onDelete={() => setValgtePerioder([])}>
-                                {intl.formatMessage(
-                                    { id: 'RedigeringPanel.ValgteDager' },
-                                    {
-                                        varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
-                                    },
-                                )}
-                            </Chips.Removable>
-                        </Chips>
-                    </div>
+                    <Chips size="small">
+                        <Chips.Removable
+                            onDelete={() => setValgtePerioder([])}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {intl.formatMessage(
+                                { id: 'RedigeringPanel.ValgteDager' },
+                                {
+                                    varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
+                                },
+                            )}
+                        </Chips.Removable>
+                    </Chips>
                 )}
             </VStack>
         </Box>

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/HvaVilDuEndreTilPanel.tsx
@@ -222,7 +222,7 @@ const HeaderForDesktop = () => {
                         <FormattedMessage id="RedigeringPanel.EndreTil" />
                     </Heading>
                 </HStack>
-                <div onClick={(e) => e.stopPropagation()}>
+                <div onClick={(e) => e.stopPropagation()} role="presentation">
                     <Chips size="small">
                         <Chips.Removable onDelete={() => setValgtePerioder([])}>
                             {intl.formatMessage(
@@ -278,7 +278,7 @@ const HeaderForMobil = ({
                             <FormattedMessage id="RedigeringPanel.EndreTil" />
                         </Heading>
                         {erMinimert && (
-                            <div onClick={(e) => e.stopPropagation()}>
+                            <div onClick={(e) => e.stopPropagation()} role="presentation">
                                 <Chips size="small">
                                     <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                         {intl.formatMessage(
@@ -298,7 +298,7 @@ const HeaderForMobil = ({
                 </HStack>
 
                 {!erMinimert && (
-                    <div onClick={(e) => e.stopPropagation()}>
+                    <div onClick={(e) => e.stopPropagation()} role="presentation">
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
@@ -59,7 +59,7 @@ const HeaderDesktop = ({ labels }: { labels: React.ReactNode }) => {
         <Box background="accent-soft" padding="space-16">
             <VStack gap="space-16">
                 <HStack justify="space-between" align="center" wrap={false}>
-                    <div onClick={(e) => e.stopPropagation()}>
+                    <div onClick={(e) => e.stopPropagation()} role="presentation">
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(
@@ -127,7 +127,7 @@ const HeaderMobil = ({
                         />
                     )}
 
-                    <div onClick={(e) => e.stopPropagation()}>
+                    <div onClick={(e) => e.stopPropagation()} role="presentation">
                         <Chips size="small">
                             <Chips.Removable onDelete={() => setValgtePerioder([])}>
                                 {intl.formatMessage(

--- a/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
+++ b/packages/uttaksplan/src/kalender/redigering/paneler/handlinger/LeggTilEllerEndrePeriodePanel.tsx
@@ -59,18 +59,19 @@ const HeaderDesktop = ({ labels }: { labels: React.ReactNode }) => {
         <Box background="accent-soft" padding="space-16">
             <VStack gap="space-16">
                 <HStack justify="space-between" align="center" wrap={false}>
-                    <div onClick={(e) => e.stopPropagation()} role="presentation">
-                        <Chips size="small">
-                            <Chips.Removable onDelete={() => setValgtePerioder([])}>
-                                {intl.formatMessage(
-                                    { id: 'RedigeringPanel.ValgteDager' },
-                                    {
-                                        varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
-                                    },
-                                )}
-                            </Chips.Removable>
-                        </Chips>
-                    </div>
+                    <Chips size="small">
+                        <Chips.Removable
+                            onDelete={() => setValgtePerioder([])}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {intl.formatMessage(
+                                { id: 'RedigeringPanel.ValgteDager' },
+                                {
+                                    varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
+                                },
+                            )}
+                        </Chips.Removable>
+                    </Chips>
                     {visPeriodeDetaljer ? (
                         <ChevronUpIcon
                             title={intl.formatMessage({ id: 'RedigeringPanel.SkjulDetaljer' })}
@@ -127,18 +128,19 @@ const HeaderMobil = ({
                         />
                     )}
 
-                    <div onClick={(e) => e.stopPropagation()} role="presentation">
-                        <Chips size="small">
-                            <Chips.Removable onDelete={() => setValgtePerioder([])}>
-                                {intl.formatMessage(
-                                    { id: 'RedigeringPanel.ValgteDager' },
-                                    {
-                                        varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
-                                    },
-                                )}
-                            </Chips.Removable>
-                        </Chips>
-                    </div>
+                    <Chips size="small">
+                        <Chips.Removable
+                            onDelete={() => setValgtePerioder([])}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {intl.formatMessage(
+                                { id: 'RedigeringPanel.ValgteDager' },
+                                {
+                                    varighet: getVarighetString(finnAntallDager(sammenslåtteValgtePerioder), intl),
+                                },
+                            )}
+                        </Chips.Removable>
+                    </Chips>
                 </VStack>
             </Box>
             <Box className="bg-ax-bg-accent-soft">


### PR DESCRIPTION
Sonar (typescript:S6848/S1082) flagget disse <div onClick={stopPropagation}>- elementene som ikke-native interaktive elementer uten tastaturstøtte. De er i realiteten kun klikk-skjold rundt Chips.Removable for å hindre at klikket bobler opp til foreldre-elementets onClick, og trenger derfor ikke tastatur- interaksjon. role="presentation" markerer dem eksplisitt som ikke-interaktive, som løser a11y-varselet uten unødvendige tastatur-handlers.

Berørte filer:
- HvaVilDuEndreTilPanel.tsx (3 forekomster)
- LeggTilEllerEndrePeriodePanel.tsx (2 forekomster)