### PR TITLE
fix: rydd opp enkle ESLint-advarsler (ref-navn og array-index-key)

### DIFF
--- a/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
+++ b/apps/foreldrepengesoknad/src/steps/uttaksplan/hooks/useLoggOverlappIVedtak.ts
@@ -12,7 +12,7 @@ export const useLoggOverlappIVedtak = (
     perioderFraBackend: UttakPeriode_fpoversikt[] | undefined,
     perioderAnnenPartFraBackend: UttakPeriode_fpoversikt[] | undefined,
 ): void => {
-    const lastCheckedFingerprint = useRef<string | null>(null);
+    const lastCheckedFingerprintRef = useRef<string | null>(null);
 
     useEffect(() => {
         if (!uttaksplan || uttaksplan.length === 0) {
@@ -20,10 +20,10 @@ export const useLoggOverlappIVedtak = (
         }
 
         const fingerprint = uttaksplan.map((p) => `${p.fom}:${p.tom}`).join(',');
-        if (lastCheckedFingerprint.current === fingerprint) {
+        if (lastCheckedFingerprintRef.current === fingerprint) {
             return;
         }
-        lastCheckedFingerprint.current = fingerprint;
+        lastCheckedFingerprintRef.current = fingerprint;
 
         const { perioderUttaksplan, ugyldigeOverlapp } = finnUgyldigeOverlappIUttaksplan(uttaksplan);
         if (ugyldigeOverlapp.length > 0) {

--- a/packages/utils/src/hooks/useBeforeUnload.ts
+++ b/packages/utils/src/hooks/useBeforeUnload.ts
@@ -1,15 +1,15 @@
 import { useEffect, useRef } from 'react';
 
 export const useBeforeUnload = (fn: () => void) => {
-    const cb = useRef(fn);
+    const cbRef = useRef(fn);
 
     useEffect(() => {
-        cb.current = fn;
+        cbRef.current = fn;
     }, [fn]);
 
     useEffect(() => {
-        globalThis.addEventListener('beforeunload', cb.current);
+        globalThis.addEventListener('beforeunload', cbRef.current);
 
-        return () => globalThis.removeEventListener('beforeunload', cb.current);
+        return () => globalThis.removeEventListener('beforeunload', cbRef.current);
     }, []);
 };

--- a/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
+++ b/packages/uttaksplan/src/context/UttaksplanRedigeringContext.tsx
@@ -37,12 +37,12 @@ export const UttaksplanRedigeringProvider = (props: Props) => {
 
     const { uttakPerioder, erEndringssøknad } = useUttaksplanData();
 
-    const harLoggetInitielleOverlapp = useRef(false);
+    const harLoggetInitielleOverlappRef = useRef(false);
     useEffect(() => {
-        if (harLoggetInitielleOverlapp.current) {
+        if (harLoggetInitielleOverlappRef.current) {
             return;
         }
-        harLoggetInitielleOverlapp.current = true;
+        harLoggetInitielleOverlappRef.current = true;
 
         const ugyldigeOverlapp = finnUgyldigeOverlapp(uttakPerioder);
         if (ugyldigeOverlapp.length === 0) {

--- a/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
+++ b/packages/uttaksplan/src/regler/RegelkatalogSide.tsx
@@ -259,7 +259,7 @@ export type RegelkatalogSideProps<T> = {
 export const RegelIdBadge = ({ id }: { id: string }) => (
     <code className="rounded bg-ax-bg-neutral-moderate px-2 py-0.5 font-mono text-xs">
         {id.split('.').map((segment, i, arr) => (
-            <span key={`${i}-${segment}`}>
+            <span key={arr.slice(0, i + 1).join('.')}>
                 {segment}
                 {i < arr.length - 1 && (
                     <>


### PR DESCRIPTION
- Rename ref-identifikatorar til å ende på 'Ref' i useBeforeUnload, UttaksplanRedigeringContext og useLoggOverlappIVedtak (@eslint-react/naming-convention-ref-name)
- Bytt indeks-basert React key til stabil akkumulert prefiks-nøkkel i RegelIdBadge (@eslint-react/no-array-index-key)