### PR TITLE
TFP-6175: vis PDL-opplysninger om annen forelder som infoboks når barn matches på fødselsdato

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.stories.tsx
@@ -134,7 +134,36 @@ export const SkalOppgiPersonalia: Story = {
     },
 };
 
-export const SkalOppgiPersonaliaFnrPåAnnenForelderOgBarnErUlike: Story = {
+export const AnnenForelderFraDødtBarnMatchetPåFødselsdato: Story = {
+    args: {
+        ...SkalOppgiPersonalia.args,
+        søkerInfo: {
+            ...defaultSøker,
+            barn: [
+                {
+                    fnr: '21091981146',
+                    fødselsdato: '2021-03-15',
+                    dødsdato: '2022-12-07',
+                    annenPart: {
+                        fnr: '12038517080',
+                        fødselsdato: '1985-03-12',
+                        navn: {
+                            fornavn: 'LEALAUS',
+                            etternavn: 'BÆREPOSE',
+                        },
+                    },
+                    navn: {
+                        fornavn: 'KLØKTIG',
+                        etternavn: 'MIDTPUNKT',
+                    },
+                    kjønn: 'M',
+                },
+            ],
+        },
+    },
+};
+
+export const VisPdlInfoboksSelvOmLagretFnrPåAnnenForelderErUlikt: Story = {
     args: {
         ...SkalOppgiPersonalia.args,
         søkerInfo: {

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.test.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.test.tsx
@@ -12,6 +12,8 @@ import * as stories from './AnnenForelderSteg.stories';
 
 const {
     AnnenForelderFraOppgittBarn,
+    AnnenForelderFraDødtBarnMatchetPåFødselsdato,
+    VisPdlInfoboksSelvOmLagretFnrPåAnnenForelderErUlikt,
     SkalOppgiPersonalia,
     ForFar,
     MorUfødtBarn,
@@ -90,6 +92,30 @@ describe('<AnnenForelderSteg>', () => {
             key: ContextDataType.APP_ROUTE,
             type: 'update',
         });
+    });
+
+    it('skal vise PDL-opplysninger som infoboks når dødt barn matches på fødselsdato', async () => {
+        render(<AnnenForelderFraDødtBarnMatchetPåFødselsdato />);
+
+        expect(await screen.findByText('LEALAUS BÆREPOSE')).toBeInTheDocument();
+        expect(screen.getByText('Fødselsnummer: 12038517080')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Fornavnet til den andre forelderen')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Etternavnet til den andre forelderen')).not.toBeInTheDocument();
+        expect(
+            screen.queryByLabelText('Fødselsnummer eller D-nummer til den andre forelderen'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('skal vise PDL-opplysninger som infoboks selv om lagret annen forelder har et annet fødselsnummer', async () => {
+        render(<VisPdlInfoboksSelvOmLagretFnrPåAnnenForelderErUlikt />);
+
+        expect(await screen.findByText('LEALAUS BÆREPOSE')).toBeInTheDocument();
+        expect(screen.getByText('Fødselsnummer: 999999999')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Fornavnet til den andre forelderen')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Etternavnet til den andre forelderen')).not.toBeInTheDocument();
+        expect(
+            screen.queryByLabelText('Fødselsnummer eller D-nummer til den andre forelderen'),
+        ).not.toBeInTheDocument();
     });
 
     it('skal fylle ut at en ikke har aleneomsorg for barnet og ikke rett til foreldrepenger i Norge og ikke hatt opphold i EØS', async () => {

--- a/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
+++ b/apps/foreldrepengesoknad/src/steps/annen-forelder/AnnenForelderSteg.tsx
@@ -62,11 +62,7 @@ export const AnnenForelderSteg = ({ søkerInfo, mellomlagreSøknadOgNaviger, avb
             select: (vedtak) => vedtak?.perioder.some((p) => p.resultat?.innvilget),
         }).data ?? false;
 
-    const oppgittFnrErUlikRegistrertBarn =
-        annenForelder !== undefined &&
-        isAnnenForelderOppgitt(annenForelder) &&
-        annenForelder.fnr !== annenForelderFraRegistrertBarn?.fnr;
-    const skalOppgiPersonalia = annenForelderFraRegistrertBarn === undefined || oppgittFnrErUlikRegistrertBarn;
+    const skalOppgiPersonalia = annenForelderFraRegistrertBarn === undefined;
 
     const onSubmit = (values: AnnenForelder) => {
         if (values.kanIkkeOppgis) {


### PR DESCRIPTION
https://jira.adeo.no/browse/TFP-6175

## Hva

Når et barn er dødt for mer enn 3 måneder siden vises det ikke lenger på forsiden. I steget "om annen forelder" matches den andre forelderen fortsatt via fødselsdato på barnet, og PDL-opplysningene om denne skal vises i infoboks (skrivebeskyttet), ikke i redigerbare inputfelt.

Tidligere ble feltene vist som redigerbare inputfelt dersom lagret fødselsnummer på annen forelder avvek fra det PDL matchet. Denne betingelsen er nå fjernet, slik at infoboks alltid vises når PDL-match finnes.

## Åpent spørsmål

Fjerningen av denne betingelsen er bredere enn kun "dødt barn"-scenarioet: den gjelder nå *alle* tilfeller der en bruker har et lagret fødselsnummer på annen forelder som avviker fra det PDL matcher (f.eks. hvis brukeren fylte ut personalia manuelt før en PDL-match fantes, og matchen dukker opp senere). I disse tilfellene vil PDL-dataene nå stille overstyre det brukeren tidligere har oppgitt, uten at brukeren varsles om dette.

Er det ønskelig at PDL-data alltid skal overstyre brukerens tidligere inntastede opplysninger i *alle* slike mismatch-tilfeller, eller bør denne endringen begrenses til kun dødsfall-scenarioet?

## Testing

- Lagt til story og test som dekker at PDL-infoboks vises når dødt barn matches på fødselsdato
- Lagt til test som dekker at PDL-infoboks vises selv om lagret fødselsnummer på annen forelder avviker fra PDL-match
- `tsc`, `vitest` og `eslint` kjørt grønt for berørt app
